### PR TITLE
fix pve wild title

### DIFF
--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -1830,7 +1830,8 @@
     "FISHERMAN": "Fisherman",
     "CHOSEN_ONE": "Chosen One",
     "VANQUISHER": "Vanquisher",
-    "OUTSIDER": "Outsider"
+    "OUTSIDER": "Outsider",
+    "WILD": "Wild"
   },
   "title_description": {
     "NOVICE": "Play your first game",

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1199,7 +1199,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
             this.state.shinyEncounter,
             pveStage.emotion
           )
-          player.opponentTitle = "Wild"
+          player.opponentTitle = "WILD"
           const rewards = pveStage.getRewards(this.state.shinyEncounter)
           resetArraySchema(player.pveRewards, rewards)
 


### PR DESCRIPTION
PVE title "Wild" was not translated correctly