### PR TITLE
change fairy splash and buff pokemonomicon

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -201,8 +201,8 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
         specialDamage = Math.round(specialDamage * attacker.critDamage)
       }
       if (attacker && attacker.items.has(Item.POKEMONOMICON)) {
-        this.status.triggerBurn(2000, this, attacker, board)
-        this.status.triggerWound(2000, this, attacker, board)
+        this.status.triggerBurn(3000, this, attacker, board)
+        this.status.triggerWound(3000, this, attacker, board)
       }
       if (this.items.has(Item.POWER_LENS) && specialDamage >= 1 && attacker) {
         attacker.handleDamage({
@@ -570,13 +570,13 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
           pokemon.effects.includes(Effect.STRANGE_STEAM) ||
           pokemon.effects.includes(Effect.AROMATIC_MIST))
       ) {
-        let d = 0
+        let damage = 0
         if (pokemon.effects.includes(Effect.AROMATIC_MIST)) {
-          d = 10
+          damage = 10
         } else if (pokemon.effects.includes(Effect.FAIRY_WIND)) {
-          d = 30
+          damage = 30
         } else if (pokemon.effects.includes(Effect.STRANGE_STEAM)) {
-          d = 60
+          damage = 60
         }
         const cells = board.getAdjacentCells(
           pokemon.positionX,
@@ -586,13 +586,7 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
         cells.forEach((cell) => {
           if (cell.value && pokemon.team !== cell.value.team) {
             cell.value.count.fairyCritCount++
-            cell.value.handleDamage({
-              damage: d,
-              board,
-              attackType: AttackType.SPECIAL,
-              attacker: pokemon,
-              shouldTargetGainMana: true
-            })
+            cell.value.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, false)
           }
         })
 

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -879,44 +879,19 @@ export default class Simulation extends Schema implements ISimulation {
           break
 
         case Effect.PHANTOM_FORCE:
-          if (types.includes(Synergy.GHOST)) {
-            pokemon.effects.push(Effect.PHANTOM_FORCE)
-          }
-          break
-
         case Effect.CURSE:
-          if (types.includes(Synergy.GHOST)) {
-            pokemon.effects.push(Effect.CURSE)
-          }
-          break
-
         case Effect.SHADOW_TAG:
-          if (types.includes(Synergy.GHOST)) {
-            pokemon.effects.push(Effect.SHADOW_TAG)
-          }
-          break
-
         case Effect.WANDERING_SPIRIT:
           if (types.includes(Synergy.GHOST)) {
-            pokemon.effects.push(Effect.WANDERING_SPIRIT)
+            pokemon.effects.push(effect)
           }
           break
 
         case Effect.AROMATIC_MIST:
-          if (types.includes(Synergy.FAIRY)) {
-            pokemon.effects.push(Effect.AROMATIC_MIST)
-          }
-          break
-
         case Effect.FAIRY_WIND:
-          if (types.includes(Synergy.FAIRY)) {
-            pokemon.effects.push(Effect.FAIRY_WIND)
-          }
-          break
-
         case Effect.STRANGE_STEAM:
           if (types.includes(Synergy.FAIRY)) {
-            pokemon.effects.push(Effect.STRANGE_STEAM)
+            pokemon.effects.push(effect)
           }
           break
 
@@ -1140,6 +1115,7 @@ export default class Simulation extends Schema implements ISimulation {
             this.board,
             AttackType.SPECIAL,
             null,
+            false,
             false
           )
         }

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -1115,7 +1115,6 @@ export default class Simulation extends Schema implements ISimulation {
             this.board,
             AttackType.SPECIAL,
             null,
-            false,
             false
           )
         }

--- a/app/types/strings/Item.ts
+++ b/app/types/strings/Item.ts
@@ -82,8 +82,7 @@ export const ItemDescription: { [key in Item]: string } = Object.freeze({
   [Item.SOUL_DEW]: `During combat, the holder gains 10% ${Stat.AP} every second`,
   [Item.UPGRADE]: `Successful attacks grant +5% bonus ${Stat.ATK_SPEED} for the rest of combat`,
   [Item.REAPER_CLOTH]: "The holder spells can critically strike",
-  [Item.POKEMONOMICON]:
-    "When the holder deals damage with their Ability, they burn and wound the target for 2 seconds",
+  [Item.POKEMONOMICON]: `When the holder deals ${Damage.SPECIAL}, they burn and wound the target for 3 seconds`,
   [Item.POWER_LENS]: `50% of incoming ${Damage.SPECIAL} is also dealt to the attacker`,
   [Item.SHELL_BELL]: "Holder heals for 30% of all damages inflicted",
   [Item.LUCKY_EGG]: `+30% ${Stat.AP} for holder and adjacent allies in the same row`,

--- a/changelog/patch-3.9.md
+++ b/changelog/patch-3.9.md
@@ -31,27 +31,20 @@ Emotes communication between players ingame
 # Changes to Synergies
 
 - Nerf Human heal: (2) 15% → 10% ; (4) 30% → 25% ; (6): 60% → 50%
+- Fairy splash now acts the same way as any other special damage, that is trigger Pokemonomicon, be absorbed by Rune Protect and be reflected by Power Lens
 
 # Changes to Items
 
-- Gracidea flower: Replace focus band
-- Buff Reaper Cloth: AP: 10% → 15% ; Crit chance: 5% → 15%
-- Rework Shiny Charm: Give 15% chance to avoid incoming damage and trigger Protect for 1 second
+- Buff Pokemonomicon: Wound/Burn duration 2 → 3 seconds ; now works with any source of special damage, not only abilities
 
 # Bugfix
 
-- Many on-hit effects now only apply when the attack is successful (not dodged or protected). This concerns: Aquatic mana burn, Fire attack buff, Poison chance, Freeze chance, Silence chance, Upgrade stacks, Red Orb damage, Smoke Ball debuff, Spike Armor
-- Choice scarf was not applying damage correctly with Ghost true damage
-- Leftovers heal was triggering twice for the item holder
-- Fix a bug where the attack speed of a pkm was stuck at .4 even with upgrade buff
+- 
 
 # UI
 
-- Add a slider option for SFX volume
-- Extra detail in the damage bars
+- 
 
 # Misc
 
-- New evolution mechanic for Poliwhirl/Clamperl. Evolution will depends if the pokemon is placed in the frontlane or not.
-- New evolution mechanic for Shaymin. Give it a Gracidea flower to evolve into Shaymin Sky.
-- Pool size for stage 5 additional picks has been increased: Common: 14 → 18 ; Uncommon: 11 → 13 ; it's now easier to evolve them
+- 


### PR DESCRIPTION
- Fairy splash now acts the same way as any other special damage, that is trigger Pokemonomicon, be absorbed by Rune Protect and be reflected by Power Lens
- Buff Pokemonomicon: Wound/Burn duration 2 → 3 seconds ; now works with any source of special damage, not only abilities

https://discord.com/channels/737230355039387749/1120290909456695346