### PR TITLE
fix bot manager init

### DIFF
--- a/app/public/src/pages/component/bot-builder/bot-manager-panel.tsx
+++ b/app/public/src/pages/component/bot-builder/bot-manager-panel.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { getAvatarSrc } from "../../../utils"
-import { addBotDatabase, deleteBotDatabase } from "../../../stores/NetworkStore"
+import { addBotDatabase, deleteBotDatabase, requestBotList } from "../../../stores/NetworkStore"
 import { useTranslation } from "react-i18next"
 
 export function BotManagerPanel() {
@@ -10,6 +10,10 @@ export function BotManagerPanel() {
   const logs = useAppSelector((state) => state.lobby.botLogDatabase)
   const bots = useAppSelector((state) => state.lobby.botList)
   const [url, setUrl] = useState<string>("")
+  if (bots.length === 0) {
+    dispatch(requestBotList())
+  }
+
   return (
     <div style={{ display: "flex" }}>
       <div

--- a/app/public/src/pages/component/bot-builder/team-builder.tsx
+++ b/app/public/src/pages/component/bot-builder/team-builder.tsx
@@ -12,7 +12,7 @@ import { IBot, IStep } from "../../../../../models/mongo-models/bot-v2"
 import CSS from "csstype"
 import { produce } from "immer"
 import { useAppSelector, useAppDispatch } from "../../../hooks"
-import { createBot } from "../../../stores/NetworkStore"
+import { createBot, requestBotList } from "../../../stores/NetworkStore"
 import { setBotCreatorSynergies } from "../../../stores/LobbyStore"
 import BuilderSynergies from "./builder-synergies"
 import { Synergy } from "../../../../../types/enum/Synergy"
@@ -153,6 +153,11 @@ export default function TeamBuilder() {
 
   const pastebinUrl: string = useAppSelector((state) => state.lobby.pastebinUrl)
   const botData: IBot = useAppSelector((state) => state.lobby.botData)
+  const bots = useAppSelector((state) => state.lobby.botList)
+
+  if (bots.length === 0) {
+    dispatch(requestBotList())
+  }
 
   function updateSynergies(i: number) {
     const newSynergies = new Map<Synergy, number>()

--- a/app/public/src/pages/main-sidebar.tsx
+++ b/app/public/src/pages/main-sidebar.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router"
 import { useTranslation } from "react-i18next"
 import { Sidebar, Menu, MenuItem, MenuItemProps } from "react-pro-sidebar"
 import { useAppDispatch, useAppSelector } from "../hooks"
-import { requestMeta, INetwork, requestBotList } from "../stores/NetworkStore"
+import { requestMeta, INetwork } from "../stores/NetworkStore"
 import { IUserLobbyState } from "../stores/LobbyStore"
 import { Role, Title } from "../../../types"
 import { cc } from "./utils/jsx"
@@ -61,12 +61,6 @@ export function MainSidebar(props: MainSidebarProps) {
     }
     changeModal("meta")
   }, [changeModal, dispatch, meta.length, metaItems.length])
-
-  const botAdminOnClick = useCallback(() => {
-    if (botList.length === 0) {
-      dispatch(requestBotList())
-    }
-  }, [botList.length, dispatch])
 
   useEffect(() => {
     if (!sidebarRef.current) {
@@ -161,10 +155,7 @@ export function MainSidebar(props: MainSidebarProps) {
             user?.role === Role.BOT_MANAGER) && (
             <NavLink
               svg="bot"
-              onClick={() => {
-                botAdminOnClick()
-                navigate("/bot-admin")
-              }}
+              onClick={() => navigate("/bot-admin")}
             >
               {t("bot_admin")}
             </NavLink>


### PR DESCRIPTION
last commit (https://github.com/keldaanCommunity/pokemonAutoChess/commit/cd10b343a6c3b9ed7bb13bb58cac0bd9ab1a5f4e) was not enough now that the pages have been moved to their own URL, the initiation logic must be done in their component itself to make it work after a page reload