### PR TITLE
fix furret family

### DIFF
--- a/app/types/enum/Pokemon.ts
+++ b/app/types/enum/Pokemon.ts
@@ -1785,7 +1785,7 @@ export const PkmFamily: { [key in Pkm]: Pkm } = {
   [Pkm.SHELLDER]: Pkm.SHELLDER,
   [Pkm.CLOYSTER]: Pkm.SHELLDER,
   [Pkm.SENTRET]: Pkm.SENTRET,
-  [Pkm.FURRET]: Pkm.FURRET,
+  [Pkm.FURRET]: Pkm.SENTRET,
   [Pkm.SPECTRIER]: Pkm.SPECTRIER,
   [Pkm.TORKOAL]: Pkm.TORKOAL,
   [Pkm.DELIBIRD]: Pkm.DELIBIRD,


### PR DESCRIPTION
Furret's pokemon family was independent from sentret, causing sentret to continue to appear in shops after furret was evolved.