### PR TITLE
Refactor targeting

### DIFF
--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -18,6 +18,8 @@ export default class AttackingState extends PokemonState {
 
     if (pokemon.cooldown <= 0) {
       pokemon.cooldown = pokemon.getAttackDelay()
+
+      // first, try to hit the same target than previous attack
       let target = board.getValue(pokemon.targetX, pokemon.targetY)
       let targetCoordinate: { x: number; y: number } | undefined = {
         x: pokemon.targetX,
@@ -39,26 +41,25 @@ export default class AttackingState extends PokemonState {
           ) <= pokemon.range
         )
       ) {
-        targetCoordinate = this.getNearestTargetCoordinate(pokemon, board)
+        // if target is no longer alive or at range, retargeting
+        targetCoordinate = this.getNearestTargetAtRangeCoordinates(
+          pokemon,
+          board
+        )
         if (targetCoordinate) {
           target = board.getValue(targetCoordinate.x, targetCoordinate.y)
         }
       }
 
-      // no target case
-      if (!targetCoordinate) {
-        pokemon.toMovingState()
-      } else if (pokemon.status.charm) {
-        pokemon.toMovingState()
-      } else if (
-        distanceC(
-          pokemon.positionX,
-          pokemon.positionY,
-          targetCoordinate.x,
-          targetCoordinate.y
-        ) > pokemon.range
-      ) {
-        pokemon.toMovingState()
+      // no target at range, changing to moving state
+      if (!target || !targetCoordinate || pokemon.status.charm) {
+        const targetAtSight = this.getNearestTargetAtSightCoordinates(
+          pokemon,
+          board
+        )
+        if (targetAtSight) {
+          pokemon.toMovingState()
+        }
       } else if (
         target &&
         pokemon.pp >= pokemon.maxPP &&

--- a/app/core/moving-state.ts
+++ b/app/core/moving-state.ts
@@ -14,18 +14,21 @@ export default class MovingState extends PokemonState {
     super.update(pokemon, dt, board, weather)
     if (pokemon.cooldown <= 0) {
       pokemon.cooldown = weather === Weather.SNOW ? 666 : 500
-      const targetCoordinate = this.getNearestTargetCoordinate(pokemon, board)
-      if (targetCoordinate) {
-        const distance = distanceC(
-          pokemon.positionX,
-          pokemon.positionY,
-          targetCoordinate.x,
-          targetCoordinate.y
-        )
-        if (distance <= pokemon.range && !pokemon.status.charm) {
+      const targetAtRange = this.getNearestTargetAtRangeCoordinates(
+        pokemon,
+        board
+      )
+      if (targetAtRange) {
+        if (!pokemon.status.charm) {
           pokemon.toAttackingState()
-        } else if (distance > 1) {
-          this.move(pokemon, board, targetCoordinate)
+        }
+      } else {
+        const targetAtSight = this.getNearestTargetAtSightCoordinates(
+          pokemon,
+          board
+        )
+        if (targetAtSight) {
+          this.move(pokemon, board, targetAtSight)
         }
       }
     } else {
@@ -107,6 +110,7 @@ export default class MovingState extends PokemonState {
   onEnter(pokemon: PokemonEntity) {
     super.onEnter(pokemon)
     pokemon.action = PokemonActionState.WALK
+    pokemon.cooldown = 0
   }
 
   onExit(pokemon: PokemonEntity) {

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -86,7 +86,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   @type("string") emotion: Emotion
   cooldown = 500
   manaCooldown = 1000
-  state: MovingState
+  state: PokemonState
   simulation: Simulation
   baseAtk: number
   baseDef: number

--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -626,8 +626,12 @@ export default class Status extends Schema implements IStatus {
       if (pkm.simulation.weather === Weather.MISTY) {
         timer = Math.round(timer * 1.3)
       }
-      this.charm = true
+      this.charm = true        
       this.charmCooldown = timer
+      if(origin){
+        pkm.targetX = origin?.positionX
+        pkm.targetY = origin?.positionY
+      }   
     }
   }
 

--- a/app/public/src/game/animation-manager.ts
+++ b/app/public/src/game/animation-manager.ts
@@ -2617,18 +2617,18 @@ export default class AnimationManager {
       entity
     )
 
-    let lock = false,
-      loop = false
+    let lock = false
+    let repeat: number | undefined
     if (
       action === PokemonActionState.HOP ||
       action === PokemonActionState.HURT
     ) {
       lock = true
-      loop = true
+      repeat = -1
     }
 
     try {
-      this.play(entity, animation, { flip, lock, loop })
+      this.play(entity, animation, { flip, lock, repeat })
     } catch (err) {
       logger.warn(`Can't play animation ${animation} for ${entity.name}`, err)
     }
@@ -2637,11 +2637,11 @@ export default class AnimationManager {
   play(
     entity: Pokemon,
     animation: AnimationType,
-    animationConfig: { flip?: boolean; loop?: boolean; lock?: boolean } = {}
+    config: { flip?: boolean; repeat?: number; lock?: boolean } = {}
   ) {
     if (entity.animationLocked) return
 
-    const orientation = animationConfig.flip
+    const orientation = config.flip
       ? OrientationFlip[entity.orientation]
       : entity.orientation
 
@@ -2659,15 +2659,9 @@ export default class AnimationManager {
     const animKey = `${textureIndex}/${tint}/${animation}/${SpriteType.ANIM}/${orientationCorrected}`
     const shadowKey = `${textureIndex}/${tint}/${animation}/${SpriteType.SHADOW}/${orientationCorrected}`
 
-    if (animationConfig.loop) {
-      // force loop an anim for debug scene in sprite viewer
-      entity.sprite.anims.play({ key: animKey, repeat: -1 })
-      entity.shadow.anims.play({ key: shadowKey, repeat: -1 })
-    } else {
-      entity.sprite.anims.play(animKey)
-      entity.shadow.anims.play(shadowKey)
-    }
-    if (animationConfig.lock) {
+    entity.sprite.anims.play({ key: animKey, repeat: config.repeat })
+    entity.shadow.anims.play({ key: shadowKey, repeat: config.repeat })
+    if (config.lock) {
       entity.animationLocked = true
     }
   }

--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -322,7 +322,7 @@ export default class BattleManager {
               this.animationManager.play(
                 pkm,
                 AnimationConfig[pkm.name as Pkm].ability,
-                { flip: this.flip, lock: true, loop: false }
+                { flip: this.flip, lock: true, repeat: 0 }
               )
               pkm.specialAttackAnimation(this.group, value)
             }

--- a/app/public/src/game/scenes/debug-scene.ts
+++ b/app/public/src/game/scenes/debug-scene.ts
@@ -70,7 +70,7 @@ export class DebugScene extends Phaser.Scene {
     this.pokemon.orientation = orientation
     if (animationType in AnimationType) {
       try {
-        this.animationManager.play(this.pokemon, animationType, { loop: true })
+        this.animationManager.play(this.pokemon, animationType, { repeat: -1 })
       } catch (err) {
         logger.error(
           `Error playing animation ${this.pokemon.name} ${animationType}`,


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1183398539456413706

- add a second targeting algorithm for targets at range, supposedly more performant and precise than the previous one
- reset cooldown when switching to moving state to reduce lag when target is dead or invalid
- retarget when being charmed
- prevent ability anim to loop


Targeting / moving algorithms are very tricky so if something breaks, i expect this comes from this PR. But it looks good with my tests