### PR TITLE
prevent flyaway when frozen, asleep or paralyzed

### DIFF
--- a/app/core/abilities/ability-strategy.ts
+++ b/app/core/abilities/ability-strategy.ts
@@ -68,7 +68,7 @@ export class AbilityStrategy {
     }
 
     if (crit) {
-      pokemon.onCritical(target, board)
+      pokemon.onCritical({ target, board })
     }
 
     if (target.status.magicBounce) {

--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -167,7 +167,7 @@ export default class AttackingState extends PokemonState {
       }
 
       if (Math.random() * 100 < pokemon.critChance) {
-        pokemon.onCritical(target, board)
+        pokemon.onCritical({ target, board })
         if (target.items.has(Item.ROCKY_HELMET) === false) {
           let opponentCritDamage = pokemon.critDamage
           if (target.effects.has(Effect.BATTLE_ARMOR)) {

--- a/app/public/dist/client/changelog/patch-4.5.md
+++ b/app/public/dist/client/changelog/patch-4.5.md
@@ -37,7 +37,7 @@
 
 - Synergies are now correctly updated after automatic pushing of a pokemon from bench to board
 - Fix Castform passive
-- Berries are now eaten after receiving ability damage that puts under 50% HP
+- Berries are now eaten after receiving ability damage or environment damage that puts under 50% HP
 
 # Misc
 

--- a/app/public/dist/client/changelog/patch-4.5.md
+++ b/app/public/dist/client/changelog/patch-4.5.md
@@ -23,6 +23,8 @@
 
 # Changes to Synergies
 
+- Flying pokemons can no longer fly away when frozen, asleep or paralyzed
+
 # Changes to Items
 
 # Gameplay


### PR DESCRIPTION
Flying pokemons can no longer fly away when frozen, asleep or paralyzed

I think it's a good way to slightly nerf flying which is performing well at the moment

Also contains more refactoring by introducing onDamageReceived and onDeath callbacks on pokemon-entity, to further simplify handleDamage function