### PR TITLE
Player avatars on board during pick and battle phase

### DIFF
--- a/app/core/design.ts
+++ b/app/core/design.ts
@@ -127,6 +127,20 @@ export default class Design {
         this.terrain[this.leftBorder[1]][i] = TerrainType.WALL
       }
     }
+
+    this.drawGroundRect(9, 13, 3, 3)
+    this.drawGroundRect(30, 1, 3, 3)
+  }
+
+  drawGroundRect(x: number, y: number, width: number, height: number) {
+    for (let i = x; i < x + width; i++) {
+      for (let j = y; j < y + height; j++) {
+        this.terrain[j][i] =
+          i === x || i === x + width - 1 || j === y || j === y + height - 1
+            ? TerrainType.WALL
+            : TerrainType.GROUND
+      }
+    }
   }
 
   generateMask() {

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -38,6 +38,7 @@ import { Passive } from "../types/enum/Passive"
 
 export default class Simulation extends Schema implements ISimulation {
   @type("string") weather: Weather = Weather.NEUTRAL
+  @type("string") winnerId: string = ""
   @type({ map: PokemonEntity }) blueTeam = new MapSchema<IPokemonEntity>()
   @type({ map: PokemonEntity }) redTeam = new MapSchema<IPokemonEntity>()
   @type({ map: Dps }) blueDpsMeter = new MapSchema<Dps>()
@@ -52,6 +53,7 @@ export default class Simulation extends Schema implements ISimulation {
   flowerSpawn: boolean[] = [false, false]
   stageLevel = 0
   player: IPlayer | undefined
+  opponent: IPlayer | undefined
   id: string
   stormLightningTimer = 0
 
@@ -70,6 +72,7 @@ export default class Simulation extends Schema implements ISimulation {
     weather: Weather
   ) {
     this.player = player
+    this.opponent = opponent ?? undefined
     this.stageLevel = stageLevel
     this.weather = weather
 
@@ -101,6 +104,7 @@ export default class Simulation extends Schema implements ISimulation {
     this.redEffects = opponent?.effects?.list ?? []
 
     this.finished = false
+    this.winnerId = ""
     this.flowerSpawn = [false, false]
     this.stormLightningTimer = randomBetween(4000, 8000)
 
@@ -1075,10 +1079,12 @@ export default class Simulation extends Schema implements ISimulation {
     if (this.blueTeam.size == 0 || this.redTeam.size == 0) {
       this.finished = true
       if (this.blueTeam.size == 0) {
+        this.winnerId = this.opponent ? this.opponent.id : "pve"
         this.redTeam.forEach((p) => {
           p.action = PokemonActionState.HOP
         })
       } else {
+        this.winnerId = this.player?.id ?? ""
         this.blueTeam.forEach((p) => {
           p.action = PokemonActionState.HOP
         })
@@ -1168,5 +1174,6 @@ export default class Simulation extends Schema implements ISimulation {
     })
 
     this.weather = Weather.NEUTRAL
+    this.winnerId = ""
   }
 }

--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -36,6 +36,7 @@ export default class Player extends Schema implements IPlayer {
   @type("boolean") shopLocked: boolean = false
   @type("uint8") streak: number = 0
   @type("uint8") interest: number = 0
+  @type("string") opponentId: string = ""
   @type("string") opponentName: string = ""
   @type("string") opponentAvatar: string = ""
   @type("string") opponentTitle: string = ""

--- a/app/models/colyseus-models/pokemon-avatar.ts
+++ b/app/models/colyseus-models/pokemon-avatar.ts
@@ -1,6 +1,6 @@
 import { Schema, type } from "@colyseus/schema"
 import { Constraint } from "matter-js"
-import { getInformations } from "../../public/src/utils"
+import { getPokemonConfigFromAvatar } from "../../public/src/utils"
 import { IPokemonAvatar } from "../../types"
 import { Orientation, PokemonActionState } from "../../types/enum/Game"
 import { Pkm, PkmIndex } from "../../types/enum/Pokemon"
@@ -27,14 +27,8 @@ export class PokemonAvatar extends Schema implements IPokemonAvatar {
     this.targetX = x
     this.targetY = y
     this.timer = timer
-    const informations = getInformations(avatar)
-    Object.keys(PkmIndex).forEach((pkm_) => {
-      const pkm = pkm_ as Pkm
-      const index = PkmIndex[pkm]
-      if (index === informations.index) {
-        this.name = pkm
-      }
-    })
-    this.shiny = informations.shiny
+    const { index, shiny } = getPokemonConfigFromAvatar(avatar)
+    this.name = Object.keys(PkmIndex).find((pkm) => PkmIndex[pkm] === index) as Pkm
+    this.shiny = shiny
   }
 }

--- a/app/public/src/game/components/board-manager.ts
+++ b/app/public/src/game/components/board-manager.ts
@@ -97,6 +97,7 @@ export default class BoardManager {
     )
     this.playerAvatar.disableInteractive()
     this.playerAvatar.orientation = Orientation.UPRIGHT
+    this.playerAvatar.updateCircleLife(this.player.life)
     this.animationManager.animatePokemon(this.playerAvatar, this.playerAvatar.action)    
   }
 
@@ -105,7 +106,7 @@ export default class BoardManager {
       this.opponentAvatar.destroy(true)
     }
 
-    if(this.mode === BoardMode.BATTLE){
+    if(this.mode === BoardMode.BATTLE && opponentId !== "pve"){
       const opponentAvatar = new PokemonAvatar(this.player.id, opponentAvatarString, 0, 0, 0)
       this.opponentAvatar = new Pokemon(
         this.scene,
@@ -117,7 +118,22 @@ export default class BoardManager {
       )
       this.opponentAvatar.disableInteractive()
       this.opponentAvatar.orientation = Orientation.DOWNLEFT
+      let opponentLife = 0 
+      this.scene.room?.state.players.forEach(p => {
+        if(p.id === opponentId) opponentLife = p.life
+      })
+      this.opponentAvatar.updateCircleLife(opponentLife)
       this.animationManager.animatePokemon(this.opponentAvatar, this.opponentAvatar.action)
+    }
+  }
+
+  updateAvatarLife(playerId: string, value: number){
+    if(this.player.id === playerId){
+      this.playerAvatar.updateCircleLife(value)
+    }
+    
+    if(this.opponentAvatar && this.opponentAvatar.id === playerId){
+      this.opponentAvatar.updateCircleLife(value)
     }
   }
 

--- a/app/public/src/game/components/board-manager.ts
+++ b/app/public/src/game/components/board-manager.ts
@@ -11,7 +11,6 @@ import { Pkm } from "../../../../types/enum/Pokemon"
 import { BoardEvent, GamePhaseState, Orientation } from "../../../../types/enum/Game"
 import { Ability } from "../../../../types/enum/Ability"
 import { PokemonAvatar } from "../../../../models/colyseus-models/pokemon-avatar"
-import store from "../../stores"
 
 export enum BoardMode { PICK = "pick", BATTLE = "battle", MINIGAME = "minigame" }
 
@@ -96,7 +95,7 @@ export default class BoardManager {
       this.player.id,
       false
     )
-
+    this.playerAvatar.disableInteractive()
     this.playerAvatar.orientation = Orientation.UPRIGHT
     this.animationManager.animatePokemon(this.playerAvatar, this.playerAvatar.action)    
   }
@@ -116,7 +115,7 @@ export default class BoardManager {
         opponentId,
         false
       )
-
+      this.opponentAvatar.disableInteractive()
       this.opponentAvatar.orientation = Orientation.DOWNLEFT
       this.animationManager.animatePokemon(this.opponentAvatar, this.opponentAvatar.action)
     }

--- a/app/public/src/game/components/weather-manager.ts
+++ b/app/public/src/game/components/weather-manager.ts
@@ -314,7 +314,7 @@ export default class WeatherManager {
       })
     )
 
-    this.fx = this.scene.cameras.main.postFX!.addDisplacement(undefined, 0, -0.002);
+    this.fx = this.scene.cameras.main.postFX.addDisplacement(undefined, 0, -0.002);
     this.fxTween = this.scene.tweens.add({
       targets: this.fx,
       y: +0.002,
@@ -337,10 +337,11 @@ export default class WeatherManager {
     if(this.fx){
       this.fx.x=0
       this.fx.y=0
-      this.fx.destroy();      
+      this.fx.destroy();
     }
     if(this.fxTween){
       this.fxTween.destroy();
     }
+    this.scene.cameras.main.postFX.clear()
   }
 }

--- a/app/public/src/game/scenes/game-scene.ts
+++ b/app/public/src/game/scenes/game-scene.ts
@@ -208,11 +208,10 @@ export default class GameScene extends Scene {
 
   updatePhase() {
     this.resetDragState()
-    if (
-      this.room?.state.phase == GamePhaseState.FIGHT ||
-      this.room?.state.phase === GamePhaseState.MINIGAME
-    ) {
+    if (this.room?.state.phase == GamePhaseState.FIGHT) {
       this.board?.battleMode()
+    } else if (this.room?.state.phase === GamePhaseState.MINIGAME) {
+      this.board?.minigameMode()
     } else {
       this.board?.pickMode()
     }
@@ -236,9 +235,14 @@ export default class GameScene extends Scene {
 
   resetDragState() {
     if (this.pokemonDragged) {
-      this.input.emit("dragend", this.input.pointer1, this.pokemonDragged, false)
+      this.input.emit(
+        "dragend",
+        this.input.pointer1,
+        this.pokemonDragged,
+        false
+      )
       this.pokemonDragged = null
-    } else if(this.itemDragged) {
+    } else if (this.itemDragged) {
       this.itemDragged.closeDetail()
       this.itemDragged.x = this.itemDragged.input!.dragStartX
       this.itemDragged.y = this.itemDragged.input!.dragStartY
@@ -371,7 +375,7 @@ export default class GameScene extends Scene {
             )} gold`
           )
           this.drawRectangles(true)
-        } else if(gameObject instanceof ItemContainer) {
+        } else if (gameObject instanceof ItemContainer) {
           this.itemDragged = gameObject
           this.drawRectangles(false)
         }
@@ -390,7 +394,11 @@ export default class GameScene extends Scene {
         const g = <Phaser.GameObjects.Container>gameObject
         g.x = dragX
         g.y = dragY
-        if(g && this.pokemonDragged != null && this.sellZoneGraphic?.visible === false){
+        if (
+          g &&
+          this.pokemonDragged != null &&
+          this.sellZoneGraphic?.visible === false
+        ) {
           this.drawRectangles(true)
         }
       }
@@ -436,7 +444,10 @@ export default class GameScene extends Scene {
             gameObject.setPosition(x, y)
           }
           this.pokemonDragged = null
-        } else if (gameObject instanceof ItemContainer && this.itemDragged != null) {
+        } else if (
+          gameObject instanceof ItemContainer &&
+          this.itemDragged != null
+        ) {
           // Item -> Item = COMBINE
           if (dropZone instanceof ItemContainer) {
             document.getElementById("game")?.dispatchEvent(

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -21,6 +21,7 @@ import {
   setShopLocked,
   setStageLevel,
   setStreak,
+  setOpponentId,
   setOpponentName,
   setOpponentAvatar,
   setOpponentTitle,
@@ -370,6 +371,9 @@ export default function Game() {
           })
         }
 
+        player.listen("opponentId", (value, previousValue) => {
+          dispatch(setOpponentId({ id: player.id, value: value }))
+        })
         player.listen("opponentName", (value, previousValue) => {
           dispatch(setOpponentName({ id: player.id, value: value }))
         })

--- a/app/public/src/stores/GameStore.ts
+++ b/app/public/src/stores/GameStore.ts
@@ -222,6 +222,7 @@ export const gameSlice = createSlice({
       if (state.currentPlayerId === action.payload.id) {
         state.currentPlayerLife = action.payload.value
       }
+      getGameScene()?.board?.updateAvatarLife(action.payload.id, action.payload.value)
     },
     setCurrentPlayerExperienceManager: (
       state,

--- a/app/public/src/stores/GameStore.ts
+++ b/app/public/src/stores/GameStore.ts
@@ -14,6 +14,7 @@ import { toast } from "react-toastify"
 import React from "react"
 import { getAvatarSrc } from "../utils"
 import { StageDuration } from "../../../types/Config"
+import { getGameScene } from "../pages/game"
 
 interface GameStateStore {
   afterGameId: string
@@ -34,6 +35,7 @@ interface GameStateStore {
   itemsProposition: string[]
   pokemonsProposition: Pkm[]
   currentPlayerSynergies: [string, number][]
+  currentPlayerOpponentId: string
   currentPlayerOpponentName: string
   currentPlayerOpponentAvatar: string
   currentPlayerOpponentTitle: string
@@ -73,6 +75,7 @@ const initialState: GameStateStore = {
   itemsProposition: new Array<Item>(),
   pokemonsProposition: new Array<Pkm>(),
   currentPlayerSynergies: new Array<[Synergy, number]>(),
+  currentPlayerOpponentId: "",
   currentPlayerOpponentName: "",
   currentPlayerOpponentAvatar: "0019/Normal",
   currentPlayerOpponentTitle: "",
@@ -174,6 +177,14 @@ export const gameSlice = createSlice({
         state.currentPlayerSynergies = Array.from(action.payload.value)
       }
     },
+    setOpponentId: (
+      state,
+      action: PayloadAction<{ value: string; id: string }>
+    ) => {
+      if (state.currentPlayerId === action.payload.id) {
+        state.currentPlayerOpponentId = action.payload.value
+      }
+    },
     setOpponentName: (
       state,
       action: PayloadAction<{ value: string; id: string }>
@@ -188,6 +199,7 @@ export const gameSlice = createSlice({
     ) => {
       if (state.currentPlayerId === action.payload.id) {
         state.currentPlayerOpponentAvatar = action.payload.value
+        getGameScene()?.board?.updateOpponentAvatar(state.currentPlayerOpponentId, state.currentPlayerOpponentAvatar)
       }
     },
     setOpponentTitle: (
@@ -272,6 +284,7 @@ export const gameSlice = createSlice({
       state.currentPlayerId = action.payload.id
       state.currentPlayerMoney = action.payload.money
       state.currentPlayerExperienceManager = action.payload.experienceManager
+      state.currentPlayerOpponentId = action.payload.opponentId
       state.currentPlayerOpponentName = action.payload.opponentName
       state.currentPlayerOpponentAvatar = action.payload.opponentAvatar
       state.currentPlayerOpponentTitle = action.payload.opponentTitle
@@ -485,6 +498,7 @@ export const {
   setCurrentPlayerMoney,
   setLife,
   setBoardSize,
+  setOpponentId,
   setOpponentName,
   setOpponentAvatar,
   setOpponentTitle,

--- a/app/public/src/utils.ts
+++ b/app/public/src/utils.ts
@@ -17,7 +17,13 @@ export function getAvatarSrc(avatar: string) {
   return `${CDN_PORTRAIT_URL}${avatar.replace("-", "/")}.png`
 }
 
-export function getInformations(avatar: string) {
+export interface IPokemonAvatarConfig {
+  index: string
+  emotion: Emotion,
+  shiny: boolean  
+}
+
+export function getPokemonConfigFromAvatar(avatar: string): IPokemonAvatarConfig {
   let emotion = Emotion.NORMAL
   let shiny = false
   let index = "0019"

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -38,7 +38,6 @@ import {
 } from "../../types"
 import { Pkm, PkmIndex } from "../../types/enum/Pokemon"
 import { Pokemon } from "../../models/colyseus-models/pokemon"
-import { Ability } from "../../types/enum/Ability"
 import { chance, pickRandomIn } from "../../utils/random"
 import { logger } from "../../utils/logger"
 import { Passive } from "../../types/enum/Passive"
@@ -1042,6 +1041,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom, any> {
             client?.send(Transfer.PLAYER_DAMAGE, playerDamage)
           }
         }
+
         player.addBattleResult(
           player.opponentName,
           currentResult,
@@ -1323,6 +1323,10 @@ export class OnUpdatePhaseCommand extends Command<GameRoom, any> {
         }
 
         player.opponentName = ""
+        player.opponentId = ""
+        player.opponentAvatar = ""
+        player.opponentTitle = ""
+
         if (!player.isBot) {
           if (!player.shopLocked) {
             this.state.shop.assignShop(player)
@@ -1398,6 +1402,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom, any> {
     this.state.players.forEach((player: Player, key: string) => {
       if (player.alive) {
         if (stageIndex != -1) {
+          player.opponentId = "pve"
           player.opponentName = NeutralStage[stageIndex].name
           player.opponentAvatar = NeutralStage[stageIndex].avatar
           player.opponentTitle = "Wild"

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -679,7 +679,7 @@ export default class GameRoom extends Room<GameState> {
           player.opponentId = id
           player.opponentName = opponent.name
           player.opponentAvatar = opponent.avatar
-          player.opponentTitle = TitleName[opponent.title]
+          player.opponentTitle = TitleName[opponent.title] ?? ""
           return id
         }
       }

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -676,6 +676,7 @@ export default class GameRoom extends Room<GameState> {
         const opponent = this.state.players.get(id)
         if (opponent) {
           player.opponents.set(id, this.state.stageLevel)
+          player.opponentId = id
           player.opponentName = opponent.name
           player.opponentAvatar = opponent.avatar
           player.opponentTitle = TitleName[opponent.title]

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -322,6 +322,7 @@ export interface IPlayer {
   shopLocked: boolean
   streak: number
   interest: number
+  opponentId: string
   opponentName: string
   opponentAvatar: string
   opponentTitle: string


### PR DESCRIPTION
![image](https://github.com/keldaanCommunity/pokemonAutoChess/assets/566536/f1283344-306b-4c44-a3b4-ade5ba27bb78)

Currently these avatars do nothing except showing player life and dancing on victory

I plan to add the ability to interact with them to communicate with emotes between players