### PR TITLE
add emotes anims in split script

### DIFF
--- a/edit/split.ts
+++ b/edit/split.ts
@@ -187,6 +187,9 @@ async function splitIndex(index: string) {
           if (!actions.includes(AnimationConfig[conf as Pkm].ability)) {
             actions.push(AnimationConfig[conf as Pkm].ability)
           }
+          if (!actions.includes(AnimationConfig[conf as Pkm].emote)) {
+            actions.push(AnimationConfig[conf as Pkm].emote)
+          }
         } else {
           actions.push(AnimationType.Attack)
         }


### PR DESCRIPTION
I just saw that you were filtering anims to add to spritesheets, that explains all the missing anims warnings.

added emote anims, sorry you'll have to do a full index again :'( 

i'm still processing the list of emotes anims, it's likely that some emote anims "Shoot" are missing