### PR TITLE
fix confusing mind not confusing the enemy

### DIFF
--- a/app/core/attack-strategy.ts
+++ b/app/core/attack-strategy.ts
@@ -402,7 +402,7 @@ export class ConfusingMindStrategy extends AttackStrategy {
     super.process(pokemon, state, board, target, crit)
     const duration = 6000 * (1 + pokemon.ap / 100)
 
-    target.status.triggerCharm(duration, target)
+    target.status.triggerConfusion(duration, target)
   }
 }
 


### PR DESCRIPTION
The Azelf's Ability Confusing Mind is charming the target instead of confusing it like the description says. This PR fixes this problem. 