### PR TITLE
fixed POKE_DOLL, electricField, psychicField, grassField, fairyField,…

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -128,34 +128,34 @@ export default class PokemonState {
       let reducedDamage = damage
 
       if (pokemon.items.has(Item.POKE_DOLL)) {
-        reducedDamage = Math.ceil(reducedDamage * 0.7)
+        damage = Math.ceil(damage * 0.7)
       }
 
       if (attacker && attacker.status.electricField) {
-        reducedDamage = Math.ceil(reducedDamage * 1.2)
+        damage = Math.ceil(damage * 1.2)
       }
 
       if (attacker && attacker.status.psychicField) {
-        reducedDamage = Math.ceil(reducedDamage * 1.2)
+        damage = Math.ceil(damage * 1.2)
       }
 
       if (attacker && attacker.status.grassField) {
-        reducedDamage = Math.ceil(reducedDamage * 1.2)
+        damage = Math.ceil(damage * 1.2)
       }
 
       if (attacker && attacker.status.fairyField) {
-        reducedDamage = Math.ceil(reducedDamage * 1.2)
+        damage = Math.ceil(damage * 1.2)
       }
 
       if (attacker && attacker.items.has(Item.FIRE_GEM)) {
-        reducedDamage = Math.ceil(reducedDamage + pokemon.hp * 0.1)
+        damage = Math.ceil(damage + pokemon.hp * 0.1)
       }
 
       if (
         pokemon.simulation.weather === Weather.MISTY &&
         attackType === AttackType.SPECIAL
       ) {
-        reducedDamage = Math.ceil(reducedDamage * 1.2)
+        damage = Math.ceil(damage * 1.2)
       }
 
       if (


### PR DESCRIPTION
… FIRE_GEM and MISTY not working correctly

With this fix the amplification of the items, fields and weather will also lead to more or less mana gain. For the item poke doll this behavior is maybe debatable. 