### PR TITLE
fixing missing frames

### DIFF
--- a/app/core/matter/mini-game.ts
+++ b/app/core/matter/mini-game.ts
@@ -25,8 +25,8 @@ import {
   SynergyTriggers
 } from "../../types/Config"
 import { Synergy } from "../../types/enum/Synergy"
-import { logger } from "../../utils/logger"
 import GameState from "../../rooms/states/game-state"
+import { entries } from "../../utils/schemas"
 
 const PLAYER_VELOCITY = 2
 const ITEM_ROTATION_SPEED = 0.0004
@@ -486,14 +486,14 @@ export class MiniGame {
       }
 
       if (
-        avatar.portalId === "" &&
+        avatar.portalId == "" &&
         player &&
         !player.isBot &&
         this.portals &&
         this.avatars
       ) {
         // send to random portal if none was taken
-        const remainingPortals = [...this.portals.entries()].filter(
+        const remainingPortals = entries(this.portals).filter(
           ([portalId, portal]) => portal.avatarId == ""
         )
         if (remainingPortals.length > 0) {

--- a/app/public/dist/client/assets/attacks/CLANGOROUS_SOUL.json
+++ b/app/public/dist/client/assets/attacks/CLANGOROUS_SOUL.json
@@ -1,398 +1,398 @@
 {
-	"textures": [
-		{
-			"image": "CLANGOROUS_SOUL.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 128,
-				"h": 175
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "012",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 8,
-						"y": 4,
-						"w": 75,
-						"h": 27
-					},
-					"frame": {
-						"x": 1,
-						"y": 1,
-						"w": 75,
-						"h": 27
-					}
-				},
-				{
-					"filename": "015",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 3,
-						"w": 49,
-						"h": 19
-					},
-					"frame": {
-						"x": 78,
-						"y": 1,
-						"w": 49,
-						"h": 19
-					}
-				},
-				{
-					"filename": "014",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 4,
-						"y": 7,
-						"w": 48,
-						"h": 18
-					},
-					"frame": {
-						"x": 78,
-						"y": 22,
-						"w": 48,
-						"h": 18
-					}
-				},
-				{
-					"filename": "010",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 14,
-						"y": 12,
-						"w": 65,
-						"h": 23
-					},
-					"frame": {
-						"x": 1,
-						"y": 30,
-						"w": 65,
-						"h": 23
-					}
-				},
-				{
-					"filename": "008",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 18,
-						"y": 15,
-						"w": 56,
-						"h": 20
-					},
-					"frame": {
-						"x": 68,
-						"y": 42,
-						"w": 56,
-						"h": 20
-					}
-				},
-				{
-					"filename": "009",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 16,
-						"y": 14,
-						"w": 61,
-						"h": 24
-					},
-					"frame": {
-						"x": 1,
-						"y": 55,
-						"w": 61,
-						"h": 24
-					}
-				},
-				{
-					"filename": "007",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 20,
-						"y": 16,
-						"w": 51,
-						"h": 21
-					},
-					"frame": {
-						"x": 64,
-						"y": 64,
-						"w": 51,
-						"h": 21
-					}
-				},
-				{
-					"filename": "016",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 40,
-						"y": 6,
-						"w": 9,
-						"h": 14
-					},
-					"frame": {
-						"x": 117,
-						"y": 64,
-						"w": 9,
-						"h": 14
-					}
-				},
-				{
-					"filename": "018",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 37,
-						"y": 2,
-						"w": 9,
-						"h": 14
-					},
-					"frame": {
-						"x": 117,
-						"y": 64,
-						"w": 9,
-						"h": 14
-					}
-				},
-				{
-					"filename": "006",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 22,
-						"y": 17,
-						"w": 47,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 81,
-						"w": 47,
-						"h": 22
-					}
-				},
-				{
-					"filename": "013",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 6,
-						"y": 11,
-						"w": 45,
-						"h": 18
-					},
-					"frame": {
-						"x": 50,
-						"y": 87,
-						"w": 45,
-						"h": 18
-					}
-				},
-				{
-					"filename": "002",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 34,
-						"y": 25,
-						"w": 28,
-						"h": 34
-					},
-					"frame": {
-						"x": 97,
-						"y": 87,
-						"w": 28,
-						"h": 34
-					}
-				},
-				{
-					"filename": "005",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 23,
-						"y": 18,
-						"w": 44,
-						"h": 41
-					},
-					"frame": {
-						"x": 1,
-						"y": 105,
-						"w": 44,
-						"h": 41
-					}
-				},
-				{
-					"filename": "004",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 25,
-						"y": 20,
-						"w": 40,
-						"h": 34
-					},
-					"frame": {
-						"x": 47,
-						"y": 107,
-						"w": 40,
-						"h": 34
-					}
-				},
-				{
-					"filename": "011",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 11,
-						"y": 14,
-						"w": 36,
-						"h": 19
-					},
-					"frame": {
-						"x": 89,
-						"y": 123,
-						"w": 36,
-						"h": 19
-					}
-				},
-				{
-					"filename": "003",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 32,
-						"y": 22,
-						"w": 31,
-						"h": 31
-					},
-					"frame": {
-						"x": 47,
-						"y": 143,
-						"w": 31,
-						"h": 31
-					}
-				},
-				{
-					"filename": "001",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 39,
-						"y": 29,
-						"w": 21,
-						"h": 25
-					},
-					"frame": {
-						"x": 1,
-						"y": 148,
-						"w": 21,
-						"h": 25
-					}
-				},
-				{
-					"filename": "000",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 88,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 40,
-						"y": 33,
-						"w": 18,
-						"h": 20
-					},
-					"frame": {
-						"x": 24,
-						"y": 148,
-						"w": 18,
-						"h": 20
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:e2007cbe17f7bcf77e33994ee6c502eb:941e3ce9443df20b7ed40f4225773aa6:17d44a265b87ca6744071433b2a7e950$"
-	}
+  "textures": [
+    {
+      "image": "CLANGOROUS_SOUL.png",
+      "format": "RGBA8888",
+      "size": {
+        "w": 128,
+        "h": 175
+      },
+      "scale": 1,
+      "frames": [
+        {
+          "filename": "012",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 8,
+            "y": 4,
+            "w": 75,
+            "h": 27
+          },
+          "frame": {
+            "x": 1,
+            "y": 1,
+            "w": 75,
+            "h": 27
+          }
+        },
+        {
+          "filename": "015",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 3,
+            "w": 49,
+            "h": 19
+          },
+          "frame": {
+            "x": 78,
+            "y": 1,
+            "w": 49,
+            "h": 19
+          }
+        },
+        {
+          "filename": "014",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 4,
+            "y": 7,
+            "w": 48,
+            "h": 18
+          },
+          "frame": {
+            "x": 78,
+            "y": 22,
+            "w": 48,
+            "h": 18
+          }
+        },
+        {
+          "filename": "010",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 14,
+            "y": 12,
+            "w": 65,
+            "h": 23
+          },
+          "frame": {
+            "x": 1,
+            "y": 30,
+            "w": 65,
+            "h": 23
+          }
+        },
+        {
+          "filename": "008",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 18,
+            "y": 15,
+            "w": 56,
+            "h": 20
+          },
+          "frame": {
+            "x": 68,
+            "y": 42,
+            "w": 56,
+            "h": 20
+          }
+        },
+        {
+          "filename": "009",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 16,
+            "y": 14,
+            "w": 61,
+            "h": 24
+          },
+          "frame": {
+            "x": 1,
+            "y": 55,
+            "w": 61,
+            "h": 24
+          }
+        },
+        {
+          "filename": "007",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 20,
+            "y": 16,
+            "w": 51,
+            "h": 21
+          },
+          "frame": {
+            "x": 64,
+            "y": 64,
+            "w": 51,
+            "h": 21
+          }
+        },
+        {
+          "filename": "016",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 40,
+            "y": 6,
+            "w": 9,
+            "h": 14
+          },
+          "frame": {
+            "x": 117,
+            "y": 64,
+            "w": 9,
+            "h": 14
+          }
+        },
+        {
+          "filename": "017",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 37,
+            "y": 2,
+            "w": 9,
+            "h": 14
+          },
+          "frame": {
+            "x": 117,
+            "y": 64,
+            "w": 9,
+            "h": 14
+          }
+        },
+        {
+          "filename": "006",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 22,
+            "y": 17,
+            "w": 47,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 81,
+            "w": 47,
+            "h": 22
+          }
+        },
+        {
+          "filename": "013",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 6,
+            "y": 11,
+            "w": 45,
+            "h": 18
+          },
+          "frame": {
+            "x": 50,
+            "y": 87,
+            "w": 45,
+            "h": 18
+          }
+        },
+        {
+          "filename": "002",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 34,
+            "y": 25,
+            "w": 28,
+            "h": 34
+          },
+          "frame": {
+            "x": 97,
+            "y": 87,
+            "w": 28,
+            "h": 34
+          }
+        },
+        {
+          "filename": "005",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 23,
+            "y": 18,
+            "w": 44,
+            "h": 41
+          },
+          "frame": {
+            "x": 1,
+            "y": 105,
+            "w": 44,
+            "h": 41
+          }
+        },
+        {
+          "filename": "004",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 25,
+            "y": 20,
+            "w": 40,
+            "h": 34
+          },
+          "frame": {
+            "x": 47,
+            "y": 107,
+            "w": 40,
+            "h": 34
+          }
+        },
+        {
+          "filename": "011",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 11,
+            "y": 14,
+            "w": 36,
+            "h": 19
+          },
+          "frame": {
+            "x": 89,
+            "y": 123,
+            "w": 36,
+            "h": 19
+          }
+        },
+        {
+          "filename": "003",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 32,
+            "y": 22,
+            "w": 31,
+            "h": 31
+          },
+          "frame": {
+            "x": 47,
+            "y": 143,
+            "w": 31,
+            "h": 31
+          }
+        },
+        {
+          "filename": "001",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 39,
+            "y": 29,
+            "w": 21,
+            "h": 25
+          },
+          "frame": {
+            "x": 1,
+            "y": 148,
+            "w": 21,
+            "h": 25
+          }
+        },
+        {
+          "filename": "000",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 88,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 40,
+            "y": 33,
+            "w": 18,
+            "h": 20
+          },
+          "frame": {
+            "x": 24,
+            "y": 148,
+            "w": 18,
+            "h": 20
+          }
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "app": "https://www.codeandweb.com/texturepacker",
+    "version": "3.0",
+    "smartupdate": "$TexturePacker:SmartUpdate:e2007cbe17f7bcf77e33994ee6c502eb:941e3ce9443df20b7ed40f4225773aa6:17d44a265b87ca6744071433b2a7e950$"
+  }
 }

