### PR TITLE
Fix preparation leave/join bugs

### DIFF
--- a/app/public/src/pages/preparation.tsx
+++ b/app/public/src/pages/preparation.tsx
@@ -1,13 +1,18 @@
 import React, { useEffect, useRef, useState } from "react"
 import Chat from "./component/chat/chat"
 import PreparationMenu from "./component/preparation/preparation-menu"
-import { Link, Navigate } from "react-router-dom"
+import { Navigate } from "react-router-dom"
 import firebase from "firebase/compat/app"
 import { FIREBASE_CONFIG } from "./utils/utils"
 import PreparationState from "../../../rooms/states/preparation-state"
 import { useAppDispatch, useAppSelector } from "../hooks"
 import { Client, Room } from "colyseus.js"
-import { gameStart, joinPreparation, logIn, setProfile } from "../stores/NetworkStore"
+import {
+  gameStart,
+  joinPreparation,
+  logIn,
+  setProfile
+} from "../stores/NetworkStore"
 import {
   addUser,
   changeUser,
@@ -165,6 +170,7 @@ export default function Preparation() {
 
       r.onMessage(Transfer.KICK, async () => {
         await r.leave(false)
+        localStore.delete(LocalStoreKeys.RECONNECTION_TOKEN)
         dispatch(leavePreparation())
         setToLobby(true)
         playSound(SOUNDS.LEAVE_ROOM)
@@ -267,6 +273,7 @@ export default function Preparation() {
           leaveLabel={t("leave_room")}
           leave={async () => {
             await room?.leave(true)
+            localStore.delete(LocalStoreKeys.RECONNECTION_TOKEN)
             dispatch(leavePreparation())
             setToLobby(true)
             playSound(SOUNDS.LEAVE_ROOM)

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -30,6 +30,7 @@ import UserMetadata from "../models/mongo-models/user-metadata"
 import { logger } from "../utils/logger"
 import { cleanProfanity } from "../utils/profanity-filter"
 import { MAX_PLAYERS_PER_LOBBY } from "../types/Config"
+import { values } from "../utils/schemas"
 
 export default class PreparationRoom extends Room<PreparationState> {
   dispatcher: Dispatcher<this>
@@ -228,12 +229,7 @@ export default class PreparationRoom extends Room<PreparationState> {
       client.send(Transfer.USER_PROFILE, userProfile)
 
       const isAlreadyInRoom = this.state.users.has(user.uid)
-      let numberOfHumanPlayers = 0
-      this.state.users.forEach((u) => {
-        if (!u.isBot) {
-          numberOfHumanPlayers++
-        }
-      })
+      let numberOfHumanPlayers = values(this.state.users).filter(u => !u.isBot).length
       if (numberOfHumanPlayers >= MAX_PLAYERS_PER_LOBBY) {
         throw "room is full"
       } else if (this.state.gameStarted) {


### PR DESCRIPTION
fix several bugs around preparation join and leave actions:
- fix kicked users not being removed from state.users
- fix bots not being replaced by a player after an async request (responsible for 9 players lobbies)
- fix anonymous users not being able to replace a bot after an async request
- fix leave preparation action not removing reconnection token