### PR TITLE
grab correct ID for leaderboard players

### DIFF
--- a/app/public/src/pages/component/lobby-menu/leaderboard-item.tsx
+++ b/app/public/src/pages/component/lobby-menu/leaderboard-item.tsx
@@ -4,8 +4,7 @@ import {
   ILeaderboardInfo
 } from "../../../../../models/colyseus-models/leaderboard-info"
 import { useAppDispatch } from "../../../hooks"
-import { setTabIndex } from "../../../stores/LobbyStore"
-import { searchById, searchName } from "../../../stores/NetworkStore"
+import { searchById } from "../../../stores/NetworkStore"
 import Elo from "../elo"
 import { getAvatarSrc } from "../../../utils"
 import { useTranslation } from "react-i18next"

--- a/app/public/src/pages/component/profile/profile.tsx
+++ b/app/public/src/pages/component/profile/profile.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react"
+import React, { useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs"
 import PlayerBox from "./player-box"

--- a/app/public/src/stores/LobbyStore.ts
+++ b/app/public/src/stores/LobbyStore.ts
@@ -22,8 +22,6 @@ import { Synergy } from "../../../types/enum/Synergy"
 import { IPokemonsStatistic } from "../../../models/mongo-models/pokemons-statistic"
 import { playSound, SOUNDS } from "../pages/utils/audio"
 import { Language } from "../../../types/enum/Language"
-import i18n from "../i18n"
-import PokemonCollection from "../../../models/colyseus-models/pokemon-collection"
 
 export interface IUserLobbyState {
   botLogDatabase: string[]

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -495,7 +495,7 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
   async fetchLeaderboards() {
     const users = await UserMetadata.find(
       {},
-      ["displayName", "avatar", "elo"],
+      ["displayName", "avatar", "elo", "uid"],
       { limit: 100, sort: { elo: -1 } }
     )
 
@@ -507,7 +507,7 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
           rank: i + 1,
           avatar: user.avatar,
           value: user.elo,
-          id: user.id
+          id: user.uid
         })
       }
     }

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -514,7 +514,7 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
 
     const levelUsers = await UserMetadata.find(
       {},
-      ["displayName", "avatar", "level"],
+      ["displayName", "avatar", "level", "uid"],
       { limit: 100, sort: { level: -1 } }
     )
 
@@ -526,7 +526,7 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
           rank: i + 1,
           avatar: user.avatar,
           value: user.level,
-          id: user.id
+          id: user.uid
         })
       }
     }


### PR DESCRIPTION
The ID I was using previously was actually the document ID and not the player ID which resulted in clicking leaderboard players doing nothing.

Also includes some import clean up that I missed the first time around