--- a/app/public/dist/client/assets/attacks/COSMIC_POWER.json
+++ b/app/public/dist/client/assets/attacks/COSMIC_POWER.json
@@ -1,770 +1,770 @@
 {
-	"textures": [
-		{
-			"image": "COSMIC_POWER.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 187,
-				"h": 255
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "021",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 12,
-						"w": 46,
-						"h": 88
-					},
-					"frame": {
-						"x": 1,
-						"y": 1,
-						"w": 46,
-						"h": 88
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "023",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 10,
-						"w": 45,
-						"h": 89
-					},
-					"frame": {
-						"x": 1,
-						"y": 91,
-						"w": 45,
-						"h": 89
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "017",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 16,
-						"w": 46,
-						"h": 85
-					},
-					"frame": {
-						"x": 49,
-						"y": 1,
-						"w": 46,
-						"h": 85
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "019",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 14,
-						"w": 44,
-						"h": 87
-					},
-					"frame": {
-						"x": 97,
-						"y": 1,
-						"w": 44,
-						"h": 87
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "025",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 8,
-						"w": 43,
-						"h": 85
-					},
-					"frame": {
-						"x": 143,
-						"y": 1,
-						"w": 43,
-						"h": 85
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "015",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 18,
-						"w": 43,
-						"h": 83
-					},
-					"frame": {
-						"x": 143,
-						"y": 88,
-						"w": 43,
-						"h": 83
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "027",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 6,
-						"w": 42,
-						"h": 85
-					},
-					"frame": {
-						"x": 48,
-						"y": 91,
-						"w": 42,
-						"h": 85
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "011",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 22,
-						"w": 48,
-						"h": 80
-					},
-					"frame": {
-						"x": 92,
-						"y": 90,
-						"w": 48,
-						"h": 80
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "000",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "002",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "004",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "006",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "008",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "010",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "012",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "014",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "016",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "018",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "020",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "022",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "024",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "026",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "028",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "030",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "032",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "034",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "036",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 34,
-						"h": 34
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "009",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 24,
-						"w": 46,
-						"h": 76
-					},
-					"frame": {
-						"x": 92,
-						"y": 172,
-						"w": 46,
-						"h": 76
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "013",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 20,
-						"w": 44,
-						"h": 81
-					},
-					"frame": {
-						"x": 140,
-						"y": 173,
-						"w": 44,
-						"h": 81
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				},
-				{
-					"filename": "029",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 104
-					},
-					"spriteSourceSize": {
-						"x": 4,
-						"y": 3,
-						"w": 39,
-						"h": 76
-					},
-					"frame": {
-						"x": 48,
-						"y": 178,
-						"w": 39,
-						"h": 76
-					},
-					"anchor": {
-						"x": 0.5,
-						"y": 1
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:cbe777fac0756cc9a2151f44c1a6d725:dbf7dbd34175d45366a0be467d1cec04:cb558f084b0ae4f62fd41135c8c1123f$"
-	}
+  "textures": [
+    {
+      "image": "COSMIC_POWER.png",
+      "format": "RGBA8888",
+      "size": {
+        "w": 187,
+        "h": 255
+      },
+      "scale": 1,
+      "frames": [
+        {
+          "filename": "017",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 12,
+            "w": 46,
+            "h": 88
+          },
+          "frame": {
+            "x": 1,
+            "y": 1,
+            "w": 46,
+            "h": 88
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "019",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 10,
+            "w": 45,
+            "h": 89
+          },
+          "frame": {
+            "x": 1,
+            "y": 91,
+            "w": 45,
+            "h": 89
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "013",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 16,
+            "w": 46,
+            "h": 85
+          },
+          "frame": {
+            "x": 49,
+            "y": 1,
+            "w": 46,
+            "h": 85
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "015",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 14,
+            "w": 44,
+            "h": 87
+          },
+          "frame": {
+            "x": 97,
+            "y": 1,
+            "w": 44,
+            "h": 87
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "021",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 8,
+            "w": 43,
+            "h": 85
+          },
+          "frame": {
+            "x": 143,
+            "y": 1,
+            "w": 43,
+            "h": 85
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "011",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 18,
+            "w": 43,
+            "h": 83
+          },
+          "frame": {
+            "x": 143,
+            "y": 88,
+            "w": 43,
+            "h": 83
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "023",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 6,
+            "w": 42,
+            "h": 85
+          },
+          "frame": {
+            "x": 48,
+            "y": 91,
+            "w": 42,
+            "h": 85
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "007",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 22,
+            "w": 48,
+            "h": 80
+          },
+          "frame": {
+            "x": 92,
+            "y": 90,
+            "w": 48,
+            "h": 80
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "000",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "001",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "002",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "003",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "004",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "006",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "008",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "010",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "012",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "014",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "016",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "018",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "020",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "022",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "024",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "026",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "027",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "028",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "029",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 34,
+            "h": 34
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "005",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 24,
+            "w": 46,
+            "h": 76
+          },
+          "frame": {
+            "x": 92,
+            "y": 172,
+            "w": 46,
+            "h": 76
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "009",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 20,
+            "w": 44,
+            "h": 81
+          },
+          "frame": {
+            "x": 140,
+            "y": 173,
+            "w": 44,
+            "h": 81
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        },
+        {
+          "filename": "025",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 104
+          },
+          "spriteSourceSize": {
+            "x": 4,
+            "y": 3,
+            "w": 39,
+            "h": 76
+          },
+          "frame": {
+            "x": 48,
+            "y": 178,
+            "w": 39,
+            "h": 76
+          },
+          "anchor": {
+            "x": 0.5,
+            "y": 1
+          }
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "app": "https://www.codeandweb.com/texturepacker",
+    "version": "3.0",
+    "smartupdate": "$TexturePacker:SmartUpdate:cbe777fac0756cc9a2151f44c1a6d725:dbf7dbd34175d45366a0be467d1cec04:cb558f084b0ae4f62fd41135c8c1123f$"
+  }
 }

--- a/app/public/dist/client/assets/attacks/DISARMING_VOICE.json
+++ b/app/public/dist/client/assets/attacks/DISARMING_VOICE.json
@@ -10,7 +10,7 @@
 			"scale": 1,
 			"frames": [
 				{
-					"filename": "025",
+					"filename": "024",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -31,7 +31,7 @@
 					}
 				},
 				{
-					"filename": "033",
+					"filename": "028",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -52,7 +52,7 @@
 					}
 				},
 				{
-					"filename": "029",
+					"filename": "026",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -73,7 +73,7 @@
 					}
 				},
 				{
-					"filename": "037",
+					"filename": "032",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -94,7 +94,7 @@
 					}
 				},
 				{
-					"filename": "027",
+					"filename": "025",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -115,7 +115,7 @@
 					}
 				},
 				{
-					"filename": "038",
+					"filename": "033",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -136,7 +136,7 @@
 					}
 				},
 				{
-					"filename": "031",
+					"filename": "027",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -241,7 +241,7 @@
 					}
 				},
 				{
-					"filename": "040",
+					"filename": "035",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -304,7 +304,7 @@
 					}
 				},
 				{
-					"filename": "042",
+					"filename": "037",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -325,7 +325,7 @@
 					}
 				},
 				{
-					"filename": "034",
+					"filename": "029",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -346,7 +346,7 @@
 					}
 				},
 				{
-					"filename": "039",
+					"filename": "034",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -451,7 +451,7 @@
 					}
 				},
 				{
-					"filename": "036",
+					"filename": "031",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -556,7 +556,7 @@
 					}
 				},
 				{
-					"filename": "035",
+					"filename": "030",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -640,7 +640,7 @@
 					}
 				},
 				{
-					"filename": "043",
+					"filename": "038",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -682,7 +682,7 @@
 					}
 				},
 				{
-					"filename": "041",
+					"filename": "036",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/app/public/dist/client/assets/attacks/FAIRY_CRIT.json
+++ b/app/public/dist/client/assets/attacks/FAIRY_CRIT.json
@@ -1,356 +1,356 @@
 {
-	"textures": [
-		{
-			"image": "FAIRY_CRIT.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 287,
-				"h": 128
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "010",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 3,
-						"w": 50,
-						"h": 56
-					},
-					"frame": {
-						"x": 1,
-						"y": 1,
-						"w": 50,
-						"h": 56
-					}
-				},
-				{
-					"filename": "009",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 4,
-						"y": 2,
-						"w": 49,
-						"h": 54
-					},
-					"frame": {
-						"x": 1,
-						"y": 59,
-						"w": 49,
-						"h": 54
-					}
-				},
-				{
-					"filename": "000",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 24,
-						"y": 34,
-						"w": 9,
-						"h": 8
-					},
-					"frame": {
-						"x": 1,
-						"y": 115,
-						"w": 9,
-						"h": 8
-					}
-				},
-				{
-					"filename": "019",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 35,
-						"y": 18,
-						"w": 8,
-						"h": 8
-					},
-					"frame": {
-						"x": 12,
-						"y": 115,
-						"w": 8,
-						"h": 8
-					}
-				},
-				{
-					"filename": "004",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 3,
-						"y": 8,
-						"w": 52,
-						"h": 49
-					},
-					"frame": {
-						"x": 52,
-						"y": 59,
-						"w": 52,
-						"h": 49
-					}
-				},
-				{
-					"filename": "005",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 5,
-						"y": 5,
-						"w": 49,
-						"h": 51
-					},
-					"frame": {
-						"x": 53,
-						"y": 1,
-						"w": 49,
-						"h": 51
-					}
-				},
-				{
-					"filename": "008",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 6,
-						"y": 3,
-						"w": 46,
-						"h": 53
-					},
-					"frame": {
-						"x": 104,
-						"y": 1,
-						"w": 46,
-						"h": 53
-					}
-				},
-				{
-					"filename": "006",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 5,
-						"y": 6,
-						"w": 47,
-						"h": 50
-					},
-					"frame": {
-						"x": 106,
-						"y": 56,
-						"w": 47,
-						"h": 50
-					}
-				},
-				{
-					"filename": "007",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 4,
-						"y": 8,
-						"w": 48,
-						"h": 47
-					},
-					"frame": {
-						"x": 152,
-						"y": 1,
-						"w": 48,
-						"h": 47
-					}
-				},
-				{
-					"filename": "011",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 3,
-						"y": 19,
-						"w": 53,
-						"h": 42
-					},
-					"frame": {
-						"x": 155,
-						"y": 50,
-						"w": 53,
-						"h": 42
-					}
-				},
-				{
-					"filename": "001",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 9,
-						"y": 19,
-						"w": 26,
-						"h": 21
-					},
-					"frame": {
-						"x": 155,
-						"y": 94,
-						"w": 26,
-						"h": 21
-					}
-				},
-				{
-					"filename": "013",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 4,
-						"y": 17,
-						"w": 47,
-						"h": 45
-					},
-					"frame": {
-						"x": 202,
-						"y": 1,
-						"w": 47,
-						"h": 45
-					}
-				},
-				{
-					"filename": "003",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 12,
-						"w": 50,
-						"h": 42
-					},
-					"frame": {
-						"x": 210,
-						"y": 48,
-						"w": 50,
-						"h": 42
-					}
-				},
-				{
-					"filename": "002",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 5,
-						"y": 15,
-						"w": 43,
-						"h": 35
-					},
-					"frame": {
-						"x": 210,
-						"y": 92,
-						"w": 43,
-						"h": 35
-					}
-				},
-				{
-					"filename": "015",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 19,
-						"w": 34,
-						"h": 41
-					},
-					"frame": {
-						"x": 251,
-						"y": 1,
-						"w": 34,
-						"h": 41
-					}
-				},
-				{
-					"filename": "017",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 56,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 24,
-						"y": 16,
-						"w": 24,
-						"h": 37
-					},
-					"frame": {
-						"x": 262,
-						"y": 44,
-						"w": 24,
-						"h": 37
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:901fee10ef82a087c5926e69abdbfa64:25c779e685e19a6e77227c857fb47818:21bec624dc13c163e2b56dd13b962a6e$"
-	}
+  "textures": [
+    {
+      "image": "FAIRY_CRIT.png",
+      "format": "RGBA8888",
+      "size": {
+        "w": 287,
+        "h": 128
+      },
+      "scale": 1,
+      "frames": [
+        {
+          "filename": "010",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 3,
+            "w": 50,
+            "h": 56
+          },
+          "frame": {
+            "x": 1,
+            "y": 1,
+            "w": 50,
+            "h": 56
+          }
+        },
+        {
+          "filename": "009",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 4,
+            "y": 2,
+            "w": 49,
+            "h": 54
+          },
+          "frame": {
+            "x": 1,
+            "y": 59,
+            "w": 49,
+            "h": 54
+          }
+        },
+        {
+          "filename": "000",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 24,
+            "y": 34,
+            "w": 9,
+            "h": 8
+          },
+          "frame": {
+            "x": 1,
+            "y": 115,
+            "w": 9,
+            "h": 8
+          }
+        },
+        {
+          "filename": "019",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 35,
+            "y": 18,
+            "w": 8,
+            "h": 8
+          },
+          "frame": {
+            "x": 12,
+            "y": 115,
+            "w": 8,
+            "h": 8
+          }
+        },
+        {
+          "filename": "004",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 3,
+            "y": 8,
+            "w": 52,
+            "h": 49
+          },
+          "frame": {
+            "x": 52,
+            "y": 59,
+            "w": 52,
+            "h": 49
+          }
+        },
+        {
+          "filename": "005",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 5,
+            "y": 5,
+            "w": 49,
+            "h": 51
+          },
+          "frame": {
+            "x": 53,
+            "y": 1,
+            "w": 49,
+            "h": 51
+          }
+        },
+        {
+          "filename": "008",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 6,
+            "y": 3,
+            "w": 46,
+            "h": 53
+          },
+          "frame": {
+            "x": 104,
+            "y": 1,
+            "w": 46,
+            "h": 53
+          }
+        },
+        {
+          "filename": "006",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 5,
+            "y": 6,
+            "w": 47,
+            "h": 50
+          },
+          "frame": {
+            "x": 106,
+            "y": 56,
+            "w": 47,
+            "h": 50
+          }
+        },
+        {
+          "filename": "007",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 4,
+            "y": 8,
+            "w": 48,
+            "h": 47
+          },
+          "frame": {
+            "x": 152,
+            "y": 1,
+            "w": 48,
+            "h": 47
+          }
+        },
+        {
+          "filename": "011",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 3,
+            "y": 19,
+            "w": 53,
+            "h": 42
+          },
+          "frame": {
+            "x": 155,
+            "y": 50,
+            "w": 53,
+            "h": 42
+          }
+        },
+        {
+          "filename": "001",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 9,
+            "y": 19,
+            "w": 26,
+            "h": 21
+          },
+          "frame": {
+            "x": 155,
+            "y": 94,
+            "w": 26,
+            "h": 21
+          }
+        },
+        {
+          "filename": "012",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 4,
+            "y": 17,
+            "w": 47,
+            "h": 45
+          },
+          "frame": {
+            "x": 202,
+            "y": 1,
+            "w": 47,
+            "h": 45
+          }
+        },
+        {
+          "filename": "003",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 12,
+            "w": 50,
+            "h": 42
+          },
+          "frame": {
+            "x": 210,
+            "y": 48,
+            "w": 50,
+            "h": 42
+          }
+        },
+        {
+          "filename": "002",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 5,
+            "y": 15,
+            "w": 43,
+            "h": 35
+          },
+          "frame": {
+            "x": 210,
+            "y": 92,
+            "w": 43,
+            "h": 35
+          }
+        },
+        {
+          "filename": "013",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 10,
+            "y": 19,
+            "w": 34,
+            "h": 41
+          },
+          "frame": {
+            "x": 251,
+            "y": 1,
+            "w": 34,
+            "h": 41
+          }
+        },
+        {
+          "filename": "014",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 56,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 24,
+            "y": 16,
+            "w": 24,
+            "h": 37
+          },
+          "frame": {
+            "x": 262,
+            "y": 44,
+            "w": 24,
+            "h": 37
+          }
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "app": "https://www.codeandweb.com/texturepacker",
+    "version": "3.0",
+    "smartupdate": "$TexturePacker:SmartUpdate:901fee10ef82a087c5926e69abdbfa64:25c779e685e19a6e77227c857fb47818:21bec624dc13c163e2b56dd13b962a6e$"
+  }
 }

