### PR TITLE
fix geologist title not obtainable

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -890,7 +890,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom, any> {
         case Effect.STEEL_SURGE:
           player.titles.add(Title.ENGINEER)
           break
-        case Effect.SANDSTORM:
+        case Effect.DRILLER:
           player.titles.add(Title.GEOLOGIST)
           break
         case Effect.TOXIC:


### PR DESCRIPTION
The geologist title was not obtainable anymore since the last stage of the ground synergy got renamed. This PR fixes the problem. 