### PR TITLE
fix eggs combining bug

### DIFF
--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -819,6 +819,7 @@ export default class GameRoom extends Room<GameState> {
 
       if (
         pokemonEvolutionName !== Pkm.DEFAULT &&
+        pokemon.name !== Pkm.EGG &&
         pokemon.rarity !== Rarity.HATCH &&
         count >= getEvolutionCountNeeded(pokemon.name)
       ) {


### PR DESCRIPTION
There is a bug causing three eggs to combine if a unit is bought. This PR adds an additional check to exclude eggs from the evolution procedure. 