--- a/app/public/dist/client/assets/attacks/FUSION_BOLT.json
+++ b/app/public/dist/client/assets/attacks/FUSION_BOLT.json
@@ -10,7 +10,7 @@
 			"scale": 1,
 			"frames": [
 				{
-					"filename": "015",
+					"filename": "011",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -73,7 +73,7 @@
 					}
 				},
 				{
-					"filename": "013",
+					"filename": "010",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -136,7 +136,7 @@
 					}
 				},
 				{
-					"filename": "011",
+					"filename": "009",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -178,7 +178,7 @@
 					}
 				},
 				{
-					"filename": "017",
+					"filename": "012",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -199,7 +199,7 @@
 					}
 				},
 				{
-					"filename": "009",
+					"filename": "008",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/app/public/dist/client/assets/attacks/HIGH_JUMP_KICK.json
+++ b/app/public/dist/client/assets/attacks/HIGH_JUMP_KICK.json
@@ -1,461 +1,461 @@
 {
-	"textures": [
-		{
-			"image": "HIGH_JUMP_KICK.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 400,
-				"h": 124
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "017",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 3,
-						"w": 62,
-						"h": 70
-					},
-					"frame": {
-						"x": 1,
-						"y": 1,
-						"w": 62,
-						"h": 70
-					}
-				},
-				{
-					"filename": "016",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 14,
-						"y": 24,
-						"w": 67,
-						"h": 50
-					},
-					"frame": {
-						"x": 1,
-						"y": 73,
-						"w": 67,
-						"h": 50
-					}
-				},
-				{
-					"filename": "015",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 24,
-						"y": 17,
-						"w": 59,
-						"h": 61
-					},
-					"frame": {
-						"x": 65,
-						"y": 1,
-						"w": 59,
-						"h": 61
-					}
-				},
-				{
-					"filename": "012",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 18,
-						"y": 9,
-						"w": 59,
-						"h": 58
-					},
-					"frame": {
-						"x": 70,
-						"y": 64,
-						"w": 59,
-						"h": 58
-					}
-				},
-				{
-					"filename": "009",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 21,
-						"y": 17,
-						"w": 54,
-						"h": 53
-					},
-					"frame": {
-						"x": 126,
-						"y": 1,
-						"w": 54,
-						"h": 53
-					}
-				},
-				{
-					"filename": "014",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 6,
-						"w": 54,
-						"h": 65
-					},
-					"frame": {
-						"x": 131,
-						"y": 56,
-						"w": 54,
-						"h": 65
-					}
-				},
-				{
-					"filename": "011",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 26,
-						"y": 22,
-						"w": 43,
-						"h": 52
-					},
-					"frame": {
-						"x": 182,
-						"y": 1,
-						"w": 43,
-						"h": 52
-					}
-				},
-				{
-					"filename": "010",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 21,
-						"y": 11,
-						"w": 50,
-						"h": 57
-					},
-					"frame": {
-						"x": 187,
-						"y": 55,
-						"w": 50,
-						"h": 57
-					}
-				},
-				{
-					"filename": "008",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 25,
-						"y": 20,
-						"w": 46,
-						"h": 46
-					},
-					"frame": {
-						"x": 227,
-						"y": 1,
-						"w": 46,
-						"h": 46
-					}
-				},
-				{
-					"filename": "013",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 25,
-						"y": 22,
-						"w": 50,
-						"h": 54
-					},
-					"frame": {
-						"x": 239,
-						"y": 49,
-						"w": 50,
-						"h": 54
-					}
-				},
-				{
-					"filename": "000",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 21,
-						"y": 16,
-						"w": 54,
-						"h": 18
-					},
-					"frame": {
-						"x": 239,
-						"y": 105,
-						"w": 54,
-						"h": 18
-					}
-				},
-				{
-					"filename": "019",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 14,
-						"y": 7,
-						"w": 40,
-						"h": 46
-					},
-					"frame": {
-						"x": 275,
-						"y": 1,
-						"w": 40,
-						"h": 46
-					}
-				},
-				{
-					"filename": "007",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 28,
-						"y": 23,
-						"w": 40,
-						"h": 40
-					},
-					"frame": {
-						"x": 291,
-						"y": 49,
-						"w": 40,
-						"h": 40
-					}
-				},
-				{
-					"filename": "018",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 26,
-						"y": 53,
-						"w": 40,
-						"h": 27
-					},
-					"frame": {
-						"x": 295,
-						"y": 91,
-						"w": 40,
-						"h": 27
-					}
-				},
-				{
-					"filename": "006",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 30,
-						"y": 25,
-						"w": 36,
-						"h": 36
-					},
-					"frame": {
-						"x": 317,
-						"y": 1,
-						"w": 36,
-						"h": 36
-					}
-				},
-				{
-					"filename": "005",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 31,
-						"y": 29,
-						"w": 34,
-						"h": 31
-					},
-					"frame": {
-						"x": 333,
-						"y": 39,
-						"w": 34,
-						"h": 31
-					}
-				},
-				{
-					"filename": "002",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 26,
-						"y": 21,
-						"w": 44,
-						"h": 23
-					},
-					"frame": {
-						"x": 355,
-						"y": 1,
-						"w": 44,
-						"h": 23
-					}
-				},
-				{
-					"filename": "004",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 33,
-						"y": 28,
-						"w": 30,
-						"h": 25
-					},
-					"frame": {
-						"x": 369,
-						"y": 26,
-						"w": 30,
-						"h": 25
-					}
-				},
-				{
-					"filename": "021",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 45,
-						"y": 59,
-						"w": 22,
-						"h": 21
-					},
-					"frame": {
-						"x": 369,
-						"y": 53,
-						"w": 22,
-						"h": 21
-					}
-				},
-				{
-					"filename": "001",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 26,
-						"y": 21,
-						"w": 44,
-						"h": 18
-					},
-					"frame": {
-						"x": 337,
-						"y": 76,
-						"w": 44,
-						"h": 18
-					}
-				},
-				{
-					"filename": "003",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 96,
-						"h": 80
-					},
-					"spriteSourceSize": {
-						"x": 32,
-						"y": 27,
-						"w": 32,
-						"h": 20
-					},
-					"frame": {
-						"x": 337,
-						"y": 96,
-						"w": 32,
-						"h": 20
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:3e73238cb02216d82b798ddcf2126448:fdef464787f9897b29be4dffe9267d5c:354dddb06a880fed6d15af2cc0418a7f$"
-	}
+  "textures": [
+    {
+      "image": "HIGH_JUMP_KICK.png",
+      "format": "RGBA8888",
+      "size": {
+        "w": 400,
+        "h": 124
+      },
+      "scale": 1,
+      "frames": [
+        {
+          "filename": "017",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 3,
+            "w": 62,
+            "h": 70
+          },
+          "frame": {
+            "x": 1,
+            "y": 1,
+            "w": 62,
+            "h": 70
+          }
+        },
+        {
+          "filename": "016",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 14,
+            "y": 24,
+            "w": 67,
+            "h": 50
+          },
+          "frame": {
+            "x": 1,
+            "y": 73,
+            "w": 67,
+            "h": 50
+          }
+        },
+        {
+          "filename": "015",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 24,
+            "y": 17,
+            "w": 59,
+            "h": 61
+          },
+          "frame": {
+            "x": 65,
+            "y": 1,
+            "w": 59,
+            "h": 61
+          }
+        },
+        {
+          "filename": "012",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 18,
+            "y": 9,
+            "w": 59,
+            "h": 58
+          },
+          "frame": {
+            "x": 70,
+            "y": 64,
+            "w": 59,
+            "h": 58
+          }
+        },
+        {
+          "filename": "009",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 21,
+            "y": 17,
+            "w": 54,
+            "h": 53
+          },
+          "frame": {
+            "x": 126,
+            "y": 1,
+            "w": 54,
+            "h": 53
+          }
+        },
+        {
+          "filename": "014",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 6,
+            "w": 54,
+            "h": 65
+          },
+          "frame": {
+            "x": 131,
+            "y": 56,
+            "w": 54,
+            "h": 65
+          }
+        },
+        {
+          "filename": "011",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 26,
+            "y": 22,
+            "w": 43,
+            "h": 52
+          },
+          "frame": {
+            "x": 182,
+            "y": 1,
+            "w": 43,
+            "h": 52
+          }
+        },
+        {
+          "filename": "010",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 21,
+            "y": 11,
+            "w": 50,
+            "h": 57
+          },
+          "frame": {
+            "x": 187,
+            "y": 55,
+            "w": 50,
+            "h": 57
+          }
+        },
+        {
+          "filename": "008",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 25,
+            "y": 20,
+            "w": 46,
+            "h": 46
+          },
+          "frame": {
+            "x": 227,
+            "y": 1,
+            "w": 46,
+            "h": 46
+          }
+        },
+        {
+          "filename": "013",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 25,
+            "y": 22,
+            "w": 50,
+            "h": 54
+          },
+          "frame": {
+            "x": 239,
+            "y": 49,
+            "w": 50,
+            "h": 54
+          }
+        },
+        {
+          "filename": "000",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 21,
+            "y": 16,
+            "w": 54,
+            "h": 18
+          },
+          "frame": {
+            "x": 239,
+            "y": 105,
+            "w": 54,
+            "h": 18
+          }
+        },
+        {
+          "filename": "019",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 14,
+            "y": 7,
+            "w": 40,
+            "h": 46
+          },
+          "frame": {
+            "x": 275,
+            "y": 1,
+            "w": 40,
+            "h": 46
+          }
+        },
+        {
+          "filename": "007",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 28,
+            "y": 23,
+            "w": 40,
+            "h": 40
+          },
+          "frame": {
+            "x": 291,
+            "y": 49,
+            "w": 40,
+            "h": 40
+          }
+        },
+        {
+          "filename": "018",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 26,
+            "y": 53,
+            "w": 40,
+            "h": 27
+          },
+          "frame": {
+            "x": 295,
+            "y": 91,
+            "w": 40,
+            "h": 27
+          }
+        },
+        {
+          "filename": "006",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 30,
+            "y": 25,
+            "w": 36,
+            "h": 36
+          },
+          "frame": {
+            "x": 317,
+            "y": 1,
+            "w": 36,
+            "h": 36
+          }
+        },
+        {
+          "filename": "005",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 31,
+            "y": 29,
+            "w": 34,
+            "h": 31
+          },
+          "frame": {
+            "x": 333,
+            "y": 39,
+            "w": 34,
+            "h": 31
+          }
+        },
+        {
+          "filename": "002",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 26,
+            "y": 21,
+            "w": 44,
+            "h": 23
+          },
+          "frame": {
+            "x": 355,
+            "y": 1,
+            "w": 44,
+            "h": 23
+          }
+        },
+        {
+          "filename": "004",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 33,
+            "y": 28,
+            "w": 30,
+            "h": 25
+          },
+          "frame": {
+            "x": 369,
+            "y": 26,
+            "w": 30,
+            "h": 25
+          }
+        },
+        {
+          "filename": "020",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 45,
+            "y": 59,
+            "w": 22,
+            "h": 21
+          },
+          "frame": {
+            "x": 369,
+            "y": 53,
+            "w": 22,
+            "h": 21
+          }
+        },
+        {
+          "filename": "001",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 26,
+            "y": 21,
+            "w": 44,
+            "h": 18
+          },
+          "frame": {
+            "x": 337,
+            "y": 76,
+            "w": 44,
+            "h": 18
+          }
+        },
+        {
+          "filename": "003",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 96,
+            "h": 80
+          },
+          "spriteSourceSize": {
+            "x": 32,
+            "y": 27,
+            "w": 32,
+            "h": 20
+          },
+          "frame": {
+            "x": 337,
+            "y": 96,
+            "w": 32,
+            "h": 20
+          }
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "app": "https://www.codeandweb.com/texturepacker",
+    "version": "3.0",
+    "smartupdate": "$TexturePacker:SmartUpdate:3e73238cb02216d82b798ddcf2126448:fdef464787f9897b29be4dffe9267d5c:354dddb06a880fed6d15af2cc0418a7f$"
+  }
 }

