### PR TITLE
fix ap scaling regression

### DIFF
--- a/app/core/attack-strategy.ts
+++ b/app/core/attack-strategy.ts
@@ -5623,8 +5623,7 @@ export class SuperFangStrategy extends AttackStrategy {
       board,
       AttackType.SPECIAL,
       pokemon,
-      crit,
-      false
+      crit
     )
   }
 }
@@ -5830,8 +5829,7 @@ export class PoisonGasStrategy extends AttackStrategy {
             board,
             AttackType.SPECIAL,
             pokemon,
-            crit,
-            true
+            crit
           )
           cell.value.status.triggerParalysis(3000, cell.value)
           cell.value.status.triggerPoison(3000, cell.value, pokemon)
@@ -5984,8 +5982,7 @@ export class StruggleBugStrategy extends AttackStrategy {
           board,
           AttackType.SPECIAL,
           pokemon,
-          crit,
-          true
+          crit
         )
       }
     })
@@ -6012,8 +6009,7 @@ export class TailGlowStrategy extends AttackStrategy {
           board,
           AttackType.SPECIAL,
           pokemon,
-          crit,
-          true
+          crit
         )
       }
     })
@@ -6042,8 +6038,7 @@ export class PrismaticLaserStrategy extends AttackStrategy {
           board,
           AttackType.SPECIAL,
           pokemon,
-          crit,
-          true
+          crit
         )
         const teleportationCell = board.getTeleportationCell(
           tg.positionX,
@@ -6078,8 +6073,7 @@ export class NightShadeStrategy extends AttackStrategy {
       board,
       AttackType.TRUE,
       pokemon,
-      crit,
-      false
+      crit
     )
   }
 }

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -207,16 +207,13 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
     board: Board,
     attackType: AttackType,
     attacker: PokemonEntity | null,
-    crit: boolean,
-    apBoost?: boolean
+    crit: boolean
   ): { death: boolean; takenDamage: number } {
     if (this.status.protect) {
       this.count.spellBlockedCount++
       return { death: false, takenDamage: 0 }
     } else {
-      let specialDamage = apBoost
-        ? damage + (damage * (attacker ? attacker.ap : 0)) / 100
-        : damage
+      let specialDamage = damage + (damage * (attacker ? attacker.ap : 0)) / 100
       if (attacker && attacker.status.doubleDamage) {
         specialDamage *= 2
         attacker.status.doubleDamage = false
@@ -279,7 +276,7 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
       !this.status.silence &&
       !this.status.protect &&
       !this.status.resurecting
-    ) {      
+    ) {
       this.pp = clamp(pp, 0, this.maxPP)
     }
   }
@@ -650,13 +647,13 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
         ) {
           // melee range
           pokemon.count.fairyCritCount++
-          splashTarget.handleSpecialDamage(
+          splashTarget.handleDamage({
             damage,
             board,
-            AttackType.SPECIAL,
-            pokemon,
-            false
-          )
+            attackType: AttackType.SPECIAL,
+            attacker: pokemon,
+            shouldTargetGainMana: false
+          })
         } else {
           // not at range, charm it instead
           splashTarget.status.triggerCharm(2000, splashTarget)

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -530,13 +530,13 @@ export default class PokemonState {
       if (pokemon.sandstormDamageTimer <= 0) {
         pokemon.sandstormDamageTimer = 1000
         const sandstormDamage = 5
-        pokemon.handleSpecialDamage(
-          sandstormDamage,
+        pokemon.handleDamage({
+          damage: sandstormDamage,
           board,
-          AttackType.SPECIAL,
-          null,
-          false
-        )
+          attackType: AttackType.SPECIAL,
+          attacker: null,
+          shouldTargetGainMana: false
+        })
       }
     }
 
@@ -552,9 +552,11 @@ export default class PokemonState {
           }
         })
       }
-      if(pokemon.effects.has(Effect.LIGHT_PULSE) ||
-         pokemon.effects.has(Effect.ETERNAL_LIGHT) ||
-         pokemon.effects.has(Effect.MAX_ILLUMINATION)){
+      if (
+        pokemon.effects.has(Effect.LIGHT_PULSE) ||
+        pokemon.effects.has(Effect.ETERNAL_LIGHT) ||
+        pokemon.effects.has(Effect.MAX_ILLUMINATION)
+      ) {
         pokemon.setPP(pokemon.pp + 10)
       }
       pokemon.manaCooldown = 1000

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -1219,13 +1219,13 @@ export default class Simulation extends Schema implements ISimulation {
           pokemonOnCell &&
           pokemonOnCell.types.has(Synergy.ELECTRIC) === false
         ) {
-          pokemonOnCell.handleSpecialDamage(
-            100,
-            this.board,
-            AttackType.SPECIAL,
-            null,
-            false
-          )
+          pokemonOnCell.handleDamage({
+            damage: 100,
+            board: this.board,
+            attackType: AttackType.SPECIAL,
+            attacker: null,
+            shouldTargetGainMana: false
+          })
         }
         this.room.broadcast(Transfer.BOARD_EVENT, {
           simulationId: this.id,


### PR DESCRIPTION
Another major regression in 4.3 to hotfix: https://github.com/keldaanCommunity/pokemonAutoChess/commit/23fa210b58e388ef778a656953ab62cbc07b3e0e#diff-20b1bbbbdf5f9f824bfcff0ae87fd8f6e8ec93523b54162a9f394920107fcfaeR208

this change in handleSpecialDamage broke all AP scaling on all abilities