### PR TITLE
allow manual edit on bot export modal

### DIFF
--- a/app/public/src/pages/component/bot-builder/bot-builder.tsx
+++ b/app/public/src/pages/component/bot-builder/bot-builder.tsx
@@ -2,17 +2,13 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router"
 import { Navigate, useSearchParams } from "react-router-dom"
-import ModalMenu from "./modal-menu"
+import ImportExportBotModal from "./import-export-bot-modal"
 import {
   IBot,
   IDetailledPokemon
 } from "../../../../../models/mongo-models/bot-v2"
 import { useAppSelector, useAppDispatch } from "../../../hooks"
-import {
-  createBot,
-  requestBotData,
-  requestBotList
-} from "../../../stores/NetworkStore"
+import { requestBotData, requestBotList } from "../../../stores/NetworkStore"
 import { ModalMode, PkmWithConfig } from "../../../../../types"
 import {
   DEFAULT_BOT_STATE,
@@ -129,16 +125,6 @@ export default function BotBuilder() {
     }
   }
 
-  function updateBot(newValue: string) {
-    try {
-      const b: IBot = JSON.parse(newValue)
-      setBot(rewriteBotRoundsRequiredto1(b))
-      setQueryParams({ bot: b.id })
-    } catch (e) {
-      alert(e)
-    }
-  }
-
   function changeAvatar(pkm: PkmWithConfig) {
     bot.name = pkm.name.toUpperCase()
     bot.avatar = getAvatarString(PkmIndex[pkm.name], pkm.shiny, pkm.emotion)
@@ -156,10 +142,6 @@ export default function BotBuilder() {
       author: displayName ?? "Anonymous",
       elo: estimateElo(bot)
     })
-  }
-
-  function create() {
-    dispatch(createBot(bot))
   }
 
   function updateStep(board: IDetailledPokemon[]) {
@@ -259,7 +241,7 @@ export default function BotBuilder() {
         error={violation}
       />
 
-      <ModalMenu
+      <ImportExportBotModal
         visible={modalVisible}
         bot={bot}
         hideModal={() => {
@@ -267,9 +249,7 @@ export default function BotBuilder() {
         }}
         modalMode={modalMode}
         importBot={importBot}
-        updateBot={updateBot}
         pasteBinUrl={pastebinUrl}
-        createBot={create}
       />
     </div>
   )

--- a/app/public/src/pages/component/bot-builder/import-export-bot-modal.tsx
+++ b/app/public/src/pages/component/bot-builder/import-export-bot-modal.tsx
@@ -3,18 +3,16 @@ import Modal from "react-bootstrap/Modal"
 import { IBot } from "../../../../../models/mongo-models/bot-v2"
 import { ModalMode } from "../../../../../types"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
-import { requestBotData } from "../../../stores/NetworkStore"
+import { createBot, requestBotData } from "../../../stores/NetworkStore"
 import { useTranslation } from "react-i18next"
 
-export default function ModalMenu(props: {
+export default function ImportExportBotModal(props: {
   bot: IBot
   hideModal: () => void
   modalMode: ModalMode
   importBot: (text: string) => void
   pasteBinUrl: string
-  createBot: () => void
   visible: boolean
-  updateBot: (newValue: string) => void
 }) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
@@ -50,6 +48,15 @@ export default function ModalMenu(props: {
     }
   }
 
+  function exportBot() {
+    try {
+      const bot = JSON.parse(textArea)
+      dispatch(createBot(bot))
+    } catch (e) {
+      setJsonError(e.message)
+    }
+  }
+
   if (props.modalMode == ModalMode.EXPORT) {
     return (
       <Modal
@@ -77,12 +84,7 @@ export default function ModalMenu(props: {
           <button className="bubbly red" onClick={props.hideModal}>
             {t("cancel")}
           </button>
-          <button
-            className="bubbly green"
-            onClick={() => {
-              props.createBot()
-            }}
-          >
+          <button className="bubbly green" onClick={exportBot}>
             {t("submit_your_bot")}
           </button>
         </Modal.Footer>


### PR DESCRIPTION
Allow manual changes on JSON for bot export. Useful for bot managers to preserve author name after they edit a bot