--- a/app/public/dist/client/assets/attacks/MAGIC_BOUNCE.json
+++ b/app/public/dist/client/assets/attacks/MAGIC_BOUNCE.json
@@ -31,7 +31,7 @@
 					}
 				},
 				{
-					"filename": "008",
+					"filename": "007",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -73,7 +73,7 @@
 					}
 				},
 				{
-					"filename": "014",
+					"filename": "013",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -115,7 +115,7 @@
 					}
 				},
 				{
-					"filename": "009",
+					"filename": "008",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -157,7 +157,7 @@
 					}
 				},
 				{
-					"filename": "013",
+					"filename": "012",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -199,7 +199,7 @@
 					}
 				},
 				{
-					"filename": "011",
+					"filename": "010",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -241,7 +241,7 @@
 					}
 				},
 				{
-					"filename": "010",
+					"filename": "009",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -283,7 +283,7 @@
 					}
 				},
 				{
-					"filename": "012",
+					"filename": "011",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/app/public/dist/client/assets/attacks/PRESENT.json
+++ b/app/public/dist/client/assets/attacks/PRESENT.json
@@ -1,461 +1,461 @@
 {
-	"textures": [
-		{
-			"image": "PRESENT.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 316,
-				"h": 125
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "024",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 4,
-						"y": 7,
-						"w": 53,
-						"h": 58
-					},
-					"frame": {
-						"x": 1,
-						"y": 1,
-						"w": 53,
-						"h": 58
-					}
-				},
-				{
-					"filename": "017",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 5,
-						"y": 17,
-						"w": 56,
-						"h": 46
-					},
-					"frame": {
-						"x": 56,
-						"y": 1,
-						"w": 56,
-						"h": 46
-					}
-				},
-				{
-					"filename": "021",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 12,
-						"y": 11,
-						"w": 40,
-						"h": 60
-					},
-					"frame": {
-						"x": 1,
-						"y": 61,
-						"w": 40,
-						"h": 60
-					}
-				},
-				{
-					"filename": "018",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 8,
-						"y": 14,
-						"w": 52,
-						"h": 44
-					},
-					"frame": {
-						"x": 114,
-						"y": 1,
-						"w": 52,
-						"h": 44
-					}
-				},
-				{
-					"filename": "023",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 26,
-						"w": 54,
-						"h": 41
-					},
-					"frame": {
-						"x": 168,
-						"y": 1,
-						"w": 54,
-						"h": 41
-					}
-				},
-				{
-					"filename": "019",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 1,
-						"y": 18,
-						"w": 54,
-						"h": 37
-					},
-					"frame": {
-						"x": 224,
-						"y": 1,
-						"w": 54,
-						"h": 37
-					}
-				},
-				{
-					"filename": "026",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 8,
-						"y": 13,
-						"w": 35,
-						"h": 48
-					},
-					"frame": {
-						"x": 280,
-						"y": 1,
-						"w": 35,
-						"h": 48
-					}
-				},
-				{
-					"filename": "022",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 17,
-						"y": 16,
-						"w": 47,
-						"h": 53
-					},
-					"frame": {
-						"x": 43,
-						"y": 61,
-						"w": 47,
-						"h": 53
-					}
-				},
-				{
-					"filename": "020",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 6,
-						"y": 2,
-						"w": 45,
-						"h": 52
-					},
-					"frame": {
-						"x": 92,
-						"y": 49,
-						"w": 45,
-						"h": 52
-					}
-				},
-				{
-					"filename": "012",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 12,
-						"y": 14,
-						"w": 42,
-						"h": 44
-					},
-					"frame": {
-						"x": 139,
-						"y": 47,
-						"w": 42,
-						"h": 44
-					}
-				},
-				{
-					"filename": "014",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 12,
-						"y": 14,
-						"w": 42,
-						"h": 44
-					},
-					"frame": {
-						"x": 183,
-						"y": 44,
-						"w": 42,
-						"h": 44
-					}
-				},
-				{
-					"filename": "006",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 14,
-						"y": 21,
-						"w": 42,
-						"h": 34
-					},
-					"frame": {
-						"x": 183,
-						"y": 90,
-						"w": 42,
-						"h": 34
-					}
-				},
-				{
-					"filename": "010",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 11,
-						"y": 15,
-						"w": 45,
-						"h": 42
-					},
-					"frame": {
-						"x": 227,
-						"y": 40,
-						"w": 45,
-						"h": 42
-					}
-				},
-				{
-					"filename": "008",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 11,
-						"y": 17,
-						"w": 46,
-						"h": 40
-					},
-					"frame": {
-						"x": 227,
-						"y": 84,
-						"w": 46,
-						"h": 40
-					}
-				},
-				{
-					"filename": "004",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 18,
-						"y": 25,
-						"w": 32,
-						"h": 27
-					},
-					"frame": {
-						"x": 274,
-						"y": 51,
-						"w": 32,
-						"h": 27
-					}
-				},
-				{
-					"filename": "028",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 12,
-						"y": 16,
-						"w": 33,
-						"h": 39
-					},
-					"frame": {
-						"x": 275,
-						"y": 80,
-						"w": 33,
-						"h": 39
-					}
-				},
-				{
-					"filename": "002",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 23,
-						"y": 30,
-						"w": 22,
-						"h": 18
-					},
-					"frame": {
-						"x": 92,
-						"y": 103,
-						"w": 22,
-						"h": 18
-					}
-				},
-				{
-					"filename": "030",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 19,
-						"y": 25,
-						"w": 24,
-						"h": 29
-					},
-					"frame": {
-						"x": 139,
-						"y": 93,
-						"w": 24,
-						"h": 29
-					}
-				},
-				{
-					"filename": "000",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 26,
-						"y": 35,
-						"w": 13,
-						"h": 13
-					},
-					"frame": {
-						"x": 165,
-						"y": 93,
-						"w": 13,
-						"h": 13
-					}
-				},
-				{
-					"filename": "016",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 41,
-						"y": 45,
-						"w": 13,
-						"h": 13
-					},
-					"frame": {
-						"x": 165,
-						"y": 93,
-						"w": 13,
-						"h": 13
-					}
-				},
-				{
-					"filename": "032",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 72
-					},
-					"spriteSourceSize": {
-						"x": 26,
-						"y": 35,
-						"w": 12,
-						"h": 12
-					},
-					"frame": {
-						"x": 116,
-						"y": 103,
-						"w": 12,
-						"h": 12
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:4934aa9719bd5431c64f724cae2b2580:73567bf27326f91b4767192ae7d04e1e:7f496a8843083020391b2b1ce1e02688$"
-	}
+  "textures": [
+    {
+      "image": "PRESENT.png",
+      "format": "RGBA8888",
+      "size": {
+        "w": 316,
+        "h": 125
+      },
+      "scale": 1,
+      "frames": [
+        {
+          "filename": "016",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 4,
+            "y": 7,
+            "w": 53,
+            "h": 58
+          },
+          "frame": {
+            "x": 1,
+            "y": 1,
+            "w": 53,
+            "h": 58
+          }
+        },
+        {
+          "filename": "009",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 5,
+            "y": 17,
+            "w": 56,
+            "h": 46
+          },
+          "frame": {
+            "x": 56,
+            "y": 1,
+            "w": 56,
+            "h": 46
+          }
+        },
+        {
+          "filename": "013",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 12,
+            "y": 11,
+            "w": 40,
+            "h": 60
+          },
+          "frame": {
+            "x": 1,
+            "y": 61,
+            "w": 40,
+            "h": 60
+          }
+        },
+        {
+          "filename": "010",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 8,
+            "y": 14,
+            "w": 52,
+            "h": 44
+          },
+          "frame": {
+            "x": 114,
+            "y": 1,
+            "w": 52,
+            "h": 44
+          }
+        },
+        {
+          "filename": "015",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 26,
+            "w": 54,
+            "h": 41
+          },
+          "frame": {
+            "x": 168,
+            "y": 1,
+            "w": 54,
+            "h": 41
+          }
+        },
+        {
+          "filename": "011",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 1,
+            "y": 18,
+            "w": 54,
+            "h": 37
+          },
+          "frame": {
+            "x": 224,
+            "y": 1,
+            "w": 54,
+            "h": 37
+          }
+        },
+        {
+          "filename": "017",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 8,
+            "y": 13,
+            "w": 35,
+            "h": 48
+          },
+          "frame": {
+            "x": 280,
+            "y": 1,
+            "w": 35,
+            "h": 48
+          }
+        },
+        {
+          "filename": "014",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 17,
+            "y": 16,
+            "w": 47,
+            "h": 53
+          },
+          "frame": {
+            "x": 43,
+            "y": 61,
+            "w": 47,
+            "h": 53
+          }
+        },
+        {
+          "filename": "012",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 6,
+            "y": 2,
+            "w": 45,
+            "h": 52
+          },
+          "frame": {
+            "x": 92,
+            "y": 49,
+            "w": 45,
+            "h": 52
+          }
+        },
+        {
+          "filename": "006",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 12,
+            "y": 14,
+            "w": 42,
+            "h": 44
+          },
+          "frame": {
+            "x": 139,
+            "y": 47,
+            "w": 42,
+            "h": 44
+          }
+        },
+        {
+          "filename": "007",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 12,
+            "y": 14,
+            "w": 42,
+            "h": 44
+          },
+          "frame": {
+            "x": 183,
+            "y": 44,
+            "w": 42,
+            "h": 44
+          }
+        },
+        {
+          "filename": "003",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 14,
+            "y": 21,
+            "w": 42,
+            "h": 34
+          },
+          "frame": {
+            "x": 183,
+            "y": 90,
+            "w": 42,
+            "h": 34
+          }
+        },
+        {
+          "filename": "005",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 11,
+            "y": 15,
+            "w": 45,
+            "h": 42
+          },
+          "frame": {
+            "x": 227,
+            "y": 40,
+            "w": 45,
+            "h": 42
+          }
+        },
+        {
+          "filename": "004",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 11,
+            "y": 17,
+            "w": 46,
+            "h": 40
+          },
+          "frame": {
+            "x": 227,
+            "y": 84,
+            "w": 46,
+            "h": 40
+          }
+        },
+        {
+          "filename": "002",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 18,
+            "y": 25,
+            "w": 32,
+            "h": 27
+          },
+          "frame": {
+            "x": 274,
+            "y": 51,
+            "w": 32,
+            "h": 27
+          }
+        },
+        {
+          "filename": "018",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 12,
+            "y": 16,
+            "w": 33,
+            "h": 39
+          },
+          "frame": {
+            "x": 275,
+            "y": 80,
+            "w": 33,
+            "h": 39
+          }
+        },
+        {
+          "filename": "001",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 23,
+            "y": 30,
+            "w": 22,
+            "h": 18
+          },
+          "frame": {
+            "x": 92,
+            "y": 103,
+            "w": 22,
+            "h": 18
+          }
+        },
+        {
+          "filename": "019",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 19,
+            "y": 25,
+            "w": 24,
+            "h": 29
+          },
+          "frame": {
+            "x": 139,
+            "y": 93,
+            "w": 24,
+            "h": 29
+          }
+        },
+        {
+          "filename": "000",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 26,
+            "y": 35,
+            "w": 13,
+            "h": 13
+          },
+          "frame": {
+            "x": 165,
+            "y": 93,
+            "w": 13,
+            "h": 13
+          }
+        },
+        {
+          "filename": "008",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 41,
+            "y": 45,
+            "w": 13,
+            "h": 13
+          },
+          "frame": {
+            "x": 165,
+            "y": 93,
+            "w": 13,
+            "h": 13
+          }
+        },
+        {
+          "filename": "020",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 72
+          },
+          "spriteSourceSize": {
+            "x": 26,
+            "y": 35,
+            "w": 12,
+            "h": 12
+          },
+          "frame": {
+            "x": 116,
+            "y": 103,
+            "w": 12,
+            "h": 12
+          }
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "app": "https://www.codeandweb.com/texturepacker",
+    "version": "3.0",
+    "smartupdate": "$TexturePacker:SmartUpdate:4934aa9719bd5431c64f724cae2b2580:73567bf27326f91b4767192ae7d04e1e:7f496a8843083020391b2b1ce1e02688$"
+  }
 }

