### PR TITLE
pokemon release fixes

### DIFF
--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -6565,7 +6565,7 @@ export class Ninjask extends Pokemon {
 export class Shedinja extends Pokemon {
   types = new SetSchema<Synergy>([Synergy.BUG, Synergy.GHOST, Synergy.FLYING])
   rarity = Rarity.EPIC
-  stars = 2
+  stars = 0
   hp = 10
   atk = 18
   def = 0

--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -88,7 +88,7 @@ export default class Shop {
   releasePokemon(pkm: Pkm) {
     const pokemon = PokemonFactory.createPokemonFromName(pkm)
     const family = PkmFamily[pokemon.name]
-    const entityNumber = pokemon.stars === 3 ? 9 : pokemon.stars === 2 ? 3 : 1
+    const entityNumber = pokemon.stars >= 3 ? 9 : pokemon.stars === 2 ? 3 : pokemon.stars === 1 ? 1 : 0
     if (pokemon.rarity === Rarity.COMMON) {
       const value = this.commonPool.get(family)
       if (value !== undefined) {


### PR DESCRIPTION
Least important bugs ever fixed

- Selling Alolan Raichu (4 star unit) would void 9 Pichus from the shop pool
- Selling Ninjask + Shedinja would create a surplus of Nincada in shop pool, and return more gold than the buy price of constituent Nincada
- Changed Shedinja stars to 0 for consistency in solving above, should have no adverse effects besides Roar of Time interaction