### PR TITLE
Fix ghost spectate

### DIFF
--- a/app/core/matchmaking.ts
+++ b/app/core/matchmaking.ts
@@ -47,6 +47,7 @@ function completeMatchupCombination(
         const ghost: Player = {
           /* dereference player so that money gain is not applied to original player when playing as ghost */
           ...playerToGhost,
+          id: "ghost-id",
           name: `Ghost of ${playerToGhost.name}`,
           avatar: getAvatarString(PkmIndex[Pkm.GASTLY], true, Emotion.HAPPY)
         } as Player

--- a/app/public/src/stores/GameStore.ts
+++ b/app/public/src/stores/GameStore.ts
@@ -293,10 +293,10 @@ export const gameSlice = createSlice({
       }
     },
     setSimulation: (state, action: PayloadAction<Simulation>) => {
-      if (
-        state.currentPlayerId === action.payload.bluePlayerId ||
-        state.currentPlayerId === action.payload.redPlayerId
-      ) {
+      const currentPlayer = state.players.find(
+        (p) => p.id === state.currentPlayerId
+      )
+      if (currentPlayer?.simulationId === action.payload.id) {
         state.currentSimulationId = action.payload.id
         state.currentSimulationTeamIndex =
           state.currentPlayerId === action.payload.bluePlayerId ? 0 : 1

--- a/app/public/src/stores/GameStore.ts
+++ b/app/public/src/stores/GameStore.ts
@@ -293,10 +293,10 @@ export const gameSlice = createSlice({
       }
     },
     setSimulation: (state, action: PayloadAction<Simulation>) => {
-      const currentPlayer = state.players.find(
-        (p) => p.id === state.currentPlayerId
-      )
-      if (currentPlayer?.simulationId === action.payload.id) {
+      if (
+        state.currentPlayerId === action.payload.bluePlayerId ||
+        state.currentPlayerId === action.payload.redPlayerId
+      ) {
         state.currentSimulationId = action.payload.id
         state.currentSimulationTeamIndex =
           state.currentPlayerId === action.payload.bluePlayerId ? 0 : 1


### PR DESCRIPTION
Revert https://github.com/keldaanCommunity/pokemonAutoChess/pull/1228 

Add id: "ghost-id". i think it's the reason why ghost bug was not around in 4.3