--- a/app/public/dist/client/assets/attacks/ROAR_OF_TIME.json
+++ b/app/public/dist/client/assets/attacks/ROAR_OF_TIME.json
@@ -10,7 +10,7 @@
 			"scale": 1,
 			"frames": [
 				{
-					"filename": "027",
+					"filename": "026",
 					"rotated": false,
 					"trimmed": false,
 					"sourceSize": {
@@ -31,7 +31,7 @@
 					}
 				},
 				{
-					"filename": "028",
+					"filename": "027",
 					"rotated": false,
 					"trimmed": false,
 					"sourceSize": {
@@ -52,7 +52,7 @@
 					}
 				},
 				{
-					"filename": "026",
+					"filename": "025",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -73,7 +73,7 @@
 					}
 				},
 				{
-					"filename": "021",
+					"filename": "020",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -115,7 +115,7 @@
 					}
 				},
 				{
-					"filename": "025",
+					"filename": "024",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -136,7 +136,7 @@
 					}
 				},
 				{
-					"filename": "022",
+					"filename": "021",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -157,7 +157,7 @@
 					}
 				},
 				{
-					"filename": "024",
+					"filename": "023",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -241,7 +241,7 @@
 					}
 				},
 				{
-					"filename": "023",
+					"filename": "022",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -283,7 +283,7 @@
 					}
 				},
 				{
-					"filename": "020",
+					"filename": "019",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -577,7 +577,7 @@
 					}
 				},
 				{
-					"filename": "019",
+					"filename": "018",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/app/public/dist/client/assets/attacks/SHADOW_BALL.json
+++ b/app/public/dist/client/assets/attacks/SHADOW_BALL.json
@@ -1,860 +1,860 @@
 {
-	"textures": [
-		{
-			"image": "SHADOW_BALL.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 504,
-				"h": 128
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "010",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 64,
-						"h": 64
-					},
-					"frame": {
-						"x": 1,
-						"y": 1,
-						"w": 64,
-						"h": 64
-					}
-				},
-				{
-					"filename": "007",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 2,
-						"w": 60,
-						"h": 60
-					},
-					"frame": {
-						"x": 1,
-						"y": 67,
-						"w": 60,
-						"h": 60
-					}
-				},
-				{
-					"filename": "013",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 64,
-						"h": 64
-					},
-					"frame": {
-						"x": 67,
-						"y": 1,
-						"w": 64,
-						"h": 64
-					}
-				},
-				{
-					"filename": "008",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 1,
-						"y": 1,
-						"w": 62,
-						"h": 62
-					},
-					"frame": {
-						"x": 133,
-						"y": 1,
-						"w": 62,
-						"h": 62
-					}
-				},
-				{
-					"filename": "006",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 5,
-						"y": 5,
-						"w": 54,
-						"h": 54
-					},
-					"frame": {
-						"x": 63,
-						"y": 67,
-						"w": 54,
-						"h": 54
-					}
-				},
-				{
-					"filename": "005",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 6,
-						"y": 6,
-						"w": 52,
-						"h": 52
-					},
-					"frame": {
-						"x": 197,
-						"y": 1,
-						"w": 52,
-						"h": 52
-					}
-				},
-				{
-					"filename": "009",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 251,
-						"y": 1,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "011",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 303,
-						"y": 1,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "012",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 303,
-						"y": 1,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "014",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 303,
-						"y": 1,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "015",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 355,
-						"y": 1,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "016",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 355,
-						"y": 1,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "017",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 355,
-						"y": 1,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "018",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 355,
-						"y": 1,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "019",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 407,
-						"y": 1,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "020",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 407,
-						"y": 1,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "004",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 10,
-						"w": 44,
-						"h": 44
-					},
-					"frame": {
-						"x": 459,
-						"y": 1,
-						"w": 44,
-						"h": 44
-					}
-				},
-				{
-					"filename": "026",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 10,
-						"w": 44,
-						"h": 44
-					},
-					"frame": {
-						"x": 459,
-						"y": 1,
-						"w": 44,
-						"h": 44
-					}
-				},
-				{
-					"filename": "021",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 119,
-						"y": 67,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "022",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 119,
-						"y": 67,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "023",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 7,
-						"w": 50,
-						"h": 50
-					},
-					"frame": {
-						"x": 171,
-						"y": 65,
-						"w": 50,
-						"h": 50
-					}
-				},
-				{
-					"filename": "024",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 8,
-						"y": 8,
-						"w": 48,
-						"h": 48
-					},
-					"frame": {
-						"x": 223,
-						"y": 55,
-						"w": 48,
-						"h": 48
-					}
-				},
-				{
-					"filename": "025",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 9,
-						"y": 9,
-						"w": 46,
-						"h": 46
-					},
-					"frame": {
-						"x": 273,
-						"y": 53,
-						"w": 46,
-						"h": 46
-					}
-				},
-				{
-					"filename": "003",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 11,
-						"y": 11,
-						"w": 42,
-						"h": 42
-					},
-					"frame": {
-						"x": 321,
-						"y": 53,
-						"w": 42,
-						"h": 42
-					}
-				},
-				{
-					"filename": "027",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 11,
-						"y": 11,
-						"w": 42,
-						"h": 42
-					},
-					"frame": {
-						"x": 321,
-						"y": 53,
-						"w": 42,
-						"h": 42
-					}
-				},
-				{
-					"filename": "002",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 13,
-						"w": 38,
-						"h": 38
-					},
-					"frame": {
-						"x": 365,
-						"y": 53,
-						"w": 38,
-						"h": 38
-					}
-				},
-				{
-					"filename": "028",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 13,
-						"w": 38,
-						"h": 38
-					},
-					"frame": {
-						"x": 365,
-						"y": 53,
-						"w": 38,
-						"h": 38
-					}
-				},
-				{
-					"filename": "001",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 15,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 365,
-						"y": 93,
-						"w": 34,
-						"h": 34
-					}
-				},
-				{
-					"filename": "032",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 15,
-						"w": 34,
-						"h": 34
-					},
-					"frame": {
-						"x": 365,
-						"y": 93,
-						"w": 34,
-						"h": 34
-					}
-				},
-				{
-					"filename": "030",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 14,
-						"y": 14,
-						"w": 36,
-						"h": 36
-					},
-					"frame": {
-						"x": 405,
-						"y": 53,
-						"w": 36,
-						"h": 36
-					}
-				},
-				{
-					"filename": "000",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 19,
-						"y": 19,
-						"w": 26,
-						"h": 26
-					},
-					"frame": {
-						"x": 273,
-						"y": 101,
-						"w": 26,
-						"h": 26
-					}
-				},
-				{
-					"filename": "034",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 19,
-						"y": 19,
-						"w": 26,
-						"h": 26
-					},
-					"frame": {
-						"x": 301,
-						"y": 101,
-						"w": 26,
-						"h": 26
-					}
-				},
-				{
-					"filename": "039",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 19,
-						"y": 17,
-						"w": 25,
-						"h": 29
-					},
-					"frame": {
-						"x": 329,
-						"y": 97,
-						"w": 25,
-						"h": 29
-					}
-				},
-				{
-					"filename": "041",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 18,
-						"y": 16,
-						"w": 27,
-						"h": 31
-					},
-					"frame": {
-						"x": 443,
-						"y": 53,
-						"w": 27,
-						"h": 31
-					}
-				},
-				{
-					"filename": "043",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 18,
-						"y": 16,
-						"w": 27,
-						"h": 31
-					},
-					"frame": {
-						"x": 472,
-						"y": 47,
-						"w": 27,
-						"h": 31
-					}
-				},
-				{
-					"filename": "040",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 19,
-						"y": 17,
-						"w": 25,
-						"h": 29
-					},
-					"frame": {
-						"x": 401,
-						"y": 93,
-						"w": 25,
-						"h": 29
-					}
-				},
-				{
-					"filename": "037",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 20,
-						"y": 17,
-						"w": 23,
-						"h": 28
-					},
-					"frame": {
-						"x": 428,
-						"y": 91,
-						"w": 23,
-						"h": 28
-					}
-				},
-				{
-					"filename": "038",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 20,
-						"y": 18,
-						"w": 23,
-						"h": 27
-					},
-					"frame": {
-						"x": 453,
-						"y": 86,
-						"w": 23,
-						"h": 27
-					}
-				},
-				{
-					"filename": "036",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 21,
-						"y": 18,
-						"w": 21,
-						"h": 26
-					},
-					"frame": {
-						"x": 478,
-						"y": 80,
-						"w": 21,
-						"h": 26
-					}
-				},
-				{
-					"filename": "035",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 24,
-						"y": 26,
-						"w": 15,
-						"h": 15
-					},
-					"frame": {
-						"x": 223,
-						"y": 105,
-						"w": 15,
-						"h": 15
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:ad7b387c5939b9c935d4b46d3069ae70:f603bf26a063788bf313e4b7a507bb3d:016833ed4536083c6738157ecd347529$"
-	}
+  "textures": [
+    {
+      "image": "SHADOW_BALL.png",
+      "format": "RGBA8888",
+      "size": {
+        "w": 504,
+        "h": 128
+      },
+      "scale": 1,
+      "frames": [
+        {
+          "filename": "010",
+          "rotated": false,
+          "trimmed": false,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 0,
+            "y": 0,
+            "w": 64,
+            "h": 64
+          },
+          "frame": {
+            "x": 1,
+            "y": 1,
+            "w": 64,
+            "h": 64
+          }
+        },
+        {
+          "filename": "007",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 2,
+            "w": 60,
+            "h": 60
+          },
+          "frame": {
+            "x": 1,
+            "y": 67,
+            "w": 60,
+            "h": 60
+          }
+        },
+        {
+          "filename": "013",
+          "rotated": false,
+          "trimmed": false,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 0,
+            "y": 0,
+            "w": 64,
+            "h": 64
+          },
+          "frame": {
+            "x": 67,
+            "y": 1,
+            "w": 64,
+            "h": 64
+          }
+        },
+        {
+          "filename": "008",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 1,
+            "y": 1,
+            "w": 62,
+            "h": 62
+          },
+          "frame": {
+            "x": 133,
+            "y": 1,
+            "w": 62,
+            "h": 62
+          }
+        },
+        {
+          "filename": "006",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 5,
+            "y": 5,
+            "w": 54,
+            "h": 54
+          },
+          "frame": {
+            "x": 63,
+            "y": 67,
+            "w": 54,
+            "h": 54
+          }
+        },
+        {
+          "filename": "005",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 6,
+            "y": 6,
+            "w": 52,
+            "h": 52
+          },
+          "frame": {
+            "x": 197,
+            "y": 1,
+            "w": 52,
+            "h": 52
+          }
+        },
+        {
+          "filename": "009",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 251,
+            "y": 1,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "011",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 303,
+            "y": 1,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "012",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 303,
+            "y": 1,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "014",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 303,
+            "y": 1,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "015",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 355,
+            "y": 1,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "016",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 355,
+            "y": 1,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "017",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 355,
+            "y": 1,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "018",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 355,
+            "y": 1,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "019",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 407,
+            "y": 1,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "020",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 407,
+            "y": 1,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "004",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 10,
+            "y": 10,
+            "w": 44,
+            "h": 44
+          },
+          "frame": {
+            "x": 459,
+            "y": 1,
+            "w": 44,
+            "h": 44
+          }
+        },
+        {
+          "filename": "026",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 10,
+            "y": 10,
+            "w": 44,
+            "h": 44
+          },
+          "frame": {
+            "x": 459,
+            "y": 1,
+            "w": 44,
+            "h": 44
+          }
+        },
+        {
+          "filename": "021",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 119,
+            "y": 67,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "022",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 119,
+            "y": 67,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "023",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 7,
+            "w": 50,
+            "h": 50
+          },
+          "frame": {
+            "x": 171,
+            "y": 65,
+            "w": 50,
+            "h": 50
+          }
+        },
+        {
+          "filename": "024",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 8,
+            "y": 8,
+            "w": 48,
+            "h": 48
+          },
+          "frame": {
+            "x": 223,
+            "y": 55,
+            "w": 48,
+            "h": 48
+          }
+        },
+        {
+          "filename": "025",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 9,
+            "y": 9,
+            "w": 46,
+            "h": 46
+          },
+          "frame": {
+            "x": 273,
+            "y": 53,
+            "w": 46,
+            "h": 46
+          }
+        },
+        {
+          "filename": "003",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 11,
+            "y": 11,
+            "w": 42,
+            "h": 42
+          },
+          "frame": {
+            "x": 321,
+            "y": 53,
+            "w": 42,
+            "h": 42
+          }
+        },
+        {
+          "filename": "027",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 11,
+            "y": 11,
+            "w": 42,
+            "h": 42
+          },
+          "frame": {
+            "x": 321,
+            "y": 53,
+            "w": 42,
+            "h": 42
+          }
+        },
+        {
+          "filename": "002",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 13,
+            "w": 38,
+            "h": 38
+          },
+          "frame": {
+            "x": 365,
+            "y": 53,
+            "w": 38,
+            "h": 38
+          }
+        },
+        {
+          "filename": "028",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 13,
+            "w": 38,
+            "h": 38
+          },
+          "frame": {
+            "x": 365,
+            "y": 53,
+            "w": 38,
+            "h": 38
+          }
+        },
+        {
+          "filename": "001",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 15,
+            "y": 15,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 365,
+            "y": 93,
+            "w": 34,
+            "h": 34
+          }
+        },
+        {
+          "filename": "030",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 15,
+            "y": 15,
+            "w": 34,
+            "h": 34
+          },
+          "frame": {
+            "x": 365,
+            "y": 93,
+            "w": 34,
+            "h": 34
+          }
+        },
+        {
+          "filename": "029",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 14,
+            "y": 14,
+            "w": 36,
+            "h": 36
+          },
+          "frame": {
+            "x": 405,
+            "y": 53,
+            "w": 36,
+            "h": 36
+          }
+        },
+        {
+          "filename": "000",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 19,
+            "y": 19,
+            "w": 26,
+            "h": 26
+          },
+          "frame": {
+            "x": 273,
+            "y": 101,
+            "w": 26,
+            "h": 26
+          }
+        },
+        {
+          "filename": "031",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 19,
+            "y": 19,
+            "w": 26,
+            "h": 26
+          },
+          "frame": {
+            "x": 301,
+            "y": 101,
+            "w": 26,
+            "h": 26
+          }
+        },
+        {
+          "filename": "036",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 19,
+            "y": 17,
+            "w": 25,
+            "h": 29
+          },
+          "frame": {
+            "x": 329,
+            "y": 97,
+            "w": 25,
+            "h": 29
+          }
+        },
+        {
+          "filename": "038",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 18,
+            "y": 16,
+            "w": 27,
+            "h": 31
+          },
+          "frame": {
+            "x": 443,
+            "y": 53,
+            "w": 27,
+            "h": 31
+          }
+        },
+        {
+          "filename": "039",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 18,
+            "y": 16,
+            "w": 27,
+            "h": 31
+          },
+          "frame": {
+            "x": 472,
+            "y": 47,
+            "w": 27,
+            "h": 31
+          }
+        },
+        {
+          "filename": "037",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 19,
+            "y": 17,
+            "w": 25,
+            "h": 29
+          },
+          "frame": {
+            "x": 401,
+            "y": 93,
+            "w": 25,
+            "h": 29
+          }
+        },
+        {
+          "filename": "034",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 20,
+            "y": 17,
+            "w": 23,
+            "h": 28
+          },
+          "frame": {
+            "x": 428,
+            "y": 91,
+            "w": 23,
+            "h": 28
+          }
+        },
+        {
+          "filename": "035",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 20,
+            "y": 18,
+            "w": 23,
+            "h": 27
+          },
+          "frame": {
+            "x": 453,
+            "y": 86,
+            "w": 23,
+            "h": 27
+          }
+        },
+        {
+          "filename": "033",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 21,
+            "y": 18,
+            "w": 21,
+            "h": 26
+          },
+          "frame": {
+            "x": 478,
+            "y": 80,
+            "w": 21,
+            "h": 26
+          }
+        },
+        {
+          "filename": "032",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 64,
+            "h": 64
+          },
+          "spriteSourceSize": {
+            "x": 24,
+            "y": 26,
+            "w": 15,
+            "h": 15
+          },
+          "frame": {
+            "x": 223,
+            "y": 105,
+            "w": 15,
+            "h": 15
+          }
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "app": "https://www.codeandweb.com/texturepacker",
+    "version": "3.0",
+    "smartupdate": "$TexturePacker:SmartUpdate:ad7b387c5939b9c935d4b46d3069ae70:f603bf26a063788bf313e4b7a507bb3d:016833ed4536083c6738157ecd347529$"
+  }
 }

