### PR TITLE
separate chat by date + update time display

### DIFF
--- a/app/public/src/pages/component/chat/chat-history.tsx
+++ b/app/public/src/pages/component/chat/chat-history.tsx
@@ -1,9 +1,12 @@
-import React, { useEffect, useRef } from "react"
+import React, { useEffect, useMemo, useRef } from "react"
 import { useAppSelector } from "../../../hooks"
 import ChatMessage from "./chat-message"
+import { IChatV2 } from "../../../../../types"
 
 export default function ChatHistory(props: { source: string }) {
-  const messages = useAppSelector((state) => state[props.source].messages)
+  const messages: IChatV2[] = useAppSelector(
+    (state) => state[props.source].messages
+  )
   const domRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -12,10 +15,29 @@ export default function ChatHistory(props: { source: string }) {
     }
   })
 
+  const dateSeparatedChat: Record<string, IChatV2[]> = useMemo(() => {
+    return messages.reduce((allMessages, message) => {
+      const date = new Date(message.time)
+      const key = date.toDateString()
+
+      return {
+        ...allMessages,
+        [key]: [...(allMessages[key] ?? []), message]
+      }
+    }, {})
+  }, [messages])
+
   return (
     <div className="chat-history" ref={domRef}>
-      {messages.map((message, index) => {
-        return <ChatMessage key={index} message={message} />
+      {Object.entries(dateSeparatedChat).map(([date, chatMessages]) => {
+        return (
+          <>
+            <div className="date">{date}</div>
+            {chatMessages.map((message, index) => {
+              return <ChatMessage key={index} message={message} />
+            })}
+          </>
+        )
       })}
     </div>
   )

--- a/app/public/src/pages/component/chat/chat-message.tsx
+++ b/app/public/src/pages/component/chat/chat-message.tsx
@@ -11,7 +11,9 @@ export default function ChatMessage(props: { message: IChatV2 }) {
   const preparationUser = useAppSelector((state) => state.preparation.user)
   const user = lobbyUser ?? preparationUser
   const role = user?.role
-  const time = formatDate(props.message.time)
+  const time = new Date(props.message.time).toLocaleTimeString(undefined, {
+    timeStyle: "short"
+  })
 
   return (
     <div className="chat">
@@ -55,25 +57,5 @@ export default function ChatMessage(props: { message: IChatV2 }) {
         <p className="chat-message">{props.message.payload}</p>
       </div>
     </div>
-  )
-}
-
-function pad(number: number) {
-  if (number < 10) {
-    return "0" + number
-  }
-  return number
-}
-
-function formatDate(n: number) {
-  const date = new Date(n)
-  return (
-    pad(date.getMonth() + 1) +
-    "/" +
-    pad(date.getDate()) +
-    " " +
-    pad(date.getHours()) +
-    ":" +
-    pad(date.getMinutes())
   )
 }

--- a/app/public/src/pages/component/chat/chat.css
+++ b/app/public/src/pages/component/chat/chat.css
@@ -35,6 +35,12 @@
   overflow-y: auto;
 }
 
+.chat-history .date {
+  color: white;
+  width: 100%;
+  text-align: center;
+}
+
 .chat button {
   padding: 0.25em;
   align-self: start;

--- a/app/public/src/pages/component/chat/chat.tsx
+++ b/app/public/src/pages/component/chat/chat.tsx
@@ -5,12 +5,13 @@ import ChatHistory from "./chat-history"
 import "./chat.css"
 import { useTranslation } from "react-i18next"
 
+const MAX_MESSAGE_LENGTH = 250
+
 export default function Chat(props: { source: string }) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const [currentText, setCurrentText] = useState<string>("")
   const user = useAppSelector((state) => state[props.source].user)
-  const MAX_MESSAGE_LENGTH = 250
 
   return (
     <div className="nes-container user-chat">


### PR DESCRIPTION
![image](https://github.com/keldaanCommunity/pokemonAutoChess/assets/25358150/ec8e61a4-7985-4f78-aecb-59d90b082bca)

![image](https://github.com/keldaanCommunity/pokemonAutoChess/assets/25358150/ad89691a-0b86-4dd0-bb2d-bb96867e6da5)

separates chat into sections by day and change chat timestamps to use local time