### PR TITLE
prevent exception server with aftersimulationStart

### DIFF
--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -182,14 +182,17 @@ export default class Simulation extends Schema implements ISimulation {
           }
 
           player.board.forEach((pokemon) => {
-            pokemon.afterSimulationStart({
-              simulation: this,
-              player,
-              team: entityTeam,
-              entity: values(entityTeam).find(
-                (p) => p.refToBoardPokemon === pokemon
-              )!
-            })
+            const entity = values(entityTeam).find(
+              (p) => p.refToBoardPokemon === pokemon
+            )
+            if (entity) {
+              pokemon.afterSimulationStart({
+                simulation: this,
+                player,
+                team: entityTeam,
+                entity
+              })
+            }
           })
         }
       }


### PR DESCRIPTION
this screwed up an entire lobby by causing server side exception on fights, will need hotfix

![WindowsTerminal_QYrMp9UY3B](https://github.com/keldaanCommunity/pokemonAutoChess/assets/566536/3dbe3792-06fa-4381-a930-a4f2b915c888)

i don't know why it only happens know, possibly because a Mawile owner had disconnected during game. This should prevent the exception but I think we'll need to dig deepter to find the root cause of why the entity cannot be found.