### PR TITLE
allow click through toast evols

### DIFF
--- a/app/public/src/styles.css
+++ b/app/public/src/styles.css
@@ -258,6 +258,7 @@ p:last-child {
 .Toastify__toast-container {
   width: auto !important;
   --toastify-z-index: 1040;
+  pointer-events: none; /* allow to click through to select a player */
 }
 
 .Toastify__toast {


### PR DESCRIPTION
The toastify elements showing players evolutions is going over the player portrait, which makes impossible switching player when a toast is visible. Added pointer-events: none to make toasts not capturing mouse clicks