### PR TITLE
Ghost damage

### DIFF
--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -217,19 +217,21 @@ export default class AttackingState extends PokemonState {
         pokemon.effects.includes(Effect.SHADOW_TAG) ? 0.7 :
         pokemon.effects.includes(Effect.WANDERING_SPIRIT) ? 1.0 : 0.0
 
-        ghostTrueDamage = rawDamageCount * ghostTrueDamageFactor
+        ghostTrueDamage = Math.ceil(rawDamageCount * ghostTrueDamageFactor)
         directDamage = rawDamageCount - ghostTrueDamage
 
         // Apply ghost true damage
-        target.handleDamage({
-          damage: Math.ceil(rawDamageCount * ghostTrueDamageFactor),
-          board,
-          attackType: AttackType.TRUE,
-          attacker: pokemon,
-          dodgeable: true,
-          shouldAttackerGainMana: pokemon.effects.includes(Effect.WANDERING_SPIRIT),  // Ensure mana gain in 100% true damage case
-          shouldTargetGainMana: true
-        })
+        if (ghostTrueDamage > 0) {
+          target.handleDamage({
+            damage: Math.ceil(rawDamageCount * ghostTrueDamageFactor),
+            board,
+            attackType: AttackType.TRUE,
+            attacker: pokemon,
+            dodgeable: true,
+            shouldAttackerGainMana: pokemon.effects.includes(Effect.WANDERING_SPIRIT),  // Ensure mana gain in 100% true damage case
+            shouldTargetGainMana: true
+          })
+        }
       }
 
       if (target.status.spikeArmor && pokemon.range === 1) {

--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -227,7 +227,7 @@ export default class AttackingState extends PokemonState {
           attackType: AttackType.TRUE,
           attacker: pokemon,
           dodgeable: true,
-          shouldAttackerGainMana: false,
+          shouldAttackerGainMana: pokemon.effects.includes(Effect.WANDERING_SPIRIT),  // Ensure mana gain in 100% true damage case
           shouldTargetGainMana: true
         })
       }


### PR DESCRIPTION
Fixed multiple issues relating to ghost synergy damage partitioning
- True damage from ghost synergy was omitted in damage calculation for choice scarf
- Full true damage from ghost 8 would result in the attacker not gaining mana from the basic attack