### PR TITLE
show pokemon/item tooltip on hover instead of click

### DIFF
--- a/app/public/src/game/components/item-container.ts
+++ b/app/public/src/game/components/item-container.ts
@@ -65,47 +65,55 @@ export default class ItemContainer extends DraggableObject {
     this.add(this.detail)
 
     this.setInteractive()
-    this.input.dropZone = true
-    this.draggable = (this.pokemonId === null)
+    this.setDropZone(true)
+    this.draggable = this.pokemonId === null
   }
 
+  setDropZone(value: boolean) {
+    if (this.input) {
+      this.input.dropZone = value
+    }
+  }
 
   onPointerOver() {
-    //this.openDetail()
     super.onPointerOver()
-    this.input.dropZone = false
+    this.setDropZone(false)
+
     if (this.draggable) {
       this.circle?.setFillStyle(0x68829e)
+    }
+
+    if (!this.detail.visible) {
+      this.openDetail()
+      this.setDropZone(false)
     }
   }
 
   onPointerOut() {
     super.onPointerOut()
     if (!this.dragDisabled) {
-      this.input.dropZone = true
+      this.setDropZone(true)
     }
     if (this.draggable) {
       this.circle?.setFillStyle(0x61738a)
+    }
+    if (this.detail.visible) {
+      this.closeDetail()
+      this.setDropZone(true)
     }
   }
 
   onPointerDown(pointer: Phaser.Input.Pointer) {
     super.onPointerDown(pointer)
     this.parentContainer.bringToTop(this)
-    if (pointer.rightButtonDown()) {
-      if (!this.detail.visible) {
-        this.openDetail()
-        this.input.dropZone = false
-      } else {
-        this.closeDetail()
-        this.input.dropZone = true
-      }
+    if (this.detail.visible) {
+      this.closeDetail()
     }
   }
 
   onPointerUp() {
     super.onPointerUp()
-    this.input.dropZone = false
+    this.setDropZone(false)
   }
 
   openDetail() {

--- a/app/public/src/game/components/item-container.ts
+++ b/app/public/src/game/components/item-container.ts
@@ -65,55 +65,47 @@ export default class ItemContainer extends DraggableObject {
     this.add(this.detail)
 
     this.setInteractive()
-    this.setDropZone(true)
-    this.draggable = this.pokemonId === null
+    this.input.dropZone = true
+    this.draggable = (this.pokemonId === null)
   }
 
-  setDropZone(value: boolean) {
-    if (this.input) {
-      this.input.dropZone = value
-    }
-  }
 
   onPointerOver() {
+    //this.openDetail()
     super.onPointerOver()
-    this.setDropZone(false)
-
+    this.input.dropZone = false
     if (this.draggable) {
       this.circle?.setFillStyle(0x68829e)
-    }
-
-    if (!this.detail.visible) {
-      this.openDetail()
-      this.setDropZone(false)
     }
   }
 
   onPointerOut() {
     super.onPointerOut()
     if (!this.dragDisabled) {
-      this.setDropZone(true)
+      this.input.dropZone = true
     }
     if (this.draggable) {
       this.circle?.setFillStyle(0x61738a)
-    }
-    if (this.detail.visible) {
-      this.closeDetail()
-      this.setDropZone(true)
     }
   }
 
   onPointerDown(pointer: Phaser.Input.Pointer) {
     super.onPointerDown(pointer)
     this.parentContainer.bringToTop(this)
-    if (this.detail.visible) {
-      this.closeDetail()
+    if (pointer.rightButtonDown()) {
+      if (!this.detail.visible) {
+        this.openDetail()
+        this.input.dropZone = false
+      } else {
+        this.closeDetail()
+        this.input.dropZone = true
+      }
     }
   }
 
   onPointerUp() {
     super.onPointerUp()
-    this.setDropZone(false)
+    this.input.dropZone = false
   }
 
   openDetail() {

--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -281,47 +281,55 @@ export default class Pokemon extends DraggableObject {
 
   onPointerDown(pointer: Phaser.Input.Pointer) {
     super.onPointerDown(pointer)
-    if (pointer.rightButtonDown() && this.shouldShowTooltip) {
+    // close detail when dragging
+    this.closeDetail()
+  }
+
+  onPointerOut(): void {
+    super.onPointerOut();
+    this.closeDetail()
+  }
+
+  onPointerOver() {
+    super.onPointerOver()
+    if (this.shouldShowTooltip) {
       const s = <GameScene>this.scene
       if (s.lastPokemonDetail && s.lastPokemonDetail != this) {
         s.lastPokemonDetail.closeDetail()
         s.lastPokemonDetail = undefined
       }
-      if (this.detail) {
-        this.closeDetail()
-      } else {
-        this.detail = new PokemonDetail(
-          this.scene,
-          0,
-          0,
-          this.name,
-          this.rarity,
-          this.life || this.hp,
-          this.atk,
-          this.def,
-          this.speDef,
-          this.range,
-          this.atkSpeed,
-          this.critChance,
-          this.critDamage,
-          this.ap,
-          this.mana || this.maxMana,
-          this.types,
-          this.skill,
-          this.passive,
-          this.emotion,
-          this.shiny,
-          this.index,
-          this.rarity === Rarity.MYTHICAL ? 3 : this.stars,
-          this.evolution
-        )
-        this.detail.setPosition(
-          this.detail.width / 2 + 40,
-          -this.detail.height / 2 - 40
-        )
-        this.add(this.detail)
-        s.lastPokemonDetail = this
-      }
+
+      this.detail = new PokemonDetail(
+        this.scene,
+        0,
+        0,
+        this.name,
+        this.rarity,
+        this.life || this.hp,
+        this.atk,
+        this.def,
+        this.speDef,
+        this.range,
+        this.atkSpeed,
+        this.critChance,
+        this.critDamage,
+        this.ap,
+        this.mana || this.maxMana,
+        this.types,
+        this.skill,
+        this.passive,
+        this.emotion,
+        this.shiny,
+        this.index,
+        this.rarity === Rarity.MYTHICAL ? 3 : this.stars,
+        this.evolution
+      )
+      this.detail.setPosition(
+        this.detail.width / 2 + 40,
+        -this.detail.height / 2 - 40
+      )
+      this.add(this.detail)
+      s.lastPokemonDetail = this
     }
   }
 


### PR DESCRIPTION
as title suggests, change when tooltips appear. This helps fix when tooltips are persistent on screen until you reclick that same pokemon.

hopefully not overstepping my bounds here, I think this could be a nice QoL improvement 


https://github.com/keldaanCommunity/pokemonAutoChess/assets/25358150/61301ab0-4a79-4a2a-aae4-37bef206999f