--- a/app/public/dist/client/assets/attacks/SHADOW_SNEAK.json
+++ b/app/public/dist/client/assets/attacks/SHADOW_SNEAK.json
@@ -60,7 +60,7 @@
 					}
 				},
 				{
-					"filename": "021",
+					"filename": "018",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -85,7 +85,7 @@
 					}
 				},
 				{
-					"filename": "029",
+					"filename": "026",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -110,7 +110,7 @@
 					}
 				},
 				{
-					"filename": "011",
+					"filename": "010",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -185,7 +185,7 @@
 					}
 				},
 				{
-					"filename": "013",
+					"filename": "011",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -210,7 +210,7 @@
 					}
 				},
 				{
-					"filename": "017",
+					"filename": "014",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -235,7 +235,7 @@
 					}
 				},
 				{
-					"filename": "025",
+					"filename": "022",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -360,7 +360,7 @@
 					}
 				},
 				{
-					"filename": "026",
+					"filename": "023",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -385,7 +385,7 @@
 					}
 				},
 				{
-					"filename": "022",
+					"filename": "019",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -410,7 +410,7 @@
 					}
 				},
 				{
-					"filename": "028",
+					"filename": "025",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -435,7 +435,7 @@
 					}
 				},
 				{
-					"filename": "024",
+					"filename": "021",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -460,7 +460,7 @@
 					}
 				},
 				{
-					"filename": "030",
+					"filename": "027",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -485,7 +485,7 @@
 					}
 				},
 				{
-					"filename": "032",
+					"filename": "029",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -510,7 +510,7 @@
 					}
 				},
 				{
-					"filename": "015",
+					"filename": "012",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -535,7 +535,7 @@
 					}
 				},
 				{
-					"filename": "016",
+					"filename": "013",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -585,7 +585,7 @@
 					}
 				},
 				{
-					"filename": "019",
+					"filename": "016",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -610,7 +610,7 @@
 					}
 				},
 				{
-					"filename": "020",
+					"filename": "017",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -635,7 +635,7 @@
 					}
 				},
 				{
-					"filename": "027",
+					"filename": "024",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -660,7 +660,7 @@
 					}
 				},
 				{
-					"filename": "033",
+					"filename": "030",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -685,7 +685,7 @@
 					}
 				},
 				{
-					"filename": "018",
+					"filename": "015",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -710,7 +710,7 @@
 					}
 				},
 				{
-					"filename": "023",
+					"filename": "020",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -735,7 +735,7 @@
 					}
 				},
 				{
-					"filename": "031",
+					"filename": "028",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -760,7 +760,7 @@
 					}
 				},
 				{
-					"filename": "034",
+					"filename": "031",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/app/public/dist/client/assets/attacks/SLASHING_CLAW.json
+++ b/app/public/dist/client/assets/attacks/SLASHING_CLAW.json
@@ -10,7 +10,7 @@
 			"scale": 1,
 			"frames": [
 				{
-					"filename": "014",
+					"filename": "013",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/app/public/dist/client/assets/attacks/SOFT_BOILED.json
+++ b/app/public/dist/client/assets/attacks/SOFT_BOILED.json
@@ -262,6 +262,27 @@
 					}
 				},
 				{
+					"filename": "025",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 64,
+						"h": 64
+					},
+					"spriteSourceSize": {
+						"x": 25,
+						"y": 15,
+						"w": 14,
+						"h": 30
+					},
+					"frame": {
+						"x": 31,
+						"y": 412,
+						"w": 14,
+						"h": 30
+					}
+				},
+				{
 					"filename": "026",
 					"rotated": false,
 					"trimmed": true,
@@ -283,49 +304,28 @@
 					}
 				},
 				{
+					"filename": "027",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 64,
+						"h": 64
+					},
+					"spriteSourceSize": {
+						"x": 25,
+						"y": 15,
+						"w": 14,
+						"h": 30
+					},
+					"frame": {
+						"x": 31,
+						"y": 412,
+						"w": 14,
+						"h": 30
+					}
+				},
+				{
 					"filename": "028",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 25,
-						"y": 15,
-						"w": 14,
-						"h": 30
-					},
-					"frame": {
-						"x": 31,
-						"y": 412,
-						"w": 14,
-						"h": 30
-					}
-				},
-				{
-					"filename": "030",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 64,
-						"h": 64
-					},
-					"spriteSourceSize": {
-						"x": 25,
-						"y": 15,
-						"w": 14,
-						"h": 30
-					},
-					"frame": {
-						"x": 31,
-						"y": 412,
-						"w": 14,
-						"h": 30
-					}
-				},
-				{
-					"filename": "032",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/app/public/dist/client/assets/attacks/SONG_OF_DESIRE.json
+++ b/app/public/dist/client/assets/attacks/SONG_OF_DESIRE.json
@@ -1,902 +1,902 @@
 {
-	"textures": [
-		{
-			"image": "SONG_OF_DESIRE.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 61,
-				"h": 250
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "039",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 2,
-						"y": 5,
-						"w": 38,
-						"h": 18
-					},
-					"frame": {
-						"x": 1,
-						"y": 1,
-						"w": 38,
-						"h": 18
-					}
-				},
-				{
-					"filename": "025",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 12,
-						"y": 15,
-						"w": 19,
-						"h": 16
-					},
-					"frame": {
-						"x": 41,
-						"y": 1,
-						"w": 19,
-						"h": 16
-					}
-				},
-				{
-					"filename": "002",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 17,
-						"w": 18,
-						"h": 22
-					},
-					"frame": {
-						"x": 41,
-						"y": 19,
-						"w": 18,
-						"h": 22
-					}
-				},
-				{
-					"filename": "005",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 17,
-						"w": 18,
-						"h": 22
-					},
-					"frame": {
-						"x": 41,
-						"y": 19,
-						"w": 18,
-						"h": 22
-					}
-				},
-				{
-					"filename": "007",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 17,
-						"w": 18,
-						"h": 22
-					},
-					"frame": {
-						"x": 41,
-						"y": 19,
-						"w": 18,
-						"h": 22
-					}
-				},
-				{
-					"filename": "009",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 17,
-						"w": 18,
-						"h": 22
-					},
-					"frame": {
-						"x": 41,
-						"y": 19,
-						"w": 18,
-						"h": 22
-					}
-				},
-				{
-					"filename": "011",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 17,
-						"w": 18,
-						"h": 22
-					},
-					"frame": {
-						"x": 41,
-						"y": 19,
-						"w": 18,
-						"h": 22
-					}
-				},
-				{
-					"filename": "013",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 17,
-						"w": 18,
-						"h": 22
-					},
-					"frame": {
-						"x": 41,
-						"y": 19,
-						"w": 18,
-						"h": 22
-					}
-				},
-				{
-					"filename": "015",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 17,
-						"w": 18,
-						"h": 22
-					},
-					"frame": {
-						"x": 41,
-						"y": 19,
-						"w": 18,
-						"h": 22
-					}
-				},
-				{
-					"filename": "017",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 17,
-						"w": 18,
-						"h": 22
-					},
-					"frame": {
-						"x": 41,
-						"y": 19,
-						"w": 18,
-						"h": 22
-					}
-				},
-				{
-					"filename": "038",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 3,
-						"y": 6,
-						"w": 35,
-						"h": 18
-					},
-					"frame": {
-						"x": 1,
-						"y": 21,
-						"w": 35,
-						"h": 18
-					}
-				},
-				{
-					"filename": "037",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 4,
-						"y": 7,
-						"w": 33,
-						"h": 18
-					},
-					"frame": {
-						"x": 1,
-						"y": 41,
-						"w": 33,
-						"h": 18
-					}
-				},
-				{
-					"filename": "021",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 12,
-						"y": 17,
-						"w": 24,
-						"h": 22
-					},
-					"frame": {
-						"x": 36,
-						"y": 43,
-						"w": 24,
-						"h": 22
-					}
-				},
-				{
-					"filename": "036",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 6,
-						"y": 8,
-						"w": 31,
-						"h": 18
-					},
-					"frame": {
-						"x": 1,
-						"y": 61,
-						"w": 31,
-						"h": 18
-					}
-				},
-				{
-					"filename": "033",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 3,
-						"w": 26,
-						"h": 25
-					},
-					"frame": {
-						"x": 34,
-						"y": 67,
-						"w": 26,
-						"h": 25
-					}
-				},
-				{
-					"filename": "035",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 1,
-						"w": 29,
-						"h": 25
-					},
-					"frame": {
-						"x": 1,
-						"y": 81,
-						"w": 29,
-						"h": 25
-					}
-				},
-				{
-					"filename": "034",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 9,
-						"y": 2,
-						"w": 27,
-						"h": 25
-					},
-					"frame": {
-						"x": 32,
-						"y": 94,
-						"w": 27,
-						"h": 25
-					}
-				},
-				{
-					"filename": "030",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 11,
-						"y": 7,
-						"w": 26,
-						"h": 23
-					},
-					"frame": {
-						"x": 1,
-						"y": 108,
-						"w": 26,
-						"h": 23
-					}
-				},
-				{
-					"filename": "031",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 11,
-						"y": 6,
-						"w": 26,
-						"h": 23
-					},
-					"frame": {
-						"x": 29,
-						"y": 121,
-						"w": 26,
-						"h": 23
-					}
-				},
-				{
-					"filename": "032",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 5,
-						"w": 26,
-						"h": 23
-					},
-					"frame": {
-						"x": 1,
-						"y": 133,
-						"w": 26,
-						"h": 23
-					}
-				},
-				{
-					"filename": "029",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 11,
-						"y": 9,
-						"w": 24,
-						"h": 22
-					},
-					"frame": {
-						"x": 29,
-						"y": 146,
-						"w": 24,
-						"h": 22
-					}
-				},
-				{
-					"filename": "000",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 17,
-						"w": 23,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 158,
-						"w": 23,
-						"h": 22
-					}
-				},
-				{
-					"filename": "004",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 17,
-						"w": 23,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 158,
-						"w": 23,
-						"h": 22
-					}
-				},
-				{
-					"filename": "006",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 17,
-						"w": 23,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 158,
-						"w": 23,
-						"h": 22
-					}
-				},
-				{
-					"filename": "008",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 17,
-						"w": 23,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 158,
-						"w": 23,
-						"h": 22
-					}
-				},
-				{
-					"filename": "010",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 17,
-						"w": 23,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 158,
-						"w": 23,
-						"h": 22
-					}
-				},
-				{
-					"filename": "012",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 17,
-						"w": 23,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 158,
-						"w": 23,
-						"h": 22
-					}
-				},
-				{
-					"filename": "014",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 17,
-						"w": 23,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 158,
-						"w": 23,
-						"h": 22
-					}
-				},
-				{
-					"filename": "016",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 17,
-						"w": 23,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 158,
-						"w": 23,
-						"h": 22
-					}
-				},
-				{
-					"filename": "018",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 17,
-						"w": 23,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 158,
-						"w": 23,
-						"h": 22
-					}
-				},
-				{
-					"filename": "023",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 17,
-						"w": 23,
-						"h": 22
-					},
-					"frame": {
-						"x": 26,
-						"y": 170,
-						"w": 23,
-						"h": 22
-					}
-				},
-				{
-					"filename": "019",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 11,
-						"y": 17,
-						"w": 22,
-						"h": 22
-					},
-					"frame": {
-						"x": 1,
-						"y": 182,
-						"w": 22,
-						"h": 22
-					}
-				},
-				{
-					"filename": "028",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 11,
-						"y": 10,
-						"w": 22,
-						"h": 21
-					},
-					"frame": {
-						"x": 25,
-						"y": 194,
-						"w": 22,
-						"h": 21
-					}
-				},
-				{
-					"filename": "020",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 19,
-						"y": 25,
-						"w": 11,
-						"h": 8
-					},
-					"frame": {
-						"x": 49,
-						"y": 194,
-						"w": 11,
-						"h": 8
-					}
-				},
-				{
-					"filename": "027",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 12,
-						"w": 21,
-						"h": 21
-					},
-					"frame": {
-						"x": 1,
-						"y": 206,
-						"w": 21,
-						"h": 21
-					}
-				},
-				{
-					"filename": "026",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 14,
-						"w": 20,
-						"h": 20
-					},
-					"frame": {
-						"x": 1,
-						"y": 229,
-						"w": 20,
-						"h": 20
-					}
-				},
-				{
-					"filename": "024",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 14,
-						"y": 17,
-						"w": 17,
-						"h": 14
-					},
-					"frame": {
-						"x": 23,
-						"y": 229,
-						"w": 17,
-						"h": 14
-					}
-				},
-				{
-					"filename": "022",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 20,
-						"y": 21,
-						"w": 13,
-						"h": 10
-					},
-					"frame": {
-						"x": 24,
-						"y": 217,
-						"w": 13,
-						"h": 10
-					}
-				},
-				{
-					"filename": "040",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 24,
-						"y": 8,
-						"w": 17,
-						"h": 14
-					},
-					"frame": {
-						"x": 42,
-						"y": 217,
-						"w": 17,
-						"h": 14
-					}
-				},
-				{
-					"filename": "041",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 26,
-						"y": 7,
-						"w": 17,
-						"h": 14
-					},
-					"frame": {
-						"x": 42,
-						"y": 233,
-						"w": 17,
-						"h": 14
-					}
-				},
-				{
-					"filename": "042",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 27,
-						"y": 6,
-						"w": 17,
-						"h": 14
-					},
-					"frame": {
-						"x": 42,
-						"y": 233,
-						"w": 17,
-						"h": 14
-					}
-				},
-				{
-					"filename": "043",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 48,
-						"h": 40
-					},
-					"spriteSourceSize": {
-						"x": 28,
-						"y": 5,
-						"w": 17,
-						"h": 14
-					},
-					"frame": {
-						"x": 42,
-						"y": 233,
-						"w": 17,
-						"h": 14
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:a9355e3e51996854cddff6e71e679467:da3bb210d21a6c5d9a1a8d812686cae9:5de4914b79c9cf89c17d0eeaf02c5c46$"
-	}
+  "textures": [
+    {
+      "image": "SONG_OF_DESIRE.png",
+      "format": "RGBA8888",
+      "size": {
+        "w": 61,
+        "h": 250
+      },
+      "scale": 1,
+      "frames": [
+        {
+          "filename": "037",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 2,
+            "y": 5,
+            "w": 38,
+            "h": 18
+          },
+          "frame": {
+            "x": 1,
+            "y": 1,
+            "w": 38,
+            "h": 18
+          }
+        },
+        {
+          "filename": "023",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 12,
+            "y": 15,
+            "w": 19,
+            "h": 16
+          },
+          "frame": {
+            "x": 41,
+            "y": 1,
+            "w": 19,
+            "h": 16
+          }
+        },
+        {
+          "filename": "001",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 15,
+            "y": 17,
+            "w": 18,
+            "h": 22
+          },
+          "frame": {
+            "x": 41,
+            "y": 19,
+            "w": 18,
+            "h": 22
+          }
+        },
+        {
+          "filename": "003",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 15,
+            "y": 17,
+            "w": 18,
+            "h": 22
+          },
+          "frame": {
+            "x": 41,
+            "y": 19,
+            "w": 18,
+            "h": 22
+          }
+        },
+        {
+          "filename": "005",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 15,
+            "y": 17,
+            "w": 18,
+            "h": 22
+          },
+          "frame": {
+            "x": 41,
+            "y": 19,
+            "w": 18,
+            "h": 22
+          }
+        },
+        {
+          "filename": "007",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 15,
+            "y": 17,
+            "w": 18,
+            "h": 22
+          },
+          "frame": {
+            "x": 41,
+            "y": 19,
+            "w": 18,
+            "h": 22
+          }
+        },
+        {
+          "filename": "009",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 15,
+            "y": 17,
+            "w": 18,
+            "h": 22
+          },
+          "frame": {
+            "x": 41,
+            "y": 19,
+            "w": 18,
+            "h": 22
+          }
+        },
+        {
+          "filename": "011",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 15,
+            "y": 17,
+            "w": 18,
+            "h": 22
+          },
+          "frame": {
+            "x": 41,
+            "y": 19,
+            "w": 18,
+            "h": 22
+          }
+        },
+        {
+          "filename": "013",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 15,
+            "y": 17,
+            "w": 18,
+            "h": 22
+          },
+          "frame": {
+            "x": 41,
+            "y": 19,
+            "w": 18,
+            "h": 22
+          }
+        },
+        {
+          "filename": "015",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 15,
+            "y": 17,
+            "w": 18,
+            "h": 22
+          },
+          "frame": {
+            "x": 41,
+            "y": 19,
+            "w": 18,
+            "h": 22
+          }
+        },
+        {
+          "filename": "036",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 3,
+            "y": 6,
+            "w": 35,
+            "h": 18
+          },
+          "frame": {
+            "x": 1,
+            "y": 21,
+            "w": 35,
+            "h": 18
+          }
+        },
+        {
+          "filename": "035",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 4,
+            "y": 7,
+            "w": 33,
+            "h": 18
+          },
+          "frame": {
+            "x": 1,
+            "y": 41,
+            "w": 33,
+            "h": 18
+          }
+        },
+        {
+          "filename": "019",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 12,
+            "y": 17,
+            "w": 24,
+            "h": 22
+          },
+          "frame": {
+            "x": 36,
+            "y": 43,
+            "w": 24,
+            "h": 22
+          }
+        },
+        {
+          "filename": "034",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 6,
+            "y": 8,
+            "w": 31,
+            "h": 18
+          },
+          "frame": {
+            "x": 1,
+            "y": 61,
+            "w": 31,
+            "h": 18
+          }
+        },
+        {
+          "filename": "031",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 10,
+            "y": 3,
+            "w": 26,
+            "h": 25
+          },
+          "frame": {
+            "x": 34,
+            "y": 67,
+            "w": 26,
+            "h": 25
+          }
+        },
+        {
+          "filename": "033",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 7,
+            "y": 1,
+            "w": 29,
+            "h": 25
+          },
+          "frame": {
+            "x": 1,
+            "y": 81,
+            "w": 29,
+            "h": 25
+          }
+        },
+        {
+          "filename": "032",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 9,
+            "y": 2,
+            "w": 27,
+            "h": 25
+          },
+          "frame": {
+            "x": 32,
+            "y": 94,
+            "w": 27,
+            "h": 25
+          }
+        },
+        {
+          "filename": "028",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 11,
+            "y": 7,
+            "w": 26,
+            "h": 23
+          },
+          "frame": {
+            "x": 1,
+            "y": 108,
+            "w": 26,
+            "h": 23
+          }
+        },
+        {
+          "filename": "029",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 11,
+            "y": 6,
+            "w": 26,
+            "h": 23
+          },
+          "frame": {
+            "x": 29,
+            "y": 121,
+            "w": 26,
+            "h": 23
+          }
+        },
+        {
+          "filename": "030",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 10,
+            "y": 5,
+            "w": 26,
+            "h": 23
+          },
+          "frame": {
+            "x": 1,
+            "y": 133,
+            "w": 26,
+            "h": 23
+          }
+        },
+        {
+          "filename": "027",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 11,
+            "y": 9,
+            "w": 24,
+            "h": 22
+          },
+          "frame": {
+            "x": 29,
+            "y": 146,
+            "w": 24,
+            "h": 22
+          }
+        },
+        {
+          "filename": "000",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 17,
+            "w": 23,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 158,
+            "w": 23,
+            "h": 22
+          }
+        },
+        {
+          "filename": "002",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 17,
+            "w": 23,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 158,
+            "w": 23,
+            "h": 22
+          }
+        },
+        {
+          "filename": "004",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 17,
+            "w": 23,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 158,
+            "w": 23,
+            "h": 22
+          }
+        },
+        {
+          "filename": "006",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 17,
+            "w": 23,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 158,
+            "w": 23,
+            "h": 22
+          }
+        },
+        {
+          "filename": "008",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 17,
+            "w": 23,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 158,
+            "w": 23,
+            "h": 22
+          }
+        },
+        {
+          "filename": "010",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 17,
+            "w": 23,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 158,
+            "w": 23,
+            "h": 22
+          }
+        },
+        {
+          "filename": "012",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 17,
+            "w": 23,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 158,
+            "w": 23,
+            "h": 22
+          }
+        },
+        {
+          "filename": "014",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 17,
+            "w": 23,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 158,
+            "w": 23,
+            "h": 22
+          }
+        },
+        {
+          "filename": "016",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 17,
+            "w": 23,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 158,
+            "w": 23,
+            "h": 22
+          }
+        },
+        {
+          "filename": "021",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 10,
+            "y": 17,
+            "w": 23,
+            "h": 22
+          },
+          "frame": {
+            "x": 26,
+            "y": 170,
+            "w": 23,
+            "h": 22
+          }
+        },
+        {
+          "filename": "017",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 11,
+            "y": 17,
+            "w": 22,
+            "h": 22
+          },
+          "frame": {
+            "x": 1,
+            "y": 182,
+            "w": 22,
+            "h": 22
+          }
+        },
+        {
+          "filename": "026",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 11,
+            "y": 10,
+            "w": 22,
+            "h": 21
+          },
+          "frame": {
+            "x": 25,
+            "y": 194,
+            "w": 22,
+            "h": 21
+          }
+        },
+        {
+          "filename": "018",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 19,
+            "y": 25,
+            "w": 11,
+            "h": 8
+          },
+          "frame": {
+            "x": 49,
+            "y": 194,
+            "w": 11,
+            "h": 8
+          }
+        },
+        {
+          "filename": "025",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 10,
+            "y": 12,
+            "w": 21,
+            "h": 21
+          },
+          "frame": {
+            "x": 1,
+            "y": 206,
+            "w": 21,
+            "h": 21
+          }
+        },
+        {
+          "filename": "024",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 10,
+            "y": 14,
+            "w": 20,
+            "h": 20
+          },
+          "frame": {
+            "x": 1,
+            "y": 229,
+            "w": 20,
+            "h": 20
+          }
+        },
+        {
+          "filename": "022",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 14,
+            "y": 17,
+            "w": 17,
+            "h": 14
+          },
+          "frame": {
+            "x": 23,
+            "y": 229,
+            "w": 17,
+            "h": 14
+          }
+        },
+        {
+          "filename": "020",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 20,
+            "y": 21,
+            "w": 13,
+            "h": 10
+          },
+          "frame": {
+            "x": 24,
+            "y": 217,
+            "w": 13,
+            "h": 10
+          }
+        },
+        {
+          "filename": "038",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 24,
+            "y": 8,
+            "w": 17,
+            "h": 14
+          },
+          "frame": {
+            "x": 42,
+            "y": 217,
+            "w": 17,
+            "h": 14
+          }
+        },
+        {
+          "filename": "039",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 26,
+            "y": 7,
+            "w": 17,
+            "h": 14
+          },
+          "frame": {
+            "x": 42,
+            "y": 233,
+            "w": 17,
+            "h": 14
+          }
+        },
+        {
+          "filename": "040",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 27,
+            "y": 6,
+            "w": 17,
+            "h": 14
+          },
+          "frame": {
+            "x": 42,
+            "y": 233,
+            "w": 17,
+            "h": 14
+          }
+        },
+        {
+          "filename": "041",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 48,
+            "h": 40
+          },
+          "spriteSourceSize": {
+            "x": 28,
+            "y": 5,
+            "w": 17,
+            "h": 14
+          },
+          "frame": {
+            "x": 42,
+            "y": 233,
+            "w": 17,
+            "h": 14
+          }
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "app": "https://www.codeandweb.com/texturepacker",
+    "version": "3.0",
+    "smartupdate": "$TexturePacker:SmartUpdate:a9355e3e51996854cddff6e71e679467:da3bb210d21a6c5d9a1a8d812686cae9:5de4914b79c9cf89c17d0eeaf02c5c46$"
+  }
 }

