### PR TITLE
Smaller sidebar

### DIFF
--- a/app/public/src/pages/component/game/game-shop.tsx
+++ b/app/public/src/pages/component/game/game-shop.tsx
@@ -40,7 +40,7 @@ export default function GameShop() {
         closeOnClick
         limit={1}
         closeButton={false}
-        style={{ left: `calc(80px + 17.5vw)`, bottom: `9vw` }}
+        style={{ left: `calc(var(--sidebar-width) + 17.5vw)`, bottom: `9vw` }}
       />
       <ToastContainer
         className="toast"
@@ -53,7 +53,7 @@ export default function GameShop() {
         closeOnClick
         limit={1}
         closeButton={false}
-        style={{ left: `calc(80px + 11.5vw)`, bottom: `9vw` }}
+        style={{ left: `calc(var(--sidebar-width) + 11.5vw)`, bottom: `9vw` }}
       />
     </>
   )

--- a/app/public/src/pages/component/main-sidebar.css
+++ b/app/public/src/pages/component/main-sidebar.css
@@ -13,7 +13,7 @@ aside.sidebar {
 
 .sidebar-logo img {
   width: 54px;
-  margin: 8px 0px 8px 12px;
+  margin: 8px 0px 8px 4px;
 }
 
 .sidebar .sidebar-logo > div {
@@ -31,6 +31,11 @@ aside.sidebar {
   display: block;
   font-size: 1rem;
   opacity: 0.75;
+}
+
+#root .sidebar.ps-collapsed {
+  width: 60px;
+  min-width: 60px;
 }
 
 .sidebar.ps-collapsed .sidebar-logo div {
@@ -69,6 +74,10 @@ aside.sidebar {
 
 .ps-menu-label {
   color: white;
+}
+
+#root .ps-menu-button {
+  padding-left: 10px;
 }
 
 .ps-menu-button .icon {

--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -148,7 +148,7 @@ export default function PreparationMenu() {
         ) : users.length > 1 ? (
           <p>{t("not_elligible_elo_hint")}</p>
         ) : (
-          <p>A{t("add_bot_or_wait_hint")}</p>
+          <p>{t("add_bot_or_wait_hint")}</p>
         )}
       </div>
 

--- a/app/public/src/pages/lobby.css
+++ b/app/public/src/pages/lobby.css
@@ -1,6 +1,4 @@
 .lobby {
-  --sidebar-offset: 90px;
-
   height: 100%;
   gap: 1vw;
   display: flex;
@@ -8,7 +6,7 @@
 
 .lobby-container {
   padding: 10px;
-  padding-left: calc(var(--sidebar-offset));
+  padding-left: calc(var(--sidebar-width) + 10px);
   width: 100%;
 }
 

--- a/app/public/src/pages/sprite-debug.css
+++ b/app/public/src/pages/sprite-debug.css
@@ -1,8 +1,6 @@
 .sprite-debug-root {
   width: 100%;
   height: 100%;
-
-  --sidebar-offset: 90px;
 }
 
 /* TODO Remove this after the absolute sidebar update goes in */
@@ -19,7 +17,7 @@
   gap: 16px;
 
   padding: 40px;
-  padding-left: calc(var(--sidebar-offset));
+  padding-left: calc(var(--sidebar-width) + 10px);
 }
 
 .sprite-debug-toolbar {

--- a/app/public/src/styles.css
+++ b/app/public/src/styles.css
@@ -7,6 +7,8 @@
   --cursor-hover: url("assets/ui/cursor-hover.png") 14 0, pointer;
   --cursor-grab: url("assets/ui/cursor-grab.png") 14 8, grab;
   --cursor-grabbing: url("assets/ui/cursor-grabbing.png") 14 8, grabbing;
+
+  --sidebar-width: 60px;
 }
 
 body.grab {
@@ -220,19 +222,19 @@ p:last-child {
 
 #game {
   height: 100vh;
-  width: calc(100vw - 80px);
+  width: calc(100vw - var(--sidebar-width));
 }
 
 #game-wrapper {
   position: relative;
-  left: 80px;
-  width: calc(100vw - 80px);
+  left: 60px;
+  width: calc(100vw - var(--sidebar-width));
 }
 
 #game-wrapper .ps-sidebar-root {
   position: absolute;
   top: 0;
-  left: -80px;
+  left: calc(-1 * var(--sidebar-width));
   bottom: 0;
 }
 


### PR DESCRIPTION
Change sidebar width from 80px to 60px

Apparently, many players are playing on small resolutions and 80px is quite big on their screen:

https://media.discordapp.net/attachments/1145018234630848573/1145018234903482418/image.png

We can easily reduce it to 60px which should be less intrusive for low reoslutions;

![chrome_N8fhTVJ6lM](https://github.com/keldaanCommunity/pokemonAutoChess/assets/566536/e32df6b9-0e9e-44d0-be48-4195a6969b02)

I also made the width configurable with a CSS variable so eventually we can change it on higher resolutions. Not sure if needed though
