### PR TITLE
fix game player detail synergies not being accurate

### DIFF
--- a/app/public/src/pages/component/game/game-player-detail.tsx
+++ b/app/public/src/pages/component/game/game-player-detail.tsx
@@ -80,7 +80,7 @@ export default function GamePlayerDetail(props: {
         {synergyList.map((synergy, i) => {
           return (
             <div
-              key={`${synergy}${i}_game-player-detail`}
+              key={`${props.name}_${synergy}${i}_game-player-detail`}
               style={{
                 display: "flex",
                 justifyContent: "space-around",

--- a/app/public/src/pages/component/game/game-player.tsx
+++ b/app/public/src/pages/component/game/game-player.tsx
@@ -7,26 +7,9 @@ import { IPlayer } from "../../../../../types"
 import { useAppSelector } from "../../../hooks"
 import { getAvatarSrc } from "../../../utils"
 import { cc } from "../../utils/jsx"
-import Synergies from "../../../../../models/colyseus-models/synergies"
-import GameState from "../../../../../rooms/states/game-state"
 
 import "react-circular-progressbar/dist/styles.css"
 import "./game-player.css"
-
-function getSynergiesFromNetworkPlayer(
-  gameState: GameState | undefined,
-  player: IPlayer
-): Synergies {
-  if (!gameState) {
-    return player.synergies
-  }
-  const networkSynergies = gameState.players.get(player.id)?.synergies?.toJSON()
-  if (networkSynergies) {
-    return networkSynergies
-  } else {
-    return player.synergies
-  }
-}
 
 export default function GamePlayer(props: {
   player: IPlayer
@@ -36,14 +19,11 @@ export default function GamePlayer(props: {
   const spectatedPlayerId = useAppSelector(
     (state) => state.game.currentPlayerId
   )
-  const game = useAppSelector((state) => state.network.game)
   const selfPlayerId = useAppSelector((state) => state.network.uid)
 
   function playerClick() {
     props.click(props.player.id)
   }
-
-  const synergies = getSynergiesFromNetworkPlayer(game?.state, props.player)
 
   return (
     <div
@@ -75,7 +55,7 @@ export default function GamePlayer(props: {
           money={props.player.money}
           level={props.player.experienceManager.level}
           history={props.player.history}
-          synergies={synergies}
+          synergies={props.player.synergies}
         />
       </ReactTooltip>
     </div>

--- a/app/public/src/pages/component/game/game-player.tsx
+++ b/app/public/src/pages/component/game/game-player.tsx
@@ -7,9 +7,26 @@ import { IPlayer } from "../../../../../types"
 import { useAppSelector } from "../../../hooks"
 import { getAvatarSrc } from "../../../utils"
 import { cc } from "../../utils/jsx"
+import Synergies from "../../../../../models/colyseus-models/synergies"
+import GameState from "../../../../../rooms/states/game-state"
 
 import "react-circular-progressbar/dist/styles.css"
 import "./game-player.css"
+
+function getSynergiesFromNetworkPlayer(
+  gameState: GameState | undefined,
+  player: IPlayer
+): Synergies {
+  if (!gameState) {
+    return player.synergies
+  }
+  const networkSynergies = gameState.players.get(player.id)?.synergies?.toJSON()
+  if (networkSynergies) {
+    return networkSynergies
+  } else {
+    return player.synergies
+  }
+}
 
 export default function GamePlayer(props: {
   player: IPlayer
@@ -19,11 +36,14 @@ export default function GamePlayer(props: {
   const spectatedPlayerId = useAppSelector(
     (state) => state.game.currentPlayerId
   )
+  const game = useAppSelector((state) => state.network.game)
   const selfPlayerId = useAppSelector((state) => state.network.uid)
 
   function playerClick() {
     props.click(props.player.id)
   }
+
+  const synergies = getSynergiesFromNetworkPlayer(game?.state, props.player)
 
   return (
     <div
@@ -55,7 +75,7 @@ export default function GamePlayer(props: {
           money={props.player.money}
           level={props.player.experienceManager.level}
           history={props.player.history}
-          synergies={props.player.synergies}
+          synergies={synergies}
         />
       </ReactTooltip>
     </div>

--- a/app/public/src/stores/GameStore.ts
+++ b/app/public/src/stores/GameStore.ts
@@ -164,6 +164,15 @@ export const gameSlice = createSlice({
       if (state.currentPlayerId === action.payload.id) {
         state.currentPlayerSynergies = Array.from(action.payload.value)
       }
+
+      const playerToUpdate = state.players.findIndex(
+        (player) => player.id === action.payload.id
+      )
+
+      if (playerToUpdate !== -1) {
+        state.players.at(playerToUpdate)!.synergies =
+          action.payload.value.toJSON()
+      }
     },
     setOpponentId: (
       state,


### PR DESCRIPTION
I think there was a slight regression in the 1v1 update where this was removed.

Re-added this logic + updated key 

Let me know if you removed this intentionally, if so we should probably hide synergies in general here as they're not updated properly without this.

Saying that, this really updates after a round so it's still not real time, but as close to it as we can get for now without having to add in a bunch more logic for updating game state synergies.