### PR TITLE
fix buying in collection + profile tweaks

### DIFF
--- a/app/models/colyseus-models/leaderboard-info.ts
+++ b/app/models/colyseus-models/leaderboard-info.ts
@@ -1,4 +1,5 @@
 export interface ILeaderboardInfo {
+  id: string;
   name: string
   avatar: string
   rank: number

--- a/app/public/src/pages/component/available-user-menu/current-users.tsx
+++ b/app/public/src/pages/component/available-user-menu/current-users.tsx
@@ -1,8 +1,7 @@
 import React from "react"
 import { ILobbyUser } from "../../../../../models/colyseus-models/lobby-user"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
-import { setTabIndex } from "../../../stores/LobbyStore"
-import { searchById, searchName } from "../../../stores/NetworkStore"
+import { searchById } from "../../../stores/NetworkStore"
 import Avatar from "../avatar"
 import "./current-users.css"
 import { useTranslation } from "react-i18next"
@@ -32,7 +31,6 @@ function User(props: { key: number; v: ILobbyUser }) {
       className="clickable"
       onClick={() => {
         dispatch(searchById(props.v.id))
-        dispatch(setTabIndex(4))
       }}
     >
       <Avatar

--- a/app/public/src/pages/component/chat/chat-message.tsx
+++ b/app/public/src/pages/component/chat/chat-message.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { removeMessage, searchById } from "../../../stores/NetworkStore"
-import { setTabIndex } from "../../../stores/LobbyStore"
 import { IChatV2, Role } from "../../../../../types"
 import { getAvatarSrc } from "../../../utils"
 
@@ -45,7 +44,6 @@ export default function ChatMessage(props: { message: IChatV2 }) {
         title={formatDate(props.message.time)}
         onClick={() => {
           dispatch(searchById(props.message.authorId))
-          dispatch(setTabIndex(4))
         }}
       >
         {props.message.author}

--- a/app/public/src/pages/component/collection/pokemon-emotion.tsx
+++ b/app/public/src/pages/component/collection/pokemon-emotion.tsx
@@ -1,7 +1,5 @@
 import React from "react"
 import { Emotion } from "../../../../../types"
-import { useAppDispatch } from "../../../hooks"
-import { buyEmotion, changeSelectedEmotion } from "../../../stores/NetworkStore"
 import { getPortraitSrc } from "../../../utils"
 import { getEmotionCost } from "../../../../../types/Config"
 import { cc } from "../../utils/jsx"
@@ -15,9 +13,9 @@ export default function PokemonEmotion(props: {
   path: string
   emotion: Emotion
   dust: number
+  onClick: () => void
 }) {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
   const cost = getEmotionCost(props.emotion, props.shiny)
   const canUnlock = !props.unlocked && cost <= props.dust
 
@@ -28,25 +26,7 @@ export default function PokemonEmotion(props: {
         unlockable: canUnlock,
         shimmer: canUnlock
       })}
-      onClick={() => {
-        if (props.unlocked) {
-          dispatch(
-            changeSelectedEmotion({
-              index: props.index,
-              emotion: props.emotion,
-              shiny: props.shiny
-            })
-          )
-        } else {
-          dispatch(
-            buyEmotion({
-              index: props.index,
-              emotion: props.emotion,
-              shiny: props.shiny
-            })
-          )
-        }
-      }}
+      onClick={props.onClick}
     >
       <img src={getPortraitSrc(props.index, props.shiny, props.emotion)} />
       {props.unlocked ? (

--- a/app/public/src/pages/component/debug/debug-scene.tsx
+++ b/app/public/src/pages/component/debug/debug-scene.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import Phaser from "phaser"
 import { DebugScene } from "../../../game/scenes/debug-scene"
 import { Pkm } from "../../../../../types/enum/Pokemon"
@@ -30,12 +30,14 @@ export default function DebugSceneContainer({
   const [loaded, setLoaded] = useState<boolean>(false)
 
   const [statusMessage, setStatusMessage] = useState<string>("")
+
   const onProgress = () =>
     setStatusMessage(debugScene?.current?.loadingManager?.statusMessage ?? "")
-  const onComplete = () => {
+
+  const onComplete = useCallback(() => {
     setLoaded(true)
     debugScene.current?.updateScene(pkm, orientation, animationType, status)
-  }
+  }, [animationType, orientation, pkm, status])
 
   useEffect(() => {
     if (!initialized.current) {
@@ -61,7 +63,7 @@ export default function DebugSceneContainer({
         }
       })
     }
-  }, [initialized])
+  }, [height, initialized, onComplete, width])
 
   useEffect(() => {
     if (initialized.current === true && loaded === true) {

--- a/app/public/src/pages/component/lobby-menu/leaderboard-item.tsx
+++ b/app/public/src/pages/component/lobby-menu/leaderboard-item.tsx
@@ -5,7 +5,7 @@ import {
 } from "../../../../../models/colyseus-models/leaderboard-info"
 import { useAppDispatch } from "../../../hooks"
 import { setTabIndex } from "../../../stores/LobbyStore"
-import { searchName } from "../../../stores/NetworkStore"
+import { searchById, searchName } from "../../../stores/NetworkStore"
 import Elo from "../elo"
 import { getAvatarSrc } from "../../../utils"
 import { useTranslation } from "react-i18next"
@@ -26,9 +26,8 @@ export default function LeaderboardItem(props: {
         alignItems: "center"
       }}
       onClick={() => {
-        if (!props.isBot) {
-          dispatch(searchName(props.item.name))
-          dispatch(setTabIndex(4))
+        if (!props.isBot && "id" in props.item) {
+          dispatch(searchById(props.item.id))
         }
       }}
     >

--- a/app/public/src/pages/component/main-sidebar.tsx
+++ b/app/public/src/pages/component/main-sidebar.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { Sidebar, Menu, MenuItem, MenuItemProps } from "react-pro-sidebar"
 import { useAppDispatch, useAppSelector } from "../../hooks"
 import { requestMeta, INetwork } from "../../stores/NetworkStore"
-import { IUserLobbyState } from "../../stores/LobbyStore"
+import { IUserLobbyState, setSearchedUser } from "../../stores/LobbyStore"
 import { Role, Title } from "../../../../types"
 import { cc } from "../utils/jsx"
 import Booster from "./booster/booster"
@@ -324,17 +324,20 @@ function Modals({
   setModal: (nextModal?: Modals) => void
   page: Page
 }) {
-  const {
-    meta,
-    metaItems,
-    metaPokemons
-  }: Partial<INetwork> & Partial<IUserLobbyState> = useAppSelector((state) => ({
-    meta: state.lobby.meta,
-    metaItems: state.lobby.metaItems,
-    metaPokemons: state.lobby.metaPokemons
-  }))
+  const meta = useAppSelector((state) => state.lobby.meta)
+  const metaItems = useAppSelector((state) => state.lobby.metaItems)
+  const metaPokemons = useAppSelector((state) => state.lobby.metaPokemons)
+  const searchedUser = useAppSelector((state) => state.lobby.searchedUser)
+
+  const dispatch = useAppDispatch()
 
   const closeModal = useCallback(() => setModal(undefined), [setModal])
+
+  useEffect(() => {
+    if (searchedUser && modal !== "profile") {
+      setModal("profile")
+    }
+  }, [modal, searchedUser, setModal])
 
   return (
     <>
@@ -344,7 +347,10 @@ function Modals({
         body={<News />}
       />
       <BasicModal
-        handleClose={closeModal}
+        handleClose={() => {
+          closeModal()
+          dispatch(setSearchedUser(undefined))
+        }}
         show={modal === "profile"}
         body={<Profile />}
       />

--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -26,9 +26,7 @@ import { IBot } from "../../../../../models/mongo-models/bot-v2"
 import { Role } from "../../../../../types"
 import { useTranslation } from "react-i18next"
 
-export default function PreparationMenu(props: {
-  setToGame: Dispatch<SetStateAction<boolean>>
-}) {
+export default function PreparationMenu() {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const [inputValue, setInputValue] = useState<string>("")

--- a/app/public/src/pages/component/profile/profile.css
+++ b/app/public/src/pages/component/profile/profile.css
@@ -24,6 +24,30 @@
 .profile .search-bar {
   grid-area: search;
   margin: 0.5em 0;
+
+  position: relative;
+}
+
+.profile .search-bar .my-input {
+  border-radius: 12px;
+}
+
+.profile .search-bar .clear-button {
+  position: absolute;
+  right: 0;
+  display: flex;
+  align-items: center;
+  border: none;
+  background: none;
+  width: 42px;
+  color: gray;
+  z-index: 3;
+}
+
+.profile .search-bar .clear-button:hover,
+.profile .search-bar .clear-button:focus {
+  box-shadow: none;
+  color: black;
 }
 
 .profile .profile-actions {
@@ -47,6 +71,9 @@
   overflow-y: auto;
   background-color: rgb(84, 89, 107);
   padding: 1em;
+  border-radius: 0 0 12px 12px;
+  border: 4px solid black;
+  border-top: 0;
 }
 
 .profile-actions .nes-container {

--- a/app/public/src/pages/component/profile/profile.tsx
+++ b/app/public/src/pages/component/profile/profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs"
 import PlayerBox from "./player-box"
@@ -25,47 +25,49 @@ import { setSearchedUser, setSuggestions } from "../../../stores/LobbyStore"
 export default function Profile() {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const user = useAppSelector(
-    (state) => state.lobby.searchedUser || state.lobby.user
-  )
-  const searchedUser = useAppSelector((state) => state.lobby.searchedUser)
+  const user = useAppSelector((state) => state.lobby.user)
   const suggestions = useAppSelector((state) => state.lobby.suggestions)
+  const searchedUser = useAppSelector((state) => state.lobby.searchedUser)
+
+  const profile = searchedUser ?? user
 
   function onSearchQueryChange(query: string) {
-    if(query ){
+    if (query) {
       dispatch(searchName(query))
     } else {
       resetSearch()
     }
   }
 
-  function resetSearch() {
+  const resetSearch = useCallback(() => {
     dispatch(setSearchedUser(undefined))
     dispatch(setSuggestions([]))
-  }
+  }, [dispatch])
 
-  return user ? (
+  return (
     <div className="nes-container profile">
       <div className="profile-box">
         <h1>{t("profile")}</h1>
-        {user && <PlayerBox user={user} />}
+        {profile && <PlayerBox user={profile} />}
       </div>
 
       <SearchBar onChange={onSearchQueryChange} />
 
       <div className="profile-actions">
-        {searchedUser ? (
+        <OtherProfileActions resetSearch={resetSearch} />
+
+        {searchedUser && searchedUser.id !== user?.id ? (
           <OtherProfileActions resetSearch={resetSearch} />
         ) : suggestions.length > 0 ? (
           <SearchResults />
         ) : (
-          <MyProfileMenu></MyProfileMenu>
+          <MyProfileMenu />
         )}
       </div>
 
-      <History history={user.history} />
+      {profile && <History history={profile.history} />}
     </div>
-  ) : null
+  )
 }
 
 function MyProfileMenu() {

--- a/app/public/src/pages/component/profile/profile.tsx
+++ b/app/public/src/pages/component/profile/profile.tsx
@@ -54,9 +54,7 @@ export default function Profile() {
       <SearchBar onChange={onSearchQueryChange} />
 
       <div className="profile-actions">
-        <OtherProfileActions resetSearch={resetSearch} />
-
-        {searchedUser && searchedUser.id !== user?.id ? (
+        {searchedUser ? (
           <OtherProfileActions resetSearch={resetSearch} />
         ) : suggestions.length > 0 ? (
           <SearchResults />

--- a/app/public/src/pages/component/profile/search-bar.tsx
+++ b/app/public/src/pages/component/profile/search-bar.tsx
@@ -1,13 +1,17 @@
 import React, { useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import Form from "react-bootstrap/Form"
+import InputGroup from "react-bootstrap/InputGroup"
+import Button from "react-bootstrap/Button"
+
 export function SearchBar({ onChange }) {
   const [searchQuery, setSearchQuery] = useState<string>("")
   const { t } = useTranslation()
 
   return (
-    <div className="search-bar nes-field is-inline">
-      <input
+    <InputGroup className="search-bar nes-field is-inline">
+      <Form.Control
         type="text"
         className="my-input"
         placeholder={t("search_player")}
@@ -17,6 +21,16 @@ export function SearchBar({ onChange }) {
           onChange(e.target.value)
         }}
       />
-    </div>
+      <Button
+        className="clear-button"
+        variant="tertiary"
+        onClick={() => {
+          setSearchQuery("")
+          onChange(undefined)
+        }}
+      >
+        X
+      </Button>
+    </InputGroup>
   )
 }

--- a/app/public/src/pages/preparation.tsx
+++ b/app/public/src/pages/preparation.tsx
@@ -240,7 +240,7 @@ export default function Preparation() {
         backgroundColor: "#000000"
       })
     }
-  }, [preloading])
+  }, [preloading, t])
 
   if (toGame) {
     return <Navigate to="/game" />
@@ -264,7 +264,7 @@ export default function Preparation() {
           }}
         />
         <main>
-          <PreparationMenu setToGame={setToGame} />
+          <PreparationMenu />
           <Chat source="preparation" />
         </main>
         <footer>

--- a/app/public/src/stores/LobbyStore.ts
+++ b/app/public/src/stores/LobbyStore.ts
@@ -23,6 +23,7 @@ import { IPokemonsStatistic } from "../../../models/mongo-models/pokemons-statis
 import { playSound, SOUNDS } from "../pages/utils/audio"
 import { Language } from "../../../types/enum/Language"
 import i18n from "../i18n"
+import PokemonCollection from "../../../models/colyseus-models/pokemon-collection"
 
 export interface IUserLobbyState {
   botLogDatabase: string[]
@@ -190,7 +191,7 @@ export const lobbySlice = createSlice({
       state.levelLeaderboard = action.payload
     },
     addPokemonConfig: (state, action: PayloadAction<IPokemonConfig>) => {
-      state.pokemonCollection.push(action.payload)
+      state.pokemonCollection = [...state.pokemonCollection, action.payload]
     },
     changePokemonConfig: (
       state,
@@ -199,9 +200,10 @@ export const lobbySlice = createSlice({
       const index = state.pokemonCollection.findIndex(
         (p) => p.id === action.payload.id
       )
+      const clonedCollection = [...state.pokemonCollection]
       if (index !== -1) {
-        state.pokemonCollection[index][action.payload.field] =
-          action.payload.value
+        clonedCollection[index][action.payload.field] = action.payload.value
+        state.pokemonCollection = clonedCollection
       }
     },
     addUser: (state, action: PayloadAction<LobbyUser>) => {

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -506,7 +506,8 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
           name: user.displayName,
           rank: i + 1,
           avatar: user.avatar,
-          value: user.elo
+          value: user.elo,
+          id: user.id
         })
       }
     }
@@ -524,7 +525,8 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
           name: user.displayName,
           rank: i + 1,
           avatar: user.avatar,
-          value: user.level
+          value: user.level,
+          id: user.id
         })
       }
     }


### PR DESCRIPTION
fixes a few bugs:
- clicking on a user in ELO or Online sections now opens their profile in modal
- no longer selects an invalid tab index (profile tab moved to modal)
- adds clear button to return to profile after a user search
- general collection optimizations
- clicking on a pokemon emotion in collection would not purchase correctly unless the modal was closed and reopened

https://github.com/keldaanCommunity/pokemonAutoChess/assets/25358150/9ae02a5c-7614-43a3-b6ef-0c397a4f2caa

