### PR TITLE
loading improvements

### DIFF
--- a/app/public/src/pages/component/game/game-loading-screen.css
+++ b/app/public/src/pages/component/game/game-loading-screen.css
@@ -6,6 +6,7 @@
   left: 0;
   bottom: 0;
   right: 0;
+  background: black;
 }
 
 .game-loading-screen li {
@@ -24,6 +25,14 @@
   text-align: center;
   font-family: monospace;
   font-size: 28pt;
+}
+
+.game-loading-screen .error {
+  color: red;
+}
+
+.game-loading-screen button {
+  margin: auto;
 }
 
 .game-loading-screen footer {

--- a/app/public/src/pages/component/game/game-loading-screen.tsx
+++ b/app/public/src/pages/component/game/game-loading-screen.tsx
@@ -1,16 +1,22 @@
-import React from "react"
+import React, { useState } from "react"
 import GamePlayerLoading from "./game-player-loading"
 import { useAppSelector } from "../../../hooks"
 import { getGameScene } from "../../game"
 import "./game-loading-screen.css"
+import { Navigate } from "react-router"
 
-export default function GameLoadingScreen() {
+export default function GameLoadingScreen(props: { connectError: string }) {
   const players = useAppSelector((state) => state.game.players)
   const currentPlayerId = useAppSelector((state) => state.network.uid)
   const progress = players.find(
     (p) => p.id === currentPlayerId
   )?.loadingProgress
   const statusMessage = getGameScene()?.loadingManager?.statusMessage
+  const [toAuth, setToAuth] = useState<boolean>(false)
+
+  if (toAuth) {
+    return <Navigate to={"/"} />
+  }
 
   return (
     <div className="game-loading-screen">
@@ -34,10 +40,16 @@ export default function GameLoadingScreen() {
           value={progress}
           max="100"
         ></progress>
-        <p>{statusMessage}</p>
+        <p id="status-message">{statusMessage}</p>
+        {props.connectError && <>
+          <p className="error">{props.connectError}</p>
+          <button onClick={() => setToAuth(true)} className="bubbly blue">
+            Back to Lobby
+          </button>
+        </>}
       </div>
       <footer>
-        Players disconnected for more than one minute are kicked out of the
+        Players disconnected for more than 3 minutes are kicked out of the
         game. Game will start after 5 minutes max of loading no matter what.
       </footer>
     </div>

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -408,21 +408,22 @@ export default class GameRoom extends Room<GameState> {
   async onLeave(client: Client, consented: boolean) {
     try {
       if (client && client.auth && client.auth.displayName) {
-        logger.info(`${client.auth.displayName} is leaving`)
+        logger.info(`${client.auth.displayName} has been disconnected`)
       }
       if (consented) {
         throw new Error("consented leave")
       }
 
-      // allow disconnected client to reconnect into this room until 1 minute
-      await this.allowReconnection(client, 60)
+      // allow disconnected client to reconnect into this room until 3 minutes
+      await this.allowReconnection(client, 180)
     } catch (e) {
       if (client && client.auth && client.auth.displayName) {
-        logger.info(`${client.auth.displayName} leave game room`)
+        logger.info(`${client.auth.displayName} left game`)
         const player = this.state.players.get(client.auth.uid)
-        if (player && player.loadingProgress < 100 && !this.state.gameLoaded) {
-          // if player quit during the loading screen, remove it from the players
+        if (player && (player.loadingProgress < 100 || this.state.stageLevel < 4)) {
+          // if player left game during the loading screen or before stage 4, remove it from the players
           this.state.players.delete(client.auth.uid)
+          logger.info(`${client.auth.displayName} has been removed from players list`)
         }
       }
       if (


### PR DESCRIPTION
trying to improve the loading process to solve issues like those:
https://discord.com/channels/737230355039387749/1119934269293338695
https://discord.com/channels/737230355039387749/1111291243687841792

- wait to be connected to game room before starting to load
- show error messages client side when failed to connect
- change reconnection delay allowed from 1 minute to 3 minutes
- change number of reconnect attemps from 2 to 3
- remove disconnected players from the players list if they disconnected before stage 4, so that they don't lose ELO