### PR TITLE
update pokemon tooltip position off of mouse when hovering

### DIFF
--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -275,6 +275,14 @@ export default class Pokemon extends DraggableObject {
 
   updateTooltipPosition() {
     if (this.detail) {
+      if (this.input && getPreferences().showDetailsOnHover) {
+        this.detail.setPosition(
+          this.input.localX + 200,
+          this.input.localY - 175
+        )
+        return;
+      }
+
       const absX = this.x + this.detail.width / 2 + 40
       const minX = this.detail.width / 2
       const maxX = window.innerWidth - this.detail.width / 2


### PR DESCRIPTION
should help remedy issues where moving mouse over the pokemon detail window prevents it from closing

https://github.com/keldaanCommunity/pokemonAutoChess/assets/25358150/bd0f327d-7aa0-4870-a5a7-23bbe3eca751

