### PR TITLE
add reconnect action

### DIFF
--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -1777,6 +1777,7 @@
   "stage": "Stage",
   "spectate": "Spectate",
   "join": "Join",
+  "reconnect": "Reconnect",
   "just_for_fun": "Just for fun",
   "password_protected": "Private Lobby (password protected)",
   "private": "Private",

--- a/app/public/dist/client/locales/fr/translation.json
+++ b/app/public/dist/client/locales/fr/translation.json
@@ -1759,6 +1759,7 @@
   "stage": "Tour",
   "spectate": "Regarder",
   "join": "Rejoindre",
+  "reconnect": "Reconnexion",
   "just_for_fun": "Juste pour le fun",
   "password_protected": "Lobby privé (protégé par mot de passe)",
   "private": "Privé",

--- a/app/public/src/pages/component/available-room-menu/game-room-item.tsx
+++ b/app/public/src/pages/component/available-room-menu/game-room-item.tsx
@@ -1,24 +1,32 @@
 import { RoomAvailable } from "colyseus.js"
 import React from "react"
 import { IGameMetadata } from "../../../../../types"
-import "./room-item.css"
 import { useTranslation } from "react-i18next"
+import { useAppSelector } from "../../../hooks"
+import { cc } from "../../utils/jsx"
+import "./room-item.css"
 
 export default function GameRoomItem(props: {
   room: RoomAvailable<IGameMetadata>
-  onSpectate: () => any
+  onJoin: (spectate: boolean) => void
 }) {
   const { t } = useTranslation()
+  const myUid = useAppSelector((state) => state.network.uid)
+  const spectate = !props.room.metadata?.playerIds.includes(myUid)
+
   return (
     <div className="room-item">
       <span className="room-name">{props.room.metadata?.name}</span>
       <span>
-        {props.room.clients} {t("player")}
-        {props.room.clients !== 1 ? "s" : ""}, {t("stage")}{" "}
+        {props.room.metadata?.playerIds.length} {t("player")}
+        {props.room.metadata?.playerIds.length !== 1 ? "s" : ""}, {t("stage")}{" "}
         {props.room.metadata?.stageLevel}
       </span>
-      <button className="bubbly blue" onClick={() => props.onSpectate()}>
-        {t("spectate")}
+      <button
+        className={cc("bubbly", spectate ? "blue" : "green")}
+        onClick={() => props.onJoin(spectate)}
+      >
+        {spectate ? t("spectate") : t("reconnect")}
       </button>
     </div>
   )

--- a/app/public/src/pages/component/wiki/wiki.css
+++ b/app/public/src/pages/component/wiki/wiki.css
@@ -1,3 +1,7 @@
+#wiki-page {
+  width: 1880px;
+}
+
 #wiki-page ul {
   padding: 0;
 }

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -86,7 +86,7 @@ export default class GameRoom extends Room<GameState> {
     logger.trace("create game room")
     this.setMetadata(<IGameMetadata>{
       name: options.name,
-      nbPlayers: Object.values(options.users).length,
+      playerIds: Object.keys(options.users),
       stageLevel: 0,
       type: "game"
     })

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -550,7 +550,7 @@ export interface IPreparationMetadata {
 
 export interface IGameMetadata {
   name: string
-  nbPlayers: number
+  playerIds: string[]
   stageLevel: number
   type: "game"
 }


### PR DESCRIPTION
changed gameroom metadata to store list of player Ids instead of number of players

added reconnect action when we detect the player is in the list of players of a room

![msedge_Oz8NZF1LW6](https://github.com/keldaanCommunity/pokemonAutoChess/assets/566536/c23950f0-32a0-48b0-8678-8620c0203a6b)
