### PR TITLE
fix flinch bypassing fluffy tail/ rune protect

### DIFF
--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -708,9 +708,11 @@ export default class Status extends Schema implements IStatus {
   }
 
   triggerFlinch(timer: number) {
-    this.flinch = true
-    if (timer > this.flinchCooldown) {
-      this.flinchCooldown = timer
+    if (!this.runeProtect) {
+      this.flinch = true
+      if (timer > this.flinchCooldown) {
+        this.flinchCooldown = timer
+      }
     }
   }
 


### PR DESCRIPTION
Currently the flinch status can not be prevented by rune protect or fluffy tail. This PR fixes the problem. 