### PR TITLE
Remove negative status after victory

### DIFF
--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -601,7 +601,7 @@ export default class Simulation extends Schema implements ISimulation {
           pokemon.status.triggerRuneProtect(60000)
         }
 
-        if(pokemon.passive === Passive.SPOT_PANDA){
+        if (pokemon.passive === Passive.SPOT_PANDA) {
           pokemon.effects.add(Effect.IMMUNITY_CONFUSION)
         }
       })
@@ -1166,11 +1166,13 @@ export default class Simulation extends Schema implements ISimulation {
       if (this.blueTeam.size === 0 && this.redTeam.size > 0) {
         this.winnerId = this.redPlayer ? this.redPlayer.id : "pve"
         this.redTeam.forEach((p) => {
+          p.status.clearNegativeStatus()
           p.action = PokemonActionState.HOP
         })
       } else if (this.redTeam.size === 0 && this.blueTeam.size > 0) {
         this.winnerId = this.bluePlayer?.id ?? ""
         this.blueTeam.forEach((p) => {
+          p.status.clearNegativeStatus()
           p.action = PokemonActionState.HOP
         })
       }

--- a/app/public/dist/client/changelog/patch-4.4.md
+++ b/app/public/dist/client/changelog/patch-4.4.md
@@ -50,6 +50,7 @@
 # Gameplay
 
 - Like poison, the following status can now have their duration extended if applied again before the end of their initial duration: Armor Reduction, Burn, Silence, Wound, Paralysis, Rune Protect, Spike Armor, Magic Bounce.
+- Negative status are cleared when the opposite team is eliminated
 
 # UI
 


### PR DESCRIPTION
to avoid draw or reducing round damage due to poison/burn