### PR TITLE
Hotfix clefairy bellsprout

### DIFF
--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -3975,7 +3975,7 @@ export class Clefairy extends Pokemon {
   rarity = Rarity.UNCOMMON
   stars = 2
   evolution = Pkm.CLEFABLE
-  evolutionRule = new ItemEvolutionRule([Item.MOON_STONE])
+  evolutionRule = new ItemEvolutionRule([Item.POKE_DOLL])
   hp = 150
   atk = 11
   def = 3

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -11,7 +11,7 @@ import {
   MausholdEvolutionTurn,
   TandemausEvolutionTurn
 } from "../../types/Config"
-import { AllItems, Item, SynergyStones } from "../../types/enum/Item"
+import { AllItems, Berries, Item, SynergyStones } from "../../types/enum/Item"
 import { Pkm, PkmIndex, Unowns } from "../../types/enum/Pokemon"
 import { Rarity, AttackType, PokemonActionState } from "../../types/enum/Game"
 import { Ability } from "../../types/enum/Ability"
@@ -3606,7 +3606,7 @@ export class Weepinbell extends Pokemon {
   rarity = Rarity.UNCOMMON
   stars = 2
   evolution = Pkm.VICTREEBEL
-  evolutionRule = new ItemEvolutionRule([Item.LEAF_STONE])
+  evolutionRule = new ItemEvolutionRule(Berries)
   hp = 160
   atk = 12
   def = 2

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -1574,7 +1574,7 @@
     "SLOWBRO": "Slowbro is looking for a KINGS_ROCK",
     "MOXIE": "Every time an enemy pokémon dies, it gains ATK equal to its stars",
     "BELLSPROUT": "Weepinbell is looking for berries",
-    "CLEFAIRY": "Clefairy is looking for a MOON_STONE",
+    "CLEFAIRY": "Clefairy is looking for a POKE_DOLL",
     "ILLUMISE_VOLBEAT": "Illumise and Volbeat gain 5 PP per second for each other member of their species alive on the board",
     "PRISM": "Necrozma switches between its Ultra forme and Normal forme depending on its exposure to LIGHT",
     "BLOSSOM": "Cherrim switches between its Sunlight forme and Normal forme depending on its exposure to LIGHT",

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -1573,7 +1573,7 @@
     "PORYGON": "Porygon2 is looking for an UPGRADE",
     "SLOWBRO": "Slowbro is looking for a KINGS_ROCK",
     "MOXIE": "Every time an enemy pokémon dies, it gains ATK equal to its stars",
-    "BELLSPROUT": "Weepinbell is looking for a LEAF_STONE",
+    "BELLSPROUT": "Weepinbell is looking for berries",
     "CLEFAIRY": "Clefairy is looking for a MOON_STONE",
     "ILLUMISE_VOLBEAT": "Illumise and Volbeat gain 5 PP per second for each other member of their species alive on the board",
     "PRISM": "Necrozma switches between its Ultra forme and Normal forme depending on its exposure to LIGHT",


### PR DESCRIPTION
Clefairy and Bellsprout can't evolve after the change preventing adding a synergy stone on a pokemon which already has this type

Changed so that Bellsprout evolve with berries and Clefairy with Pokedoll

I let you decide if hotfix worthy