### PR TITLE
improve bot power eval

### DIFF
--- a/app/public/src/pages/component/bot-builder/bot-logic.ts
+++ b/app/public/src/pages/component/bot-builder/bot-logic.ts
@@ -74,9 +74,9 @@ export const POWER_SCORE_BY_CATEGORY = {
 }
 
 export const POWER_AVERAGES = [
-  2, 3, 3.5, 4, 4.5, 5, 6, 7, 8, 9, 11, 11.5, 12, 13, 14, 15, 16, 17, 18, 19,
-  24, 25, 25.5, 26, 27, 27.5, 28, 28.5, 29, 29.5, 30, 30.5, 31, 31.5, 32, 32.5,
-  33, 33.5, 34, 34.5, 35, 35.5, 36, 36.5, 37, 37.5, 38, 38.5, 39, 39.5, 40
+  2, 2, 3, 4, 4.5, 5, 6, 7, 8, 9, 11, 11.5, 12, 13, 14, 15, 16, 17, 18, 19, 24,
+  25, 25.5, 26, 27, 27.5, 28, 28.5, 29, 29.5, 30, 30.5, 31, 31.5, 32, 32.5, 33,
+  33.5, 34, 34.5, 35, 35.5, 36, 36.5, 37, 37.5, 38, 38.5, 39, 39.5, 40
 ]
 
 export const BOT_SCORES = {
@@ -176,12 +176,13 @@ export function rewriteBotRoundsRequiredto1(bot: IBot) {
 }
 
 export function estimateElo(bot: IBot): number {
+  const stepsToEvaluate = bot.steps.slice(3)
   const averageScore =
-    bot.steps
+    stepsToEvaluate
       .map((step, stage) =>
         getPowerEvaluation(getPowerScore(step.board), stage)
       )
-      .reduce((total, score) => total + score, 0) / bot.steps.length
+      .reduce((total, score) => total + score, 0) / stepsToEvaluate.length
 
   if (averageScore < 10) return 500
   if (averageScore < 20) return 600

--- a/app/public/src/pages/component/bot-builder/bot-logic.ts
+++ b/app/public/src/pages/component/bot-builder/bot-logic.ts
@@ -176,13 +176,12 @@ export function rewriteBotRoundsRequiredto1(bot: IBot) {
 }
 
 export function estimateElo(bot: IBot): number {
-  const stepsToEvaluate = bot.steps.slice(3)
+  const scores = bot.steps
+    .map((step, stage) => getPowerEvaluation(getPowerScore(step.board), stage))
+    .slice(3)
+
   const averageScore =
-    stepsToEvaluate
-      .map((step, stage) =>
-        getPowerEvaluation(getPowerScore(step.board), stage + 3)
-      )
-      .reduce((total, score) => total + score, 0) / stepsToEvaluate.length
+    scores.reduce((total, score) => total + score, 0) / scores.length
 
   if (averageScore < 10) return 500
   if (averageScore < 20) return 600

--- a/app/public/src/pages/component/bot-builder/bot-logic.ts
+++ b/app/public/src/pages/component/bot-builder/bot-logic.ts
@@ -180,7 +180,7 @@ export function estimateElo(bot: IBot): number {
   const averageScore =
     stepsToEvaluate
       .map((step, stage) =>
-        getPowerEvaluation(getPowerScore(step.board), stage)
+        getPowerEvaluation(getPowerScore(step.board), stage + 3)
       )
       .reduce((total, score) => total + score, 0) / stepsToEvaluate.length
 


### PR DESCRIPTION
the first 3 stages should not be counted in power evaluation- they don’t fight players

as suggested here: https://discord.com/channels/737230355039387749/1182091636818313296