--- a/app/public/dist/client/assets/attacks/SPARKLING_ARIA.json
+++ b/app/public/dist/client/assets/attacks/SPARKLING_ARIA.json
@@ -409,7 +409,7 @@
 					}
 				},
 				{
-					"filename": "051",
+					"filename": "042",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -472,7 +472,7 @@
 					}
 				},
 				{
-					"filename": "050",
+					"filename": "041",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -829,7 +829,7 @@
 					}
 				},
 				{
-					"filename": "052",
+					"filename": "043",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/app/public/dist/client/assets/attacks/SPIKE_ARMOR.json
+++ b/app/public/dist/client/assets/attacks/SPIKE_ARMOR.json
@@ -1,314 +1,314 @@
 {
-	"textures": [
-		{
-			"image": "SPIKE_ARMOR.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 22,
-				"h": 238
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "000",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 20,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 1,
-						"w": 20,
-						"h": 32
-					}
-				},
-				{
-					"filename": "008",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 20,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 1,
-						"w": 20,
-						"h": 32
-					}
-				},
-				{
-					"filename": "006",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 12,
-						"y": 0,
-						"w": 20,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 35,
-						"w": 20,
-						"h": 32
-					}
-				},
-				{
-					"filename": "014",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 12,
-						"y": 0,
-						"w": 20,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 35,
-						"w": 20,
-						"h": 32
-					}
-				},
-				{
-					"filename": "001",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 1,
-						"y": 0,
-						"w": 19,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 69,
-						"w": 19,
-						"h": 32
-					}
-				},
-				{
-					"filename": "009",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 1,
-						"y": 0,
-						"w": 19,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 69,
-						"w": 19,
-						"h": 32
-					}
-				},
-				{
-					"filename": "005",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 0,
-						"w": 19,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 103,
-						"w": 19,
-						"h": 32
-					}
-				},
-				{
-					"filename": "013",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 0,
-						"w": 19,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 103,
-						"w": 19,
-						"h": 32
-					}
-				},
-				{
-					"filename": "003",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 8,
-						"y": 0,
-						"w": 17,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 137,
-						"w": 17,
-						"h": 32
-					}
-				},
-				{
-					"filename": "011",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 8,
-						"y": 0,
-						"w": 17,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 137,
-						"w": 17,
-						"h": 32
-					}
-				},
-				{
-					"filename": "002",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 4,
-						"y": 0,
-						"w": 15,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 171,
-						"w": 15,
-						"h": 32
-					}
-				},
-				{
-					"filename": "010",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 4,
-						"y": 0,
-						"w": 15,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 171,
-						"w": 15,
-						"h": 32
-					}
-				},
-				{
-					"filename": "004",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 14,
-						"y": 0,
-						"w": 15,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 205,
-						"w": 15,
-						"h": 32
-					}
-				},
-				{
-					"filename": "012",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 32,
-						"h": 32
-					},
-					"spriteSourceSize": {
-						"x": 14,
-						"y": 0,
-						"w": 15,
-						"h": 32
-					},
-					"frame": {
-						"x": 1,
-						"y": 205,
-						"w": 15,
-						"h": 32
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:01ea7db79976dac2060ac8016200318c:78904471cbedb973f09970482bab4ec6:1fd962cdb3642b84400a77cf00de2a83$"
-	}
+  "textures": [
+    {
+      "image": "SPIKE_ARMOR.png",
+      "format": "RGBA8888",
+      "size": {
+        "w": 22,
+        "h": 238
+      },
+      "scale": 1,
+      "frames": [
+        {
+          "filename": "000",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 0,
+            "y": 0,
+            "w": 20,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 1,
+            "w": 20,
+            "h": 32
+          }
+        },
+        {
+          "filename": "007",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 0,
+            "y": 0,
+            "w": 20,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 1,
+            "w": 20,
+            "h": 32
+          }
+        },
+        {
+          "filename": "006",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 12,
+            "y": 0,
+            "w": 20,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 35,
+            "w": 20,
+            "h": 32
+          }
+        },
+        {
+          "filename": "013",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 12,
+            "y": 0,
+            "w": 20,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 35,
+            "w": 20,
+            "h": 32
+          }
+        },
+        {
+          "filename": "001",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 1,
+            "y": 0,
+            "w": 19,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 69,
+            "w": 19,
+            "h": 32
+          }
+        },
+        {
+          "filename": "008",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 1,
+            "y": 0,
+            "w": 19,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 69,
+            "w": 19,
+            "h": 32
+          }
+        },
+        {
+          "filename": "005",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 0,
+            "w": 19,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 103,
+            "w": 19,
+            "h": 32
+          }
+        },
+        {
+          "filename": "012",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 13,
+            "y": 0,
+            "w": 19,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 103,
+            "w": 19,
+            "h": 32
+          }
+        },
+        {
+          "filename": "003",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 8,
+            "y": 0,
+            "w": 17,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 137,
+            "w": 17,
+            "h": 32
+          }
+        },
+        {
+          "filename": "010",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 8,
+            "y": 0,
+            "w": 17,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 137,
+            "w": 17,
+            "h": 32
+          }
+        },
+        {
+          "filename": "002",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 4,
+            "y": 0,
+            "w": 15,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 171,
+            "w": 15,
+            "h": 32
+          }
+        },
+        {
+          "filename": "009",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 4,
+            "y": 0,
+            "w": 15,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 171,
+            "w": 15,
+            "h": 32
+          }
+        },
+        {
+          "filename": "004",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 14,
+            "y": 0,
+            "w": 15,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 205,
+            "w": 15,
+            "h": 32
+          }
+        },
+        {
+          "filename": "011",
+          "rotated": false,
+          "trimmed": true,
+          "sourceSize": {
+            "w": 32,
+            "h": 32
+          },
+          "spriteSourceSize": {
+            "x": 14,
+            "y": 0,
+            "w": 15,
+            "h": 32
+          },
+          "frame": {
+            "x": 1,
+            "y": 205,
+            "w": 15,
+            "h": 32
+          }
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "app": "https://www.codeandweb.com/texturepacker",
+    "version": "3.0",
+    "smartupdate": "$TexturePacker:SmartUpdate:01ea7db79976dac2060ac8016200318c:78904471cbedb973f09970482bab4ec6:1fd962cdb3642b84400a77cf00de2a83$"
+  }
 }

