### PR TITLE
Update destroyed tooltips + cleanup

### DIFF
--- a/app/public/src/game/components/draggable-object.ts
+++ b/app/public/src/game/components/draggable-object.ts
@@ -16,14 +16,16 @@ export default class DraggableObject extends GameObjects.Container {
     this.dragDisabled = dragDisabled
     this.setSize(width, height)
     this.setInteractive()
-      .on("pointerover", () => this.onPointerOver())
+      .on("pointerover", (pointer: Phaser.Input.Pointer) => {
+        this.onPointerOver(pointer)
+      })
       .on("pointerout", () => this.onPointerOut())
       .on(
         "pointerdown",
         (
           pointer: Phaser.Input.Pointer,
-          x: number,
-          y: number,
+          _x: number,
+          _y: number,
           event: Phaser.Types.Input.EventData
         ) => {
           event.stopPropagation()
@@ -38,12 +40,13 @@ export default class DraggableObject extends GameObjects.Container {
     return !this.dragDisabled
   }
 
-  set draggable(isDraggable: boolean){
+  set draggable(isDraggable: boolean) {
     this.dragDisabled = !isDraggable
     this.scene.input.setDraggable(this, isDraggable)
   }
 
-  onPointerOver() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onPointerOver(pointer) {
     if (!this.dragDisabled) {
       document.body.classList.add("grab")
     }
@@ -55,6 +58,7 @@ export default class DraggableObject extends GameObjects.Container {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onPointerDown(pointer) {
     if (!this.dragDisabled) {
       document.body.classList.add("grabbing")

--- a/app/public/src/game/components/item-container.ts
+++ b/app/public/src/game/components/item-container.ts
@@ -82,17 +82,23 @@ export default class ItemContainer extends DraggableObject {
     this.add(this.detail)
 
     this.setInteractive()
-    this.input.dropZone = true
+    this.updateDropZone(true)
     this.draggable = this.pokemonId === null && playerId === currentPlayerUid
   }
 
-  onPointerOver() {
-    super.onPointerOver()
+  updateDropZone(value: boolean) {
+    if (this.input) {
+      this.input.dropZone = value
+    }
+  }
+
+  onPointerOver(pointer) {
+    super.onPointerOver(pointer)
     if (getPreferences().showDetailsOnHover && !this.detail.visible) {
       clearTimeout(this.mouseoutTimeout)
       this.openDetail()
     }
-    this.input.dropZone = false
+    this.updateDropZone(false)
     if (this.draggable) {
       this.circle?.setFillStyle(0x68829e)
     }
@@ -101,7 +107,7 @@ export default class ItemContainer extends DraggableObject {
   onPointerOut() {
     super.onPointerOut()
     if (!this.dragDisabled) {
-      this.input.dropZone = true
+      this.updateDropZone(true)
     }
     if (this.draggable) {
       this.circle?.setFillStyle(0x61738a)
@@ -124,17 +130,17 @@ export default class ItemContainer extends DraggableObject {
     if (pointer.rightButtonDown() && !getPreferences().showDetailsOnHover) {
       if (!this.detail.visible) {
         this.openDetail()
-        this.input.dropZone = false
+        this.updateDropZone(false)
       } else {
         this.closeDetail()
-        this.input.dropZone = true
+        this.updateDropZone(true)
       }
     }
   }
 
   onPointerUp() {
     super.onPointerUp()
-    this.input.dropZone = false
+    this.updateDropZone(false)
   }
 
   openDetail() {
@@ -202,5 +208,10 @@ export default class ItemContainer extends DraggableObject {
     } else {
       this.countText.setText(value.toString())
     }
+  }
+
+  destroy(fromScene?: boolean | undefined): void {
+    super.destroy(fromScene)
+    this.closeDetail()
   }
 }

--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -183,7 +183,7 @@ export default class Pokemon extends DraggableObject {
     this.sprite.setScale(2, 2)
     this.sprite.on(
       Phaser.Animations.Events.ANIMATION_COMPLETE,
-      (animation, frame, gameObject, frameKey: string) => {
+      () => {
         const g = <GameScene>scene
         // go back to idle anim if no more animation in queue
         if (pokemon.action !== PokemonActionState.HURT) {
@@ -289,6 +289,11 @@ export default class Pokemon extends DraggableObject {
     }
   }
 
+  destroy(fromScene?: boolean | undefined): void {
+    super.destroy(fromScene)
+    this.closeDetail()
+  }
+
   closeDetail() {
     if (this.detail) {
       this.detail.dom.remove()
@@ -333,6 +338,8 @@ export default class Pokemon extends DraggableObject {
       this.detail.width / 2 + 40,
       -this.detail.height / 2 - 40
     )
+
+    this.detail.removeInteractive()
     this.add(this.detail)
     s.lastPokemonDetail = this
   }
@@ -370,13 +377,14 @@ export default class Pokemon extends DraggableObject {
     }
   }
 
-  onPointerOver() {
-    super.onPointerOver()
+  onPointerOver(pointer) {
+    super.onPointerOver(pointer)
 
     if (
       getPreferences().showDetailsOnHover &&
       this.shouldShowTooltip &&
-      this.detail == null
+      this.detail == null &&
+      !pointer.leftButtonDown() // we're dragging another pokemon
     ) {
       this.openDetail()
     }

--- a/app/public/src/pages/component/game/game-pokemon-detail.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-detail.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { Pokemon } from "../../../../../models/colyseus-models/pokemon"
 import { IPokemonConfig } from "../../../../../models/mongo-models/user-metadata"
 import { RarityColor } from "../../../../../types/Config"
@@ -17,14 +17,24 @@ export function GamePokemonDetail(props: {
   pokemonConfig?: IPokemonConfig
 }) {
   const { t } = useTranslation()
-  const pokemonStats = [
-    { stat: Stat.HP, value: props.pokemon.hp },
-    { stat: Stat.DEF, value: props.pokemon.def },
-    { stat: Stat.ATK, value: props.pokemon.atk },
-    { stat: Stat.PP, value: props.pokemon.maxPP },
-    { stat: Stat.SPE_DEF, value: props.pokemon.speDef },
-    { stat: Stat.RANGE, value: props.pokemon.range }
-  ]
+  const pokemonStats = useMemo(
+    () => [
+      { stat: Stat.HP, value: props.pokemon.hp },
+      { stat: Stat.DEF, value: props.pokemon.def },
+      { stat: Stat.ATK, value: props.pokemon.atk },
+      { stat: Stat.PP, value: props.pokemon.maxPP },
+      { stat: Stat.SPE_DEF, value: props.pokemon.speDef },
+      { stat: Stat.RANGE, value: props.pokemon.range }
+    ],
+    [
+      props.pokemon.atk,
+      props.pokemon.def,
+      props.pokemon.hp,
+      props.pokemon.maxPP,
+      props.pokemon.range,
+      props.pokemon.speDef
+    ]
+  )
 
   return (
     <div className="game-pokemon-detail in-shop">
@@ -48,8 +58,8 @@ export function GamePokemonDetail(props: {
           {t(`rarity.${props.pokemon.rarity}`)}
         </p>
         <p className="game-pokemon-detail-entry-tier">
-          {Array.from({ length: props.pokemon.stars }, () => (
-            <img src="assets/ui/star.svg" height="16"></img>
+          {Array.from({ length: props.pokemon.stars }, (_, index) => (
+            <img key={index} src="assets/ui/star.svg" height="16"></img>
           ))}
         </p>
       </div>

--- a/app/public/src/pages/component/main-sidebar.tsx
+++ b/app/public/src/pages/component/main-sidebar.tsx
@@ -136,7 +136,8 @@ export function MainSidebar(props: MainSidebarProps) {
           </NavLink>
         )}
 
-        {page !== "game" && (
+        {/** TODO Enable these once we populate preparation room pokemonCollection */}
+        {page === "main_lobby" && (
           <NavLink
             location="collection"
             svg="collection"
@@ -146,7 +147,7 @@ export function MainSidebar(props: MainSidebarProps) {
             {t("collection")}
           </NavLink>
         )}
-        {page !== "game" && (
+        {page === "main_lobby" && (
           <NavLink
             location="booster"
             svg="booster"

--- a/app/public/src/pages/utils/descriptions.tsx
+++ b/app/public/src/pages/utils/descriptions.tsx
@@ -27,10 +27,6 @@ export const iconRegExp = new RegExp(
   "g"
 )
 
-const oldRegEx =
-  /(?<=\W|^)(?:PHYSICAL|SPECIAL|TRUE|ATK|ATK_SPEED|CRIT_CHANCE|CRIT_DAMAGE|DEF|HP|PP|RANGE|SHIELD|SPE_DEF|AP|BURN|SILENCE|POISON|FREEZE|PROTECT|SLEEP|CONFUSION|WOUND|RESURECTION|PARALYSIS|ARMOR_REDUCTION|GRASS_FIELD|FAIRY_FIELD|RUNE_PROTECT|ELECTRIC_FIELD|PSYCHIC_FIELD|SUN|RAIN|WINDY|SNOW|SANDSTORM|MISTY|STORM|NEUTRAL|NIGHT|NORMAL|GRASS|FIRE|WATER|ELECTRIC|FIGHTING|PSYCHIC|DARK|STEEL|GROUND|POISON|DRAGON|FIELD|MONSTER|HUMAN|AQUATIC|BUG|FLYING|FLORA|ROCK|GHOST|FAIRY|ICE|FOSSIL|SOUND|ARTIFICIAL|BABY|\[[^\]]+\])(?=\W|$)/g
-console.log({ iconRegExp, oldRegEx })
-
 export function addIconsToDescription(description: string, tier = 0, ap = 0) {
   const matchIcon = description.match(iconRegExp)
   if (matchIcon === null) return description
@@ -143,9 +139,9 @@ export function addIconsToDescription(description: string, tier = 0, ap = 0) {
     }
 
     return (
-      <>
+      <span key={i}>
         {d} {f}
-      </>
+      </span>
     )
   })
 }

--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -3,13 +3,11 @@ import { Client, logger, RoomListingData } from "colyseus"
 import { ArraySchema } from "@colyseus/schema"
 import { EmbedBuilder } from "discord.js"
 import { nanoid } from "nanoid"
-import { CallbackError, FilterQuery } from "mongoose"
 import { GameRecord } from "../../models/colyseus-models/game-record"
 import LobbyUser from "../../models/colyseus-models/lobby-user"
 import BannedUser from "../../models/mongo-models/banned-user"
 import { BotV2, IBot } from "../../models/mongo-models/bot-v2"
 import UserMetadata, {
-  IUserMetadata,
   IPokemonConfig
 } from "../../models/mongo-models/user-metadata"
 import DetailledStatistic from "../../models/mongo-models/detailled-statistic-v2"

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -7,7 +7,7 @@ import {
 } from "colyseus"
 import { Dispatcher } from "@colyseus/command"
 import LobbyState from "./states/lobby-state"
-import { connect, createConnection } from "mongoose"
+import { connect } from "mongoose"
 import BannedUser from "../models/mongo-models/banned-user"
 import ChatV2 from "../models/mongo-models/chat-v2"
 import UserMetadata from "../models/mongo-models/user-metadata"


### PR DESCRIPTION
- added `closeDetail` calls to destroy methods of pokemon and item-containers (should help with ghost item details when switching views)
- prevent detail open when dragging a pokemon/item
- add keys to maps to get rid of warning
- removed/cleaned up function inputs/imports (or included eslint disable for the warnings)
- hide boosters/collection in preparation room (modals are populated off of lobby details, so doesn't work, need to repopulate)
