### PR TITLE
4.5 day one hot fixes (#1301)

### DIFF
--- a/app/core/matter/mini-game.ts
+++ b/app/core/matter/mini-game.ts
@@ -26,13 +26,13 @@ import {
 } from "../../types/Config"
 import { Synergy } from "../../types/enum/Synergy"
 import GameState from "../../rooms/states/game-state"
-import { entries, keys, values } from "../../utils/schemas"
+import { keys, values } from "../../utils/schemas"
 
 const PLAYER_VELOCITY = 2
 const ITEM_ROTATION_SPEED = 0.0004
 const PORTAL_ROTATION_SPEED = 0.0003
 const SYMBOL_ROTATION_SPEED = 0.0006
-const CAROUSEL_RADIUS = 140
+const CAROUSEL_RADIUS = 150
 const NB_SYMBOLS_PER_PLAYER = 4
 
 export class MiniGame {

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -1180,7 +1180,7 @@
     "AIR_SLASH": "Deals [25,50,100,SP] SPECIAL and inflicts FLINCH for 7 seconds",
     "EGGSPLOSION": "Launches an explosive egg at its target, inflicting [40,80,140,SP] SPECIAL and applying ARMOR_REDUCTION for 4 seconds to all adjacent enemies. If the target is KO, you have a 30% chance of getting an egg on your bench.",
     "FLORAL_HEALING": "Heals as many HP as max PP of Comfey's holder or Comfey itself if not hold",
-    "VINE_WHIP": "Deals 100 SPECIAL, causing it and all adjacent enemies to FLINCH for 3 seconds",
+    "VINE_WHIP": "Deals [100,SP] SPECIAL, causing it and all adjacent enemies to FLINCH for 3 seconds",
     "BODY_SLAM": "Deals [30,SP]% of user max HP as SPECIAL",
     "BARB_BARRAGE": "Dives into the middle of the enemy team, inflicting [15,30,60,SP] SPECIAL and POISON all adjacent units for 3 seconds",
     "MAGIC_POWDER": "Gain [10,20,40,SP] SHIELD and SILENCE adjacent enemies for [2,4,6] seconds",

--- a/app/public/dist/client/locales/es/translation.json
+++ b/app/public/dist/client/locales/es/translation.json
@@ -1180,7 +1180,7 @@
     "AIR_SLASH": "Causa [25,50,100,SP] de SPECIAL y deja al enemigo FLINCH por 7 segundos",
     "EGGSPLOSION": "Lanza un huevo explosivo al objetivo, infligiendo [40,80,140,SP] de SPECIAL y aplicando ARMOR_REDUCTION por 4 seconds a todos los enemigos adyacentes. Si el objetivo queda KO, tienes un 30% de recibir un huevo.",
     "FLORAL_HEALING": "Cura tantos HP como máximos PP tenga el portador de comfey o del propio comfey si no es llevado por ningun otro pokemon.",
-    "VINE_WHIP": "Causa 100 de SPECIAL, causando FLINCH a todos los pokemon adyacentes por 3 segundos",
+    "VINE_WHIP": "Causa [100,SP] de SPECIAL, causando FLINCH a todos los pokemon adyacentes por 3 segundos",
     "BODY_SLAM": "Inflige [30,SP]% del HP máximo del usuaio como SPECIAL",
     "BARB_BARRAGE": "Bucea en medio del equipo enemigo, causando [15,30,60,SP] de SPECIAL y dejando POISONa todos los pokemon adyacentes por 3 segundos",
     "MAGIC_POWDER": "Gana [10,20,40,SP] SHIELD y deja SILENCE a los enemigos adyacentes por [2,4,6] segundos",

--- a/app/public/dist/client/locales/fr/translation.json
+++ b/app/public/dist/client/locales/fr/translation.json
@@ -1180,7 +1180,7 @@
     "AIR_SLASH": "Inflige [25,50,100,SP] SPECIAL et FLINCH pendant 7 secondes",
     "EGGSPLOSION": "Lance un oeuf explosif sur la cible, infligeant [40,80,140,SP] SPECIAL et ARMOR_REDUCTION pendant 4 secondes à tous les adversaires adjacents. Si la cible est KO, vous avez 30% de chance d'obtenir un Oeuf Pokémon.",
     "FLORAL_HEALING": "Soigne autant de HP que de PP max du porteur de $t(pkm.COMFEY) ou de $t(pkm.COMFEY) lui-même s'il n'est pas porté",
-    "VINE_WHIP": "Inflige 100 SPECIAL, et cause FLINCH à la cible et aux adversaires adjacents pendant 3 secondes",
+    "VINE_WHIP": "Inflige [100,SP] SPECIAL, et cause FLINCH à la cible et aux adversaires adjacents pendant 3 secondes",
     "BODY_SLAM": "Inflige [30,SP]% des HP max du lanceur en SPECIAL",
     "BARB_BARRAGE": "Plonge au milieu de l'équipe adverse, infligeant [15,30,60,SP] SPECIAL et POISON à tous les ennemis adjacents pendant 3 secondes",
     "MAGIC_POWDER": "Gagne [10,20,40,SP] SHIELD et SILENCE les ennemis adjacents pendant [2,4,6] secondes",

--- a/app/public/src/game/components/board-manager.ts
+++ b/app/public/src/game/components/board-manager.ts
@@ -127,6 +127,9 @@ export default class BoardManager {
   }
 
   addPokemon(pokemon: IPokemon): Pokemon {
+    if (this.pokemons.has(pokemon.id)) {
+      return this.pokemons.get(pokemon.id)!
+    }
     const coordinates = transformCoordinate(
       pokemon.positionX,
       pokemon.positionY
@@ -143,9 +146,6 @@ export default class BoardManager {
 
     this.animationManager.animatePokemon(pokemonUI, pokemon.action, false)
     this.pokemons.set(pokemonUI.id, pokemonUI)
-    if (pokemon.positionY != 0 && this.mode !== BoardMode.PICK) {
-      pokemonUI.destroy()
-    }
 
     return pokemonUI
   }

--- a/app/public/src/game/components/minigame-manager.ts
+++ b/app/public/src/game/components/minigame-manager.ts
@@ -177,9 +177,6 @@ export default class MinigameManager {
         case "avatarId":
           if (value != "" && typeof value === "string") {
             const avatar = this.pokemons.get(value)
-            logger.debug(
-              `Player ${value} (${avatar?.playerId}) has taken portal ${portal.id}`
-            )
             this.symbols.forEach((symbol) => {
               if (symbol.getData("portalId") === portal.id) {
                 this.removeSymbol(symbol)

--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -188,11 +188,7 @@ export default class Pokemon extends DraggableObject {
       this.animationLocked = false
       const g = <GameScene>scene
       // go back to idle anim if no more animation in queue
-      g.animationManager?.animatePokemon(
-        this,
-        pokemon.action,
-        this.flip
-      )
+      g.animationManager?.animatePokemon(this, pokemon.action, this.flip)
     })
     this.height = this.sprite.height
     this.width = this.sprite.width

--- a/app/public/src/game/game-container.ts
+++ b/app/public/src/game/game-container.ts
@@ -40,6 +40,7 @@ import Count from "../../../models/colyseus-models/count"
 import { Ability } from "../../../types/enum/Ability"
 import { Portal, SynergySymbol } from "../../../models/colyseus-models/portal"
 import Simulation from "../../../core/simulation"
+import { BoardMode } from "./components/board-manager"
 
 class GameContainer {
   room: Room<GameState>
@@ -513,7 +514,12 @@ class GameContainer {
   /* Board pokemons */
 
   handleBoardPokemonAdd(player: IPlayer, pokemon: IPokemon) {
-    if (player.id === this.spectatedPlayerId) {
+    const board = this.gameScene?.board
+    if (
+      board &&
+      player.id === this.spectatedPlayerId &&
+      (board.mode === BoardMode.PICK || pokemon.positionY === 0)
+    ) {
       const pokemonUI = this.gameScene?.board?.addPokemon(pokemon)
       if (pokemonUI && pokemon.action === PokemonActionState.FISH) {
         pokemonUI.fishingAnimation()

--- a/app/public/src/pages/component/game/game-stage-info.tsx
+++ b/app/public/src/pages/component/game/game-stage-info.tsx
@@ -103,7 +103,7 @@ export default function GameStageInfo() {
                   className="pokemon-portrait"
                 />
                 {opponentTitle && (
-                  <p className="player-title">{opponentTitle}</p>
+                  <p className="player-title">{t(`title.${opponentTitle}`)}</p>
                 )}
                 <p className="player-name">
                   {isPVE ? t(opponentName) : opponentName}

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -204,6 +204,7 @@ export class OnGameStartRequestCommand extends Command<
               this.room.setGameStarted(true)
               logger.debug("game start", game.roomId)
               this.room.broadcast(Transfer.GAME_START, game.roomId)
+              setTimeout(() => this.room.disconnect(), 30000) // TRYFIX: ranked lobbies prep rooms not being removed
             }
           })
         }

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -112,8 +112,6 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
         if (!data) {
           // remove room listing data
           if (roomIndex !== -1) {
-            const previousData = this.rooms[roomIndex]
-
             this.rooms.splice(roomIndex, 1)
 
             this.clients.forEach((client) => {

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -272,7 +272,8 @@ export const UltraShop = new Array<Pkm>(
   Pkm.ELECTRIKE,
   Pkm.SHUPPET,
   Pkm.HAPPINY,
-  Pkm.SOLOSIS
+  Pkm.SOLOSIS,
+  Pkm.SOBBLE
 )
 
 export const UniqueShop = new Array<PkmProposition>(


### PR DESCRIPTION
* fix vine whip description

* prevent sprite duplicates for fishing/eggs

* translate opponent title

* increase carousel radius

* add sobble to ultra shop

* tryfix ranked lobbies prep rooms not being removed