### PR TITLE
add basic sprite debug page

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -141,6 +141,10 @@ app.get("/bot-admin", (req, res) => {
   res.sendFile(viewsSrc)
 })
 
+app.get("/sprite-debug", (req, res) => {
+  res.sendFile(viewsSrc)
+})
+
 app.get("/pokemons", (req, res) => {
   res.send(Pkm)
 })

--- a/app/public/src/index.tsx
+++ b/app/public/src/index.tsx
@@ -9,6 +9,7 @@ import AfterGame from "./pages/after-game"
 import TeamBuilder from "./pages/component/bot-builder/team-builder"
 import { BotManagerPanel } from "./pages/component/bot-builder/bot-manager-panel"
 import { Provider } from "react-redux"
+import { SpriteDebug } from "./pages/component/lobby-menu/sprite-debug"
 import store from "./stores/index"
 
 import "./i18n"
@@ -31,6 +32,7 @@ root.render(
             <Route path="/after" element={<AfterGame />} />
             <Route path="/bot-builder" element={<TeamBuilder />} />
             <Route path="/bot-admin" element={<BotManagerPanel />} />
+            <Route path="/sprite-debug" element={<SpriteDebug />} />
           </Routes>
         </BrowserRouter>
       </Suspense>

--- a/app/public/src/pages/component/anim/TestStatusAnim.tsx
+++ b/app/public/src/pages/component/anim/TestStatusAnim.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect } from "react"
+import React, { useEffect, useMemo, useRef } from "react"
 import Phaser from "phaser"
 import { nanoid } from "nanoid"
 import { createStatusAnimations } from "../../../game/animation-manager"
 import { loadStatusMultiAtlas } from "../../../game/components/loading-manager"
 import {
   Orientation,
-  PokemonActionState,
   PokemonTint,
   SpriteType
 } from "../../../../../types/enum/Game"
