### PR TITLE
add an additional check on game room dispose

### DIFF
--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -450,7 +450,17 @@ export default class GameRoom extends Room<GameState> {
   }
 
   async onDispose() {
-    // logger.info(`dispose game room`);
+    const numberOfPlayersAlive = this.getNumberOfPlayersAlive(
+      this.state.players
+    )
+
+    if (numberOfPlayersAlive > 1) {
+      logger.warn(
+        `Game room has been disposed while they were still ${numberOfPlayersAlive} players alive.`
+      )
+      return // we skip elo compute/game history in case of technical issue such as a crash of node
+    }
+
     try {
       this.state.endTime = Date.now()
       const players: components["schemas"]["GameHistory"]["players"] = []


### PR DESCRIPTION
check that number of alive players <= 1 before computing elo / saving game history

just in case the room is disposed for another reason than game end (node crash / server reboot)

# Drawback

In case all players disconnect before the game ends, no one will get ELO compute / titles etc. At least one player must stay connected until the end