### PR TITLE
redesign online avatars

### DIFF
--- a/app/public/src/pages/component/avatar.css
+++ b/app/public/src/pages/component/avatar.css
@@ -1,0 +1,47 @@
+.avatar.player-box {
+    display: flex;
+    align-items: center;
+    padding: 0;
+    gap: 12px;
+    overflow: hidden;
+}
+
+.player-portrait {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+}
+
+.avatar .pokemon-portrait {
+    width: 55px;
+    height: 55px;
+    border-radius: 10px 0 0 10px;
+}
+
+.player-name {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: 1rem;
+}
+
+.player-title-role {
+    display: flex;
+    align-content: center;
+    align-items: center;
+    gap: 4px;
+}
+
+.player-title-role .player-title {
+    margin: 0;
+}
+
+.avatar .elo {
+    margin-right: 8px;
+}
+
+.avatar .elo img {
+    height: 45px;
+    width: 45px;
+}

--- a/app/public/src/pages/component/avatar.tsx
+++ b/app/public/src/pages/component/avatar.tsx
@@ -5,61 +5,30 @@ import { RoleBadge } from "./RoleBadge"
 import { getAvatarSrc } from "../../utils"
 import { useTranslation } from "react-i18next"
 
+import "./avatar.css"
+
 export default function Avatar(props: {
-  elo: number | undefined
   name: string
   avatar: string
-  title: string
-  role: Role
+  elo?: number
+  title?: string
+  role?: Role
 }) {
   const { t } = useTranslation()
-  const elo = props.elo ? <Elo elo={props.elo} /> : null
 
   return (
-    <div
-      className="player-box"
-      style={{
-        display: "flex",
-        justifyContent: "space-around",
-        alignItems: "center",
-        flexFlow: "column"
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          gap: "5px",
-          justifyContent: "space-between",
-          alignItems: "center",
-          maxWidth: "100%"
-        }}
-      >
-        <img
-          style={{ width: "40px", height: "40px" }}
-          className="pokemon-portrait"
-          src={getAvatarSrc(props.avatar)}
-        />
-
-        <span
-          style={{
-            overflow: "hidden",
-            whiteSpace: "nowrap",
-            textOverflow: "ellipsis",
-            padding: "0 0.5em"
-          }}
-        >
-          {props.name}
+    <div className="avatar player-box">
+      <img className="pokemon-portrait" src={getAvatarSrc(props.avatar)} />
+      <div className="player-portrait">
+        <span className="player-title-role">
+          {props.title && (
+            <p className="player-title">{t(`title.${props.title}`)}</p>
+          )}
+          {props.role && <RoleBadge role={props.role} />}
         </span>
-        <RoleBadge role={props.role} />
+        <span className="player-name">{props.name}</span>
       </div>
-      <div style={{ display: "flex", gap: "5px", alignItems: "center" }}>
-        {props.title && (
-          <p className="player-title" style={{ margin: "0px" }}>
-            {t(`title.${props.title}`)}
-          </p>
-        )}
-        {elo}
-      </div>
+      {props.elo && <Elo elo={props.elo} />}
     </div>
   )
 }

--- a/app/public/src/pages/component/chat/chat.tsx
+++ b/app/public/src/pages/component/chat/chat.tsx
@@ -30,7 +30,6 @@ export default function Chat(props: { source: string }) {
             user?.anonymous ? t("chat_disabled_anonymous") : t("type_here")
           }
           disabled={user?.anonymous}
-          id="name_field"
           type="text"
           title={
             user?.anonymous ? t("chat_disabled_anonymous") : t("type_here")

--- a/app/public/src/pages/lobby.css
+++ b/app/public/src/pages/lobby.css
@@ -63,7 +63,8 @@
 }
 
 .lobby .current-users-menu ul {
-  display: unset;
+  display: flex;
+  flex-direction: column;
 }
 
 .lobby .user-chat {


### PR DESCRIPTION
![image](https://github.com/keldaanCommunity/pokemonAutoChess/assets/25358150/5a3e4d0b-b484-49c7-944a-629477ba1b9b)

wanted to blow up the user avatar image a bit and squish the height of the overall container to fit more players into the online column

could extend these in the future for other areas where we show users