@@ -13,14 +12,16 @@ import durations from "../../../../dist/client/assets/pokemons/durations.json"
 import { AnimationType } from "../../../../../types/Animation"
 
 export default function TestAnim({
+  pkmIndex,
   height = 100,
   width = 100,
   offset = [0, 0],
   scale = 1,
   depth = 7,
-  animationKey = "burn",
+  animationKey,
   atlasKey = "status"
 }: {
+  pkmIndex?: string
   height?: number
   width?: number
   atlasKey?: string
@@ -29,89 +30,157 @@ export default function TestAnim({
   scale?: number
   depth?: number
 }) {
-  let PKM_INDEX
-  switch (animationKey) {
-    case "ELECTRIC_SURGE":
-      PKM_INDEX = "0025"
-      break
-    case "PSYCHIC_SURGE":
-      PKM_INDEX = "0063"
-      break
-    case "GRASSY_SURGE":
-      PKM_INDEX = "0069"
-      break
-    case "MISTY_SURGE":
-      PKM_INDEX = "0035"
-      break
-    default:
-      PKM_INDEX = "0019"
-      break
-  }
+  const gameRef = useRef<Phaser.Game>()
 
-  class TestAnimScene extends Phaser.Scene {
-    preload() {
-      loadStatusMultiAtlas(this)
-      this.load.multiatlas(
-        PKM_INDEX,
-        `/assets/pokemons/${PKM_INDEX}.json`,
-        "/assets/pokemons"
-      )
+  const PKM_INDEX = useMemo(() => {
+    if (pkmIndex) {
+      return pkmIndex
     }
 
-    create() {
-      createStatusAnimations(this)
-
-      const durationArray =
-        durations[
-          `${PKM_INDEX}/${PokemonTint.NORMAL}/${AnimationType.Idle}/${SpriteType.ANIM}`
-        ]
-      const frameArray = this.anims.generateFrameNames(PKM_INDEX, {
-        start: 0,
-        end: durationArray.length - 1,
-        zeroPad: 4,
-        prefix: `${PokemonTint.NORMAL}/${AnimationType.Idle}/${SpriteType.ANIM}/${Orientation.DOWN}/`
-      })
-      for (let i = 0; i < durationArray.length; i++) {
-        if (frameArray[i]) {
-          frameArray[i]["duration"] = durationArray[i] * 10
-        }
-      }
-
-      this.game.anims.create({
-        key: PKM_INDEX,
-        frames: frameArray,
-        repeat: -1
-      })
-
-      const pkmSprite = this.add.sprite(
-        width / 2,
-        height / 2,
-        PKM_INDEX,
-        `${PokemonTint.NORMAL}/${AnimationType.Idle}/${SpriteType.ANIM}/${Orientation.DOWN}/0000`
-      )
-      pkmSprite.play(PKM_INDEX)
-      pkmSprite.setScale(2).setDepth(3)
-
-      const statusSprite = this.add
-        .sprite(width / 2 + offset[0], height / 2 + offset[1], atlasKey)
-        .play(animationKey)
-      statusSprite.setScale(scale).setDepth(depth)
+    switch (animationKey) {
+      case "ELECTRIC_SURGE":
+        return "0025"
+      case "PSYCHIC_SURGE":
+        return "0063"
+      case "GRASSY_SURGE":
+        return "0069"
+      case "MISTY_SURGE":
+        return "0035"
+      default:
+        return "0019"
     }
-  }
+  }, [animationKey, pkmIndex])
 
   const containerId = nanoid()
 
   useEffect(() => {
-    const game = new Phaser.Game({
-      type: Phaser.AUTO,
-      parent: containerId,
-      pixelArt: true,
-      width,
-      height,
-      scene: [TestAnimScene],
-      backgroundColor: "#61738a"
-    })
-  })
+    if (pkmIndex || animationKey) {
+      gameRef.current?.destroy(true)
+      gameRef.current = undefined
+    }
+  }, [animationKey, pkmIndex])
+
+  useEffect(() => {
+    if (!gameRef.current) {
+      const scene = new TestAnimScene(
+        PKM_INDEX,
+        height,
+        width,
+        atlasKey,
+        offset,
+        scale,
+        depth,
+        animationKey
+      )
+
+      gameRef.current = new Phaser.Game({
+        type: Phaser.AUTO,
+        parent: containerId,
+        pixelArt: true,
+        width,
+        height,
+        scene: [scene],
+        backgroundColor: "#61738a"
+      })
+    }
+  }, [
+    PKM_INDEX,
+    animationKey,
+    atlasKey,
+    containerId,
+    depth,
+    height,
+    offset,
+    scale,
+    width
+  ])
 
   return <div id={containerId} className="test-anim-wrapper"></div>
+}
+
+export class TestAnimScene extends Phaser.Scene {
+  index: string
+  height: number
+  width: number
+  atlasKey: string
+  animationKey?: string
+  offset: [number, number]
+  statusScale: number
+  depth: number
+
+  constructor(
+    index: string,
+    height: number,
+    width: number,
+    atlasKey: string,
+    offset: [number, number],
+    statusScale: number,
+    depth: number,
+    animationKey?: string
+  ) {
+    super()
+    this.index = index
+    this.height = height
+    this.width = width
+    this.atlasKey = atlasKey
+    this.animationKey = animationKey
+    this.offset = offset
+    this.statusScale = statusScale
+    this.depth = depth
+  }
+
+  preload() {
+    loadStatusMultiAtlas(this)
+    this.load.multiatlas(
+      this.index,
+      `/assets/pokemons/${this.index}.json`,
+      "/assets/pokemons"
+    )
+  }
+
+  create() {
+    createStatusAnimations(this)
+
+    const durationArray =
+      durations[
+        `${this.index}/${PokemonTint.NORMAL}/${AnimationType.Idle}/${SpriteType.ANIM}`
+      ]
+    const frameArray = this.anims.generateFrameNames(this.index, {
+      start: 0,
+      end: durationArray.length - 1,
+      zeroPad: 4,
+      prefix: `${PokemonTint.NORMAL}/${AnimationType.Idle}/${SpriteType.ANIM}/${Orientation.DOWN}/`
+    })
+    for (let i = 0; i < durationArray.length; i++) {
+      if (frameArray[i]) {
+        frameArray[i]["duration"] = durationArray[i] * 10
+      }
+    }
+
+    this.game.anims.create({
+      key: this.index,
+      frames: frameArray,
+      repeat: -1
+    })
+
+    const pkmSprite = this.add.sprite(
+      this.width / 2,
+      this.height / 2,
+      this.index,
+      `${PokemonTint.NORMAL}/${AnimationType.Idle}/${SpriteType.ANIM}/${Orientation.DOWN}/0000`
+    )
+    pkmSprite.play(this.index)
+    pkmSprite.setScale(2).setDepth(3)
+
+    if (this.animationKey) {
+      const statusSprite = this.add
+        .sprite(
+          this.width / 2 + this.offset[0],
+          this.height / 2 + this.offset[1],
+          this.atlasKey
+        )
+        .play(this.animationKey)
+      statusSprite.setScale(this.statusScale).setDepth(this.depth)
+    }
+  }
 }

--- a/app/public/src/pages/component/lobby-menu/sprite-debug.css
+++ b/app/public/src/pages/component/lobby-menu/sprite-debug.css
@@ -1,0 +1,51 @@
+.sprite-debug-root {
+    width: 100%;
+    height: 100%;
+
+    --sidebar-offset: 90px;
+}
+
+/* TODO Remove this after the absolute sidebar update goes in */
+.sprite-debug-root aside.sidebar {
+    position: absolute;
+    height: 100%;
+    z-index: 999;
+}
+
+.sprite-debug-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 16px;
+
+    padding: 40px;
+    padding-left: calc(var(--sidebar-offset));
+}
+
+.sprite-debug-toolbar {
+    width: 100%;
+
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+
+}
+
+.sprite-debug-toolbar > div {
+    background-color: #006bb3;
+    border-radius: 4px;
+    color: white;
+    border: 2px solid black;
+    padding: 4px 12px;
+}
+
+.sprite-debug-sprite {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+}
+
+.sprite-debug-sprite canvas {
+    border: 2px solid black;
+    border-radius: 4px;
+}

--- a/app/public/src/pages/component/lobby-menu/sprite-debug.tsx
+++ b/app/public/src/pages/component/lobby-menu/sprite-debug.tsx
@@ -1,0 +1,114 @@
+import React, { useMemo, useState } from "react"
+import { t } from "i18next"
+
+import { MainSidebar } from "../../main-sidebar"
+import { PokemonTypeahead } from "../typeahead/pokemon-typeahead"
+import { StatusTypeahead } from "../typeahead/status-typeahead"
+import { Status } from "../../../../../types/enum/Status"
+import { Pkm } from "../../../../../types/enum/Pokemon"
+
+import TestStatusAnim from "../anim/TestStatusAnim"
+import PokemonFactory from "../../../../../models/pokemon-factory"
+
+import "./sprite-debug.css"
+import { useNavigate } from "react-router-dom"
+
+export function SpriteDebug() {
+  const navigate = useNavigate()
+  const [sprite, setSprite] = useState<Pkm>()
+  const [status, setStatus] = useState<string>()
+
+  const pkmIndex = useMemo(
+    () => (sprite ? PokemonFactory.createPokemonFromName(sprite).index : null),
+    [sprite]
+  )
+
+  return (
+    <div className="sprite-debug-root">
+      <MainSidebar
+        page="main_lobby"
+        leave={() => navigate("/lobby")}
+        leaveLabel={t("back_to_lobby")}
+      />
+      <div className="sprite-debug-container">
+        <div className="sprite-debug-toolbar">
+          <div>
+            Pokemon:
+            <PokemonTypeahead onChange={(update) => setSprite(update)} />
+          </div>
+          <div>
+            Status:
+            <StatusTypeahead onChange={(update) => setStatus(update)} />
+          </div>
+        </div>
+        <div className="sprite-debug-sprite">
+          <TestStatusAnim
+            pkmIndex={pkmIndex}
+            atlasKey="status"
+            width={500}
+            height={500}
+            {...(status ? PARAMS_ANIM_BY_STATUS[status] : {})}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const PARAMS_ANIM_BY_STATUS: {
+  [key in Status]: {
+    animationKey: string
+    offset?: [number, number]
+    scale?: number
+    depth?: number
+  }
+} = {
+  [Status.BURN]: { animationKey: "burn", scale: 2, offset: [0, -30] },
+  [Status.SILENCE]: { animationKey: "silence", scale: 2, offset: [0, -30] },
+  [Status.POISON]: { animationKey: "poison", scale: 2, offset: [0, -30] },
+  [Status.FREEZE]: { animationKey: "freeze", scale: 2, offset: [0, 0] },
+  [Status.PROTECT]: { animationKey: "protect", scale: 2, offset: [0, -30] },
+  [Status.SLEEP]: { animationKey: "sleep", scale: 2, offset: [0, -30] },
+  [Status.CONFUSION]: { animationKey: "confusion", scale: 2, offset: [0, -30] },
+  [Status.WOUND]: { animationKey: "wound", scale: 2, offset: [0, -30] },
+  [Status.RESURECTION]: {
+    animationKey: "resurection",
+    scale: 2,
+    offset: [0, -45]
+  },
+  [Status.PARALYSIS]: { animationKey: "paralysis", scale: 2, offset: [0, -20] },
+  [Status.ARMOR_REDUCTION]: {
+    animationKey: "armorReduction",
+    scale: 2,
+    offset: [0, -40]
+  },
+  [Status.RUNE_PROTECT]: {
+    animationKey: "rune_protect",
+    scale: 2,
+    offset: [0, -45]
+  },
+  [Status.ELECTRIC_FIELD]: {
+    animationKey: "ELECTRIC_SURGE",
+    scale: 2,
+    offset: [0, 10],
+    depth: 0
+  },
+  [Status.PSYCHIC_FIELD]: {
+    animationKey: "PSYCHIC_SURGE",
+    scale: 2,
+    offset: [0, 10],
+    depth: 0
+  },
+  [Status.GRASS_FIELD]: {
+    animationKey: "GRASSY_SURGE",
+    scale: 2,
+    offset: [0, 10],
+    depth: 0
+  },
+  [Status.FAIRY_FIELD]: {
+    animationKey: "MISTY_SURGE",
+    scale: 1,
+    offset: [0, 10],
+    depth: 0
+  }
+}

--- a/app/public/src/pages/component/typeahead/pokemon-typeahead.tsx
+++ b/app/public/src/pages/component/typeahead/pokemon-typeahead.tsx
@@ -1,0 +1,26 @@
+import React, { useMemo } from "react"
+import { Typeahead } from "react-bootstrap-typeahead"
+
+import { TypeaheadProps } from "./types"
+
+import { PrecomputedRaritPokemonyAll } from "../../../../../types"
+import PRECOMPUTED_RARITY_POKEMONS_ALL from "../../../../../models/precomputed/type-rarity-all.json"
+import { Pkm } from "../../../../../types/enum/Pokemon"
+
+const precomputed =
+  PRECOMPUTED_RARITY_POKEMONS_ALL as PrecomputedRaritPokemonyAll
+
+export function PokemonTypeahead({ onChange }: TypeaheadProps<Pkm>) {
+  const pokemonOptions = useMemo(() => Object.values(precomputed).flat(), [])
+
+  return (
+    <Typeahead
+      options={pokemonOptions}
+      placeholder="Select a pokemon"
+      onChange={(option) => {
+        const val = option[0] as Pkm
+        onChange(val)
+      }}
+    />
+  )
+}

--- a/app/public/src/pages/component/typeahead/pokemon-typeahead.tsx
+++ b/app/public/src/pages/component/typeahead/pokemon-typeahead.tsx
@@ -15,6 +15,7 @@ export function PokemonTypeahead({ onChange }: TypeaheadProps<Pkm>) {
 
   return (
     <Typeahead
+      id="pokemon-typeahead"
       options={pokemonOptions}
       placeholder="Select a pokemon"
       onChange={(option) => {

--- a/app/public/src/pages/component/typeahead/status-typeahead.tsx
+++ b/app/public/src/pages/component/typeahead/status-typeahead.tsx
@@ -10,6 +10,7 @@ export function StatusTypeahead({ onChange }: TypeaheadProps) {
 
   return (
     <Typeahead
+      id="status-typeahead"
       options={statusOptions}
       placeholder="Select a status"
       onChange={(option) => {

--- a/app/public/src/pages/component/typeahead/status-typeahead.tsx
+++ b/app/public/src/pages/component/typeahead/status-typeahead.tsx
@@ -1,0 +1,21 @@
+import React, { useMemo } from "react"
+import { Typeahead } from "react-bootstrap-typeahead"
+
+import { TypeaheadProps } from "./types"
+
+import { Status } from "../../../../../types/enum/Status"
+
+export function StatusTypeahead({ onChange }: TypeaheadProps) {
+  const statusOptions = useMemo(() => Object.values(Status), [])
+
+  return (
+    <Typeahead
+      options={statusOptions}
+      placeholder="Select a status"
+      onChange={(option) => {
+        const val = option[0] as string
+        onChange(val)
+      }}
+    />
+  )
+}

--- a/app/public/src/pages/component/typeahead/types.ts
+++ b/app/public/src/pages/component/typeahead/types.ts
@@ -1,0 +1,3 @@
+export interface TypeaheadProps<T = string> {
+  onChange: (value: T) => void
+}

--- a/app/public/src/pages/component/wiki/wiki-status.tsx
+++ b/app/public/src/pages/component/wiki/wiki-status.tsx
@@ -1,66 +1,7 @@
 import React from "react"
 import { Status } from "../../../../../types/enum/Status"
 import { addIconsToDescription } from "../../utils/descriptions"
-import TestStatusAnim from "../anim/TestStatusAnim"
 import { useTranslation } from "react-i18next"
-
-// export const PARAMS_ANIM_BY_STATUS: {
-//   [key in Status]: {
-//     animationKey: string
-//     offset?: [number, number]
-//     scale?: number
-//     depth?: number
-//   }
-// } = {
-//   [Status.BURN]: { animationKey: "burn", scale: 2, offset: [0, -30] },
-//   [Status.SILENCE]: { animationKey: "silence", scale: 2, offset: [0, -30] },
-//   [Status.POISON]: { animationKey: "poison", scale: 2, offset: [0, -30] },
-//   [Status.FREEZE]: { animationKey: "freeze", scale: 2, offset: [0, 0] },
-//   [Status.PROTECT]: { animationKey: "protect", scale: 2, offset: [0, -30] },
-//   [Status.SLEEP]: { animationKey: "sleep", scale: 2, offset: [0, -30] },
-//   [Status.CONFUSION]: { animationKey: "confusion", scale: 2, offset: [0, -30] },
-//   [Status.WOUND]: { animationKey: "wound", scale: 2, offset: [0, -30] },
-//   [Status.RESURECTION]: {
-//     animationKey: "resurection",
-//     scale: 2,
-//     offset: [0, -45]
-//   },
-//   [Status.PARALYSIS]: { animationKey: "paralysis", scale: 2, offset: [0, -20] },
-//   [Status.ARMOR_REDUCTION]: {
-//     animationKey: "armorReduction",
-//     scale: 2,
-//     offset: [0, -40]
-//   },
-//   [Status.RUNE_PROTECT]: {
-//     animationKey: "rune_protect",
-//     scale: 2,
-//     offset: [0, -45]
-//   },
-//   [Status.ELECTRIC_FIELD]: {
-//     animationKey: "ELECTRIC_SURGE",
-//     scale: 2,
-//     offset: [0, 10],
-//     depth: 0
-//   },
-//   [Status.PSYCHIC_FIELD]: {
-//     animationKey: "PSYCHIC_SURGE",
-//     scale: 2,
-//     offset: [0, 10],
-//     depth: 0
-//   },
-//   [Status.GRASS_FIELD]: {
-//     animationKey: "GRASSY_SURGE",
-//     scale: 2,
-//     offset: [0, 10],
-//     depth: 0
-//   },
-//   [Status.FAIRY_FIELD]: {
-//     animationKey: "MISTY_SURGE",
-//     scale: 1,
-//     offset: [0, 10],
-//     depth: 0
-//   }
-// }
 
 export default function WikiStatus() {
   const { t } = useTranslation()

--- a/app/public/src/pages/main-sidebar.tsx
+++ b/app/public/src/pages/main-sidebar.tsx
@@ -153,11 +153,15 @@ export function MainSidebar(props: MainSidebarProps) {
           (user?.role === Role.ADMIN ||
             user?.role === Role.MODERATOR ||
             user?.role === Role.BOT_MANAGER) && (
-            <NavLink
-              svg="bot"
-              onClick={() => navigate("/bot-admin")}
-            >
+            <NavLink svg="bot" onClick={() => navigate("/bot-admin")}>
               {t("bot_admin")}
+            </NavLink>
+          )}
+
+        {page !== "game" &&
+          (user?.role === Role.ADMIN || user?.role === Role.MODERATOR) && (
+            <NavLink svg="bot" onClick={() => navigate("/sprite-debug")}>
+              Debug sprite
             </NavLink>
           )}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "phaser3-rex-plugins": "^1.60.4",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
+        "react-bootstrap-typeahead": "^6.2.3",
         "react-circular-progressbar": "^2.1.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^13.1.2",
@@ -8267,6 +8268,11 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "peer": true
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -16014,6 +16020,29 @@
         }
       }
     },
+    "node_modules/react-bootstrap-typeahead": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-6.2.3.tgz",
+      "integrity": "sha512-Ge2au2WxR8CWsAH3GbKsaJpIEV2OMKum2Ov7/kuVMBlHNKwsJc2ULJIjk3yZMoTvvfOzOnYDScaWrQwzPc5c/A==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "@popperjs/core": "^2.10.2",
+        "@restart/hooks": "^0.4.0",
+        "classnames": "^2.2.0",
+        "fast-deep-equal": "^3.1.1",
+        "invariant": "^2.2.1",
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.5.8",
+        "react-overlays": "^5.2.0",
+        "react-popper": "^2.2.5",
+        "scroll-into-view-if-needed": "^2.2.20",
+        "warning": "^4.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-circular-progressbar": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.1.0.tgz",
@@ -16043,6 +16072,11 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-i18next": {
       "version": "13.1.2",
@@ -16246,6 +16280,39 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-pro-sidebar": {
@@ -16961,6 +17028,14 @@
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
+      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
+      "dependencies": {
+        "compute-scroll-into-view": "^1.0.20"
       }
     },
     "node_modules/semver": {
@@ -24929,6 +25004,11 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -30897,6 +30977,25 @@
         "warning": "^4.0.3"
       }
     },
+    "react-bootstrap-typeahead": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-6.2.3.tgz",
+      "integrity": "sha512-Ge2au2WxR8CWsAH3GbKsaJpIEV2OMKum2Ov7/kuVMBlHNKwsJc2ULJIjk3yZMoTvvfOzOnYDScaWrQwzPc5c/A==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "@popperjs/core": "^2.10.2",
+        "@restart/hooks": "^0.4.0",
+        "classnames": "^2.2.0",
+        "fast-deep-equal": "^3.1.1",
+        "invariant": "^2.2.1",
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.5.8",
+        "react-overlays": "^5.2.0",
+        "react-popper": "^2.2.5",
+        "scroll-into-view-if-needed": "^2.2.20",
+        "warning": "^4.0.1"
+      }
+    },
     "react-circular-progressbar": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.1.0.tgz",
@@ -30921,6 +31020,11 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-i18next": {
       "version": "13.1.2",
@@ -31081,6 +31185,30 @@
             "yargs-parser": "^21.1.1"
           }
         }
+      }
+    },
+    "react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "requires": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      }
+    },
+    "react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "requires": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
       }
     },
     "react-pro-sidebar": {
@@ -31586,6 +31714,14 @@
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "requires": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "scroll-into-view-if-needed": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
+      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
+      "requires": {
+        "compute-scroll-into-view": "^1.0.20"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "phaser3-rex-plugins": "^1.60.4",
     "react": "^18.2.0",
     "react-bootstrap": "^2.8.0",
+    "react-bootstrap-typeahead": "^6.2.3",
     "react-circular-progressbar": "^2.1.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^13.1.2",


### PR DESCRIPTION
creates admin/mod only sprite debug page

currently allows for picking from any pokemon and any status, only in forward facing position

also adds the package [react-bootstrap-typeahead](https://www.npmjs.com/package/react-bootstrap-typeahead)

future updates:
- increase scale
- change pokemon direction
- change shiny
- more???


https://github.com/keldaanCommunity/pokemonAutoChess/assets/25358150/3b6b2f0d-7a8d-480f-9ff6-78aa4b49d50b

