### PR TITLE
make non-cc status durations extendable

### DIFF
--- a/app/public/dist/client/changelog/patch-4.4.md
+++ b/app/public/dist/client/changelog/patch-4.4.md
@@ -43,7 +43,7 @@
 
 # Gameplay
 
--
+- Like poison, the following status can now have their duration extended if applied again before the end of their initial duration: Armor Reduction, Burn, Silence, Wound, Paralysis, Rune Protect, Spike Armor, Magic Bounce.
 
 # UI
 


### PR DESCRIPTION
Like poison, the following status can now have their duration extended if applied again before the end of their initial duration: Armor Reduction, Burn, Silence, Wound, Paralysis, Rune Protect, Spike Armor, Magic Bounce. Blocking status like Sleep, Freeze or Protect still cannot be extended.

fix https://discord.com/channels/737230355039387749/1169029299710468238