### PR TITLE
fix player removal while refreshing

### DIFF
--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -560,7 +560,7 @@ export default class GameRoom extends Room<GameState> {
             player.titles.add(Title.GRAND_MASTER)
           }
 
-          if (usr.elo && elligibleToELO) {
+          if (usr.elo != null && elligibleToELO) {
             const elo = computeElo(
               this.transformToSimplePlayer(player),
               rank,

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -428,10 +428,7 @@ export default class GameRoom extends Room<GameState> {
       if (client && client.auth && client.auth.displayName) {
         logger.info(`${client.auth.displayName} left game`)
         const player = this.state.players.get(client.auth.uid)
-        if (
-          player &&
-          (player.loadingProgress < 100 || this.state.stageLevel < 4)
-        ) {
+        if (player && this.state.stageLevel < 4) {
           // if player left game during the loading screen or before stage 4, remove it from the players
           this.state.players.delete(client.auth.uid)
           this.state.players.forEach((player) => {


### PR DESCRIPTION
fix an edge case where player could be removed while refreshing at the same time than the max allowed reconnect time
it's unlikely but it simplifies code as well. Now we make sure than no player can be removed after stage 3