### PR TITLE
redesign chat messages

### DIFF
--- a/app/public/src/pages/component/chat/chat-message.tsx
+++ b/app/public/src/pages/component/chat/chat-message.tsx
@@ -3,62 +3,57 @@ import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { removeMessage, searchById } from "../../../stores/NetworkStore"
 import { IChatV2, Role } from "../../../../../types"
 import { getAvatarSrc } from "../../../utils"
+import { cc } from "../../utils/jsx"
 
 export default function ChatMessage(props: { message: IChatV2 }) {
   const dispatch = useAppDispatch()
-  const role = useAppSelector((state) => state.lobby.user?.role)
-
-  const removeButton =
-    role && (role === Role.MODERATOR || role === Role.ADMIN) ? (
-      <button
-        className="bubbly red"
-        onClick={() => {
-          dispatch(
-            removeMessage({
-              id: props.message.id
-            })
-          )
-        }}
-      >
-        <p style={{ fontSize: "0.5em", margin: "0px" }}>X</p>
-      </button>
-    ) : null
+  const lobbyUser = useAppSelector((state) => state.lobby.user)
+  const preparationUser = useAppSelector((state) => state.preparation.user)
+  const user = lobbyUser ?? preparationUser
+  const role = user?.role
+  const time = formatDate(props.message.time)
 
   return (
-    <div
-      className="chat"
-      style={{
-        display: "flex",
-        flexFlow: "row nowrap",
-        alignItems: "top",
-        justifyContent: "start"
-      }}
-    >
-      <img
-        src={getAvatarSrc(props.message.avatar)}
-        style={{ alignSelf: "start" }}
-        className="pokemon-portrait"
-      />
-      <span
-        className="chat-message-author"
-        title={formatDate(props.message.time)}
-        onClick={() => {
-          dispatch(searchById(props.message.authorId))
-        }}
-      >
-        {props.message.author}
-      </span>
-      <p
-        style={{
-          fontSize: "1vw",
-          wordBreak: "break-word",
-          flex: "1",
-          margin: "0"
-        }}
-      >
-        {props.message.payload}
-      </p>
-      {removeButton}
+    <div className="chat">
+      <div className="chat-message-container">
+        {props.message.author && (
+          <div
+            className={cc("chat-user", {
+              sameUser: props.message.authorId === user?.id
+            })}
+          >
+            <img
+              src={getAvatarSrc(props.message.avatar)}
+              className="pokemon-portrait"
+            />
+            <div
+              className="author-and-time"
+              title="open profile"
+              onClick={() => dispatch(searchById(props.message.authorId))}
+            >
+              <span className="chat-message-author">
+                {props.message.author}
+              </span>
+              <span className="chat-message-time">{time}</span>
+            </div>
+            {role && (role === Role.MODERATOR || role === Role.ADMIN) && (
+              <button
+                className="remove-chat bubbly red"
+                onClick={() =>
+                  dispatch(
+                    removeMessage({
+                      id: props.message.id
+                    })
+                  )
+                }
+              >
+                <p style={{ fontSize: "0.5em", margin: "0px" }}>X</p>
+              </button>
+            )}
+          </div>
+        )}
+        <p className="chat-message">{props.message.payload}</p>
+      </div>
     </div>
   )
 }

--- a/app/public/src/pages/component/chat/chat.css
+++ b/app/public/src/pages/component/chat/chat.css
@@ -40,17 +40,71 @@
   align-self: start;
 }
 
-.chat-message-author {
-  font-size: 1vw;
-  display: inline-block;
-  margin: 0 0.5em;
-  color: rgb(255, 193, 7);
-  max-width: 10ch;
-  word-break: break-word;
+
+.chat-message-author span {
+  line-height: 1.2em;
 }
 
-.chat span,
-.chat p {
-  padding: 0.25em 0 0 0;
+.chat {
+  display: flex;
+  gap: 8px;
+  margin: 0.25em 0;
+  border-radius: 8px;
+  font-size: 1.25rem;
+  border: solid;
+  border-color: black;
+  background: rgba(97, 115, 138, 0.815);
+  color: white;
+  cursor: var(--cursor-hover);
+}
+
+.pokemon-portrait {
+  align-self: start;
+}
+
+.chat-message-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-user {
+  display: flex;
+  gap: 8px;
+  padding: 6px;
+  background-color: #54596b;
+  border-bottom: 2px solid black;
+  border-radius: 4px;
+}
+
+.chat-message {
+  font-size: 1rem;
   line-height: 1.2em;
+  word-break: break-word;
+  padding: 6px;
+}
+
+.author-and-time {
+  font-size: 1rem;
+  width: 100%;
+  word-break: break-word;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.chat-message-author {
+  color: #ffc107;
+}
+
+.chat-message-time {
+  font-size: 0.75rem;
+}
+
+.remove-chat {
+  align-self: center;
+}
+
+.sameUser {
+  background-color: rgba(17, 148, 236, 0.604);
 }

--- a/app/public/src/styles.css
+++ b/app/public/src/styles.css
@@ -507,22 +507,6 @@ p:last-child {
   background-color: #4f5160;
 }
 
-.chat {
-  display: block;
-  padding: 0;
-  margin: 0.25em 0;
-  border-radius: 8px;
-  font-size: 1.25rem;
-  border: solid;
-  border-color: black;
-  background: #61738a;
-  color: white;
-  cursor: var(--cursor-hover);
-}
-.chat:nth-child(odd) {
-  background-color: #54596b;
-}
-
 .player-box {
   background: #54596b;
   border-radius: 12px;


### PR DESCRIPTION
- rearranged items in chat bubbles for a cleaner look
- name time visible and changed title to "open profile"
- if the message comes from the current player, we update the chat header to a light blue
  - honestly not sold on the blue coloring (it's same as buttons and highlights) I originally tried a light gold and really liked it (sort of a reverse coloring with the name) but it might pop a little too much
- removed icons from system messages

lobby:
![image](https://github.com/keldaanCommunity/pokemonAutoChess/assets/25358150/90bb2ff3-91b0-44b4-9138-bd346f4fabc8)


preparation room:
![image](https://github.com/keldaanCommunity/pokemonAutoChess/assets/25358150/64dcb9ef-02a1-46d0-83fb-99ac06dea822)
