### PR TITLE
not count berries in bot builder

### DIFF
--- a/app/public/dist/client/changelog/patch-4.5.md
+++ b/app/public/dist/client/changelog/patch-4.5.md
@@ -94,3 +94,4 @@ All berries are eaten when below 50% HP, and heal at least 20HP when eaten:
 - New title: Vanquisher: Win a Ranked match
 - New title: Outsider: Win a Ranked match with 8 players while having the lowest ELO of all
 - Leaderboards are now recalculated server-side every 10 minutes
+- Berries are now longer counted as item components in Bot Builder

--- a/app/public/src/pages/component/bot-builder/bot-logic.ts
+++ b/app/public/src/pages/component/bot-builder/bot-logic.ts
@@ -9,7 +9,7 @@ import {
   PortalCarouselStages
 } from "../../../../../types/Config"
 import { Rarity } from "../../../../../types/enum/Game"
-import { BasicItems, Item } from "../../../../../types/enum/Item"
+import { BasicItems, Berries, Item } from "../../../../../types/enum/Item"
 import { PkmIndex, Pkm, PkmDuos } from "../../../../../types/enum/Pokemon"
 import { logger } from "../../../../../utils/logger"
 import { clamp, min } from "../../../../../utils/number"
@@ -151,7 +151,8 @@ export function getNbComponentsOnBoard(board: IDetailledPokemon[]): number {
     .flatMap((pkm) => pkm.items)
     .reduce(
       (nbComponents: number, item: Item) =>
-        nbComponents + (BasicItems.includes(item) ? 1 : 2),
+        nbComponents +
+        (Berries.includes(item) ? 0 : BasicItems.includes(item) ? 1 : 2),
       0
     )
 }


### PR DESCRIPTION
Berries are now longer counted as item components in Bot Builder