### PR TITLE
refactor dynamic synergies

### DIFF
--- a/app/public/dist/client/changelog/patch-4.6.md
+++ b/app/public/dist/client/changelog/patch-4.6.md
@@ -19,7 +19,7 @@
 
 # Bugfix
 
--
+- Arceus/Kecleon dynamic synergies should now also work in bot builder / team planner
 
 # Misc
 

--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -41,6 +41,7 @@ import {
 } from "../../../../types/Config"
 import { DebugScene } from "../scenes/debug-scene"
 import { preferences } from "../../preferences"
+import { values } from "../../../../utils/schemas"
 
 export default class Pokemon extends DraggableObject {
   evolution: Pkm
@@ -143,7 +144,7 @@ export default class Pokemon extends DraggableObject {
     this.def = pokemon.def
     this.speDef = pokemon.speDef
     this.attackType = pokemon.attackType
-    pokemon.types.forEach((t) => this.types.add(t))
+    this.types = new Set(values(pokemon.types))
     this.maxPP = pokemon.maxPP
     this.atkSpeed = pokemon.atkSpeed
     this.targetX = null

--- a/app/public/src/pages/component/bot-builder/team-builder.tsx
+++ b/app/public/src/pages/component/bot-builder/team-builder.tsx
@@ -13,9 +13,9 @@ import {
 import { Synergy } from "../../../../../types/enum/Synergy"
 import { PkmWithConfig, Emotion } from "../../../../../types"
 import Synergies from "../synergy/synergies"
-import "./team-builder.css"
 import { computeSynergies } from "../../../../../models/colyseus-models/synergies"
 import BotAvatar from "./bot-avatar"
+import "./team-builder.css"
 
 export default function TeamBuilder(props: {
   bot?: IBot

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -86,12 +86,6 @@ export class OnShopCommand extends Command<
     if (!canBuy) return
 
     player.money -= cost
-    if (
-      pokemon.passive === Passive.PROTEAN2 ||
-      pokemon.passive === Passive.PROTEAN3
-    ) {
-      this.room.checkDynamicSynergies(player, pokemon)
-    }
 
     const x = player.getFirstAvailablePositionInBench()
     pokemon.positionX = x !== undefined ? x : -1
@@ -134,12 +128,6 @@ export class OnDragDropCommand extends Command<
       message.updateItems = false
       const pokemon = player.board.get(detail.id)
       if (pokemon) {
-        if (
-          pokemon.passive === Passive.PROTEAN2 ||
-          pokemon.passive === Passive.PROTEAN3
-        ) {
-          this.room.checkDynamicSynergies(player, pokemon)
-        }
         const x = parseInt(detail.x)
         const y = parseInt(detail.y)
         if (pokemon.name === Pkm.DITTO) {
@@ -200,9 +188,6 @@ export class OnDragDropCommand extends Command<
             }
           }
         }
-        player.synergies.update(player.board)
-        player.effects.update(player.synergies, player.board)
-        player.boardSize = this.room.getTeamSize(player.board)
       }
 
       if (!success && client.send) {
@@ -214,6 +199,7 @@ export class OnDragDropCommand extends Command<
 
       player.synergies.update(player.board)
       player.effects.update(player.synergies, player.board)
+      player.boardSize = this.room.getTeamSize(player.board)
     }
     if (commands.length > 0) {
       return commands
@@ -1023,7 +1009,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
             this.room.swap(player, pokemon, coordinate[0], coordinate[1])
           }
         }
-        if(numberOfPokemonsToMove > 0){
+        if (numberOfPokemonsToMove > 0) {
           player.synergies.update(player.board)
         }
       }

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -594,9 +594,12 @@ export default class GameRoom extends Room<GameState> {
             if (rank === 1) {
               usr.wins += 1
               if (this.state.lobbyType === LobbyType.RANKED) {
-                usr.booster += 1                
+                usr.booster += 1
                 player.titles.add(Title.VANQUISHER)
-                if(usr.elo === Math.min(...values(this.state.players).map(p => p.elo)) && humans.length >= 8){
+                const minElo = Math.min(
+                  ...values(this.state.players).map((p) => p.elo)
+                )
+                if (usr.elo === minElo && humans.length >= 8) {
                   player.titles.add(Title.OUTSIDER)
                 }
                 this.presence.publish("ranked-lobby-winner", player)
@@ -764,33 +767,6 @@ export default class GameRoom extends Room<GameState> {
     return values(player.board).find(
       (pokemon) => pokemon.positionX == x && pokemon.positionY == y
     )
-  }
-
-  checkDynamicSynergies(player: Player, pokemon: Pokemon) {
-    const n =
-      pokemon.passive === Passive.PROTEAN3
-        ? 3
-        : pokemon.passive === Passive.PROTEAN2
-        ? 2
-        : 1
-    const rankArray = new Array<{ s: Synergy; v: number }>()
-    player.synergies.forEach((value, key) => {
-      if (value > 0) {
-        rankArray.push({ s: key as Synergy, v: value })
-      }
-    })
-    rankArray.sort((a, b) => {
-      return b.v - a.v
-    })
-    pokemon.types.clear()
-    for (let i = 0; i < n; i++) {
-      const kv = rankArray.shift()
-      if (kv) {
-        pokemon.types.add(kv.s)
-      }
-    }
-    player.synergies.update(player.board)
-    player.effects.update(player.synergies, player.board)
   }
 
   checkEvolutionsAfterPokemonAcquired(playerId: string) {


### PR DESCRIPTION
Refactor dynamic synergies computation for Arceus/Kecleon so that it also works for team planner / bot builder

Also contains two optimizations:
- add false on board.onAdd to prevent listening for changes twice
- computing synergies was done twice after drag n drop
