### PR TITLE
fix fire 4 not applying burn in onAttack

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -346,14 +346,14 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
 
     if (
       this.effects.includes(Effect.BLAZE) ||
+      this.effects.includes(Effect.VICTORY_STAR) ||
       this.effects.includes(Effect.DROUGHT) ||
       this.effects.includes(Effect.DESOLATE_LAND)
     ) {
       let burnChance = 0
       if (this.effects.includes(Effect.BLAZE)) {
         burnChance = 0.2
-      }
-      if (this.effects.includes(Effect.VICTORY_STAR)) {
+      } else if (this.effects.includes(Effect.VICTORY_STAR)) {
         burnChance = 0.2
       } else if (this.effects.includes(Effect.DROUGHT)) {
         burnChance = 0.3


### PR DESCRIPTION
Victory Star was not applying burn to opponents on hit correctly, can be seen in [this video](https://www.youtube.com/watch?v=VJHVNLa6PwI). Fixed by adding corresponding effect to the fire synergy check in onAttack.