### PR TITLE
Fix ghost income

### DIFF
--- a/app/core/matchmaking.ts
+++ b/app/core/matchmaking.ts
@@ -1,5 +1,8 @@
 import Player from "../models/colyseus-models/player"
+import { getAvatarString } from "../public/src/utils"
 import GameState from "../rooms/states/game-state"
+import { Emotion } from "../types"
+import { PkmIndex, Pkm } from "../types/enum/Pokemon"
 import { logger } from "../utils/logger"
 
 export type Matchup = { a: Player; b: Player; count: number; ghost?: boolean }
@@ -46,11 +49,20 @@ export function selectMatchups(state: GameState): Matchup[] {
     )[0]
     ghostMatchup.ghost = true
     if (ghostMatchup.a.id !== remainingPlayer.id) {
-      // ensure remaining player is player A in ghost round
+      // ensure remaining player is player A and ghost is playerB in ghost round
       ghostMatchup.b = ghostMatchup.a
       ghostMatchup.a = remainingPlayer
     }
+    /* dereference player so that money gain is not applied to original player when playing as ghost */
+    const ghost: Player = {
+      ...ghostMatchup.b,
+      id: "ghost-id",
+      name: `Ghost of ${ghostMatchup.b.name}`,
+      avatar: getAvatarString(PkmIndex[Pkm.GASTLY], true, Emotion.HAPPY)
+    } as Player
+    ghostMatchup.b = ghost
     selectedMatchups.push(ghostMatchup)
+    //logger.debug(`Round ${state.stageLevel} has ${ghost.name}`)
   }
   /*
   logger.debug("Matchmaking round " + state.stageLevel)

--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -31,7 +31,7 @@ export default class Player extends Schema implements IPlayer {
   @type(["string"]) shop = new ArraySchema<Pkm>()
   @type(ExperienceManager) experienceManager = new ExperienceManager()
   @type({ map: "uint8" }) synergies = new Synergies()
-  @type("uint8") money = process.env.MODE == "dev" ? 400 : 6
+  @type("uint16") money = process.env.MODE == "dev" ? 400 : 6
   @type("uint8") life = 100
   @type("boolean") shopLocked: boolean = false
   @type("uint8") streak: number = 0

--- a/app/public/src/pages/component/game/game-stage-info.css
+++ b/app/public/src/pages/component/game/game-stage-info.css
@@ -53,6 +53,7 @@
 #game-stage-info .player-information img {
   width: 1.5em;
   height: 1.5em;
+  margin: auto;
 }
 
 #game-stage-info .player-information .player-title {

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -55,6 +55,7 @@ import { max } from "../../utils/number"
 import { getWeather } from "../../utils/weather"
 import Simulation from "../../core/simulation"
 import { selectMatchups } from "../../core/matchmaking"
+import { values } from "../../utils/schemas"
 
 export class OnShopCommand extends Command<
   GameRoom,
@@ -776,7 +777,12 @@ export class OnJoinCommand extends Command<
     try {
       if (options.spectate === true) {
         this.state.spectators.add(client.auth.uid)
+      } else if (values(this.state.players).some((p) => p.id === auth.uid)) {
+        logger.info(
+          `${client.auth.displayName} ${client.id} reconnected to game room`
+        )
       } else {
+        // init player
         const user = await UserMetadata.findOne({ uid: auth.uid })
         if (user) {
           const player = new Player(

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1598,15 +1598,6 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
           playerB.opponentName = playerA.name
           playerB.opponentAvatar = playerA.avatar
           playerB.opponentTitle = playerA.title ?? ""
-        } else {
-          playerA.opponentId = "ghost-id"
-          playerA.opponentName = `Ghost of ${playerB.name}`
-          playerA.opponentAvatar = getAvatarString(
-            PkmIndex[Pkm.GASTLY],
-            true,
-            Emotion.HAPPY
-          )
-          playerA.opponentTitle = "Ghost"
         }
 
         this.state.simulations.set(simulation.id, simulation)


### PR DESCRIPTION
Fix two problems

1) money was stored in UINT8 meaning it resets to 0 when going over 256. Changed to UINT16

https://github.com/keldaanCommunity/pokemonAutoChess/assets/566536/98a0978d-6466-482f-949a-d230b31776f9

2) Dereference ghost player when assigning matchups so that it does not apply bonus income (Amulet coin, payday etc...) to original player. Should work as well for pokemon gain or item gain with Unowns hidden power