--- a/app/public/dist/client/assets/attacks/TRI_ATTACK.json
+++ b/app/public/dist/client/assets/attacks/TRI_ATTACK.json
@@ -10,7 +10,7 @@
 			"scale": 1,
 			"frames": [
 				{
-					"filename": "010",
+					"filename": "005",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -31,7 +31,7 @@
 					}
 				},
 				{
-					"filename": "004",
+					"filename": "002",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -52,7 +52,7 @@
 					}
 				},
 				{
-					"filename": "014",
+					"filename": "007",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -73,7 +73,7 @@
 					}
 				},
 				{
-					"filename": "018",
+					"filename": "009",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -94,7 +94,7 @@
 					}
 				},
 				{
-					"filename": "012",
+					"filename": "006",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -115,7 +115,7 @@
 					}
 				},
 				{
-					"filename": "016",
+					"filename": "008",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -136,7 +136,7 @@
 					}
 				},
 				{
-					"filename": "008",
+					"filename": "004",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -157,7 +157,7 @@
 					}
 				},
 				{
-					"filename": "002",
+					"filename": "001",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -178,7 +178,7 @@
 					}
 				},
 				{
-					"filename": "006",
+					"filename": "003",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -199,7 +199,7 @@
 					}
 				},
 				{
-					"filename": "020",
+					"filename": "010",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/app/public/src/game/animation-manager.ts
+++ b/app/public/src/game/animation-manager.ts
@@ -107,7 +107,7 @@ export default class AnimationManager {
       key: Ability.COSMIC_POWER,
       frames: this.game.anims.generateFrameNames("COSMIC_POWER", {
         start: 0,
-        end: 36,
+        end: 29,
         zeroPad: 3
       }),
       duration: 1000,
@@ -118,7 +118,7 @@ export default class AnimationManager {
       key: Ability.SOFT_BOILED,
       frames: this.game.anims.generateFrameNames("SOFT_BOILED", {
         start: 0,
-        end: 32,
+        end: 28,
         zeroPad: 3
       }),
       duration: 1000,
@@ -765,7 +765,7 @@ export default class AnimationManager {
       key: Ability.ROAR_OF_TIME,
       frames: this.game.anims.generateFrameNames("ROAR_OF_TIME", {
         start: 0,
-        end: 28,
+        end: 27,
         zeroPad: 3
       }),
       duration: 1000,
@@ -819,7 +819,7 @@ export default class AnimationManager {
       key: Ability.ICY_WIND,
       frames: this.game.anims.generateFrameNames(Ability.ICY_WIND, {
         start: 0,
-        end: 19,
+        end: 3,
         zeroPad: 3
       }),
       duration: 300,
@@ -841,7 +841,7 @@ export default class AnimationManager {
       key: Ability.PRESENT,
       frames: this.game.anims.generateFrameNames(Ability.PRESENT, {
         start: 0,
-        end: 32,
+        end: 20,
         zeroPad: 3
       }),
       duration: 1000,
@@ -918,7 +918,7 @@ export default class AnimationManager {
       key: Ability.SLASHING_CLAW,
       frames: this.game.anims.generateFrameNames(Ability.SLASHING_CLAW, {
         start: 0,
-        end: 14,
+        end: 13,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1083,7 +1083,7 @@ export default class AnimationManager {
       key: Ability.SHADOW_SNEAK,
       frames: this.game.anims.generateFrameNames(Ability.SHADOW_SNEAK, {
         start: 0,
-        end: 34,
+        end: 31,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1169,7 +1169,7 @@ export default class AnimationManager {
       key: Ability.ECHO,
       frames: this.game.anims.generateFrameNames(Ability.ECHO, {
         start: 0,
-        end: 36,
+        end: 22,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1191,7 +1191,7 @@ export default class AnimationManager {
       key: Ability.SHADOW_BALL,
       frames: this.game.anims.generateFrameNames(Ability.SHADOW_BALL, {
         start: 0,
-        end: 43,
+        end: 39,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1202,7 +1202,7 @@ export default class AnimationManager {
       key: Ability.SPIKE_ARMOR,
       frames: this.game.anims.generateFrameNames(Ability.SPIKE_ARMOR, {
         start: 0,
-        end: 14,
+        end: 13,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1213,7 +1213,7 @@ export default class AnimationManager {
       key: Ability.MAGIC_BOUNCE,
       frames: this.game.anims.generateFrameNames(Ability.MAGIC_BOUNCE, {
         start: 0,
-        end: 14,
+        end: 13,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1247,7 +1247,7 @@ export default class AnimationManager {
       key: Ability.SONG_OF_DESIRE,
       frames: this.game.anims.generateFrameNames(Ability.SONG_OF_DESIRE, {
         start: 0,
-        end: 43,
+        end: 41,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1291,7 +1291,7 @@ export default class AnimationManager {
       key: Ability.HIGH_JUMP_KICK,
       frames: this.game.anims.generateFrameNames(Ability.HIGH_JUMP_KICK, {
         start: 0,
-        end: 21,
+        end: 20,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1302,7 +1302,7 @@ export default class AnimationManager {
       key: Ability.TRI_ATTACK,
       frames: this.game.anims.generateFrameNames(Ability.TRI_ATTACK, {
         start: 0,
-        end: 20,
+        end: 10,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1324,7 +1324,7 @@ export default class AnimationManager {
       key: Ability.FUSION_BOLT,
       frames: this.game.anims.generateFrameNames(Ability.FUSION_BOLT, {
         start: 0,
-        end: 17,
+        end: 12,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1346,7 +1346,7 @@ export default class AnimationManager {
       key: Ability.DISARMING_VOICE,
       frames: this.game.anims.generateFrameNames(Ability.DISARMING_VOICE, {
         start: 0,
-        end: 43,
+        end: 38,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1368,7 +1368,7 @@ export default class AnimationManager {
       key: Ability.CLANGOROUS_SOUL,
       frames: this.game.anims.generateFrameNames(Ability.CLANGOROUS_SOUL, {
         start: 0,
-        end: 18,
+        end: 17,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1423,7 +1423,7 @@ export default class AnimationManager {
       key: Ability.SMOG,
       frames: this.game.anims.generateFrameNames(Ability.SMOG, {
         start: 0,
-        end: 10,
+        end: 8,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1500,7 +1500,7 @@ export default class AnimationManager {
       key: "FAIRY_CRIT",
       frames: this.game.anims.generateFrameNames("FAIRY_CRIT", {
         start: 0,
-        end: 19,
+        end: 14,
         zeroPad: 3
       }),
       duration: 1000,
@@ -1892,7 +1892,7 @@ export default class AnimationManager {
       key: Ability.SPARKLING_ARIA,
       frames: this.game.anims.generateFrameNames(Ability.SPARKLING_ARIA, {
         start: 0,
-        end: 52,
+        end: 43,
         zeroPad: 3
       }),
       duration: 1000,

--- a/app/public/src/game/components/minigame-manager.ts
+++ b/app/public/src/game/components/minigame-manager.ts
@@ -175,7 +175,6 @@ export default class MinigameManager {
           break
 
         case "avatarId":
-          logger.debug("change portal.avatarId", value)
           if (value != "" && typeof value === "string") {
             const avatar = this.pokemons.get(value)
             logger.debug(

--- a/app/public/src/pages/component/game/game-options-modal.tsx
+++ b/app/public/src/pages/component/game/game-options-modal.tsx
@@ -97,7 +97,7 @@ export default function GameOptionsModal(props: {
               </label>
             </p>
             <p>
-              {t("community_translations")}
+              {t("community_translations")}{" "}
               <a
                 href="https://discord.com/channels/737230355039387749/1134014553529790464"
                 target="_blank"


### PR DESCRIPTION
Fix a bunch of those warnings:

![chrome_R3xJHCbG5h](https://github.com/keldaanCommunity/pokemonAutoChess/assets/566536/09bacf50-b6df-4694-b9c4-1329ff41c18a)

specials and attacks are the remaining ones, but much more complex to fix

I just shifted the missing frames numbers. This is very regular so I think we do something wrong with TexturePacker exports

