### PR TITLE
Fix game record alt shiny avatars

### DIFF
--- a/app/models/colyseus-models/game-record.ts
+++ b/app/models/colyseus-models/game-record.ts
@@ -12,7 +12,7 @@ export class PokemonRecord extends Schema implements IPokemonRecord {
   @type("string") avatar: string
   @type(["string"]) items = new ArraySchema<Item>()
 
-  constructor(mongoPokemon: any) {
+  constructor(mongoPokemon: IPokemonRecord) {
     super()
     this.name = mongoPokemon.name
     this.avatar = mongoPokemon.avatar

--- a/app/public/src/utils.ts
+++ b/app/public/src/utils.ts
@@ -18,7 +18,7 @@ export function getAvatarString(
   shiny?: boolean,
   emotion?: Emotion
 ): string {
-  const defaultIndex = index ? index : PkmIndex[Pkm.MAGIKARP]
+  const defaultIndex = index ?? PkmIndex[Pkm.MAGIKARP]
   const shinyPad = shiny
     ? defaultIndex.length === 4
       ? "/0000/0001"

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -42,7 +42,7 @@ import {
   IPokemon,
   Transfer
 } from "../types"
-import { Pkm, PkmFamily, PkmIndex } from "../types/enum/Pokemon"
+import { Pkm, PkmFamily } from "../types/enum/Pokemon"
 import { Synergy } from "../types/enum/Synergy"
 import { Pokemon } from "../models/colyseus-models/pokemon"
 import { IGameUser } from "../models/colyseus-models/game-user"
@@ -51,14 +51,14 @@ import { components } from "../api-v1/openapi"
 import { Title, Role } from "../types"
 import PRECOMPUTED_TYPE_POKEMONS from "../models/precomputed/type-pokemons.json"
 import BannedUser from "../models/mongo-models/banned-user"
-import { coinflip, pickRandomIn, shuffleArray } from "../utils/random"
+import { coinflip, shuffleArray } from "../utils/random"
 import { Rarity } from "../types/enum/Game"
 import { Weather } from "../types/enum/Weather"
-import { FilterQuery } from "mongoose"
 import { MiniGame } from "../core/matter/mini-game"
 import { logger } from "../utils/logger"
 import { computeElo } from "../core/elo"
 import { Passive } from "../types/enum/Passive"
+import { getAvatarString } from "../public/src/utils"
 
 export default class GameRoom extends Room<GameState> {
   dispatcher: Dispatcher<this>
@@ -648,8 +648,7 @@ export default class GameRoom extends Room<GameState> {
 
     player.board.forEach((pokemon: IPokemon) => {
       if (pokemon.positionY != 0) {
-        const shinyPad = pokemon.shiny ? "/0000/0001" : ""
-        const avatar = `${pokemon.index}${shinyPad}/${pokemon.emotion}`
+        const avatar = getAvatarString(pokemon.index, pokemon.shiny, pokemon.emotion)
         const s: IGameHistoryPokemonRecord = {
           name: pokemon.name,
           avatar: avatar,


### PR DESCRIPTION
![image](https://github.com/keldaanCommunity/pokemonAutoChess/assets/566536/c41ad1a9-b273-4f27-bfd0-3f760139d10d)

fix missing avatars when alt shiny (supposed to be Alolan Golem here)

Note that it doesn't fix existing records in the database, we have to do a migration scirpt if we want to fix previous records