### PR TITLE
Ranked lobby countdown

### DIFF
--- a/app/public/dist/client/changelog/patch-4.7.md
+++ b/app/public/dist/client/changelog/patch-4.7.md
@@ -15,3 +15,5 @@
 # Bugfix
 
 # Misc
+
+- Added Ultraball Ranked lobby on a weekly basis, on Sunday at 9pm UTC. 5 boosters for the winner

--- a/app/public/dist/client/changelog/patch-4.7.md
+++ b/app/public/dist/client/changelog/patch-4.7.md
@@ -12,6 +12,8 @@
 
 # UI
 
+- Next ranked lobby is now shown with a countdown in lobby room menu. Removed ranked lobbies chat announcements.
+
 # Bugfix
 
 # Misc

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -2521,5 +2521,6 @@
   },
   "lobby_full": "Lobby is full",
   "game_already_started": "Game has already started",
-  "min_rank_not_reached": "Your rank is not high enough to play this ranked match"
+  "min_rank_not_reached": "Your rank is not high enough to play this ranked match",
+  "ranked_match": "Ranked Match"
 }

--- a/app/public/src/pages/component/available-room-menu/room-item.tsx
+++ b/app/public/src/pages/component/available-room-menu/room-item.tsx
@@ -3,7 +3,10 @@ import React from "react"
 import { IPreparationMetadata } from "../../../../../types"
 import { cc } from "../../utils/jsx"
 import "./room-item.css"
-import { EloRankThreshold, MAX_PLAYERS_PER_LOBBY } from "../../../../../types/Config"
+import {
+  EloRankThreshold,
+  MAX_PLAYERS_PER_LOBBY
+} from "../../../../../types/Config"
 import { useTranslation } from "react-i18next"
 import { useAppSelector } from "../../../hooks"
 
@@ -14,15 +17,19 @@ export default function RoomItem(props: {
   const { t } = useTranslation()
   const user = useAppSelector((state) => state.lobby.user)
 
-  let canJoin = true, disabledReason = null
-  if(props.room.clients >= MAX_PLAYERS_PER_LOBBY){
-    canJoin = false;
+  let canJoin = true,
+    disabledReason: string | null = null
+  if (props.room.clients >= MAX_PLAYERS_PER_LOBBY) {
+    canJoin = false
     disabledReason = t("lobby_full")
-  } else if(props.room.metadata?.gameStarted === true){
-    canJoin = false;
+  } else if (props.room.metadata?.gameStarted === true) {
+    canJoin = false
     disabledReason = t("game_already_started")
-  } else if(props.room.metadata?.minRank != null && (user?.elo ?? 0) < EloRankThreshold[props.room.metadata?.minRank]){
-    canJoin = false;
+  } else if (
+    props.room.metadata?.minRank != null &&
+    (user?.elo ?? 0) < EloRankThreshold[props.room.metadata?.minRank]
+  ) {
+    canJoin = false
     disabledReason = t("min_rank_not_reached")
   }
 
@@ -49,7 +56,11 @@ export default function RoomItem(props: {
       {props.room.metadata?.minRank && (
         <img
           alt={t("minimum_rank")}
-          title={t("minimum_rank")+": "+t("elorank."+props.room.metadata?.minRank)}
+          title={
+            t("minimum_rank") +
+            ": " +
+            t("elorank." + props.room.metadata?.minRank)
+          }
           className="rank icon"
           src={"/assets/ranks/" + props.room.metadata?.minRank + ".svg"}
         />
@@ -58,7 +69,7 @@ export default function RoomItem(props: {
         {props.room.clients}/{MAX_PLAYERS_PER_LOBBY}
       </span>
       <button
-        title={disabledReason}
+        title={disabledReason ?? t("join")}
         disabled={!canJoin}
         className={cc(
           "bubbly",

--- a/app/public/src/pages/component/available-room-menu/room-menu.css
+++ b/app/public/src/pages/component/available-room-menu/room-menu.css
@@ -27,6 +27,26 @@
   margin: 0 auto;
 }
 
+.room-menu .rank.icon {
+  width: 50px;
+}
+
+.special-lobby-announcement {
+  background: #40404080;
+  padding: 0.4em 0.5em;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5em;
+  margin: 0;
+  width: 100%;
+}
+
+.special-lobby-announcement span:last-child {
+  flex: 0 0 6ch;
+}
+
 @media (max-width: 640px) {
   .room-menu .subtitle {
     font-size: 3vw;

--- a/app/public/src/pages/component/available-room-menu/room-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/room-menu.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from "react-i18next"
 import { localStore, LocalStoreKeys } from "../../utils/store"
 import { LobbyType } from "../../../../../types/enum/Game"
 import "./room-menu.css"
+import { SpecialLobbyCountdown } from "./special-lobby-countdown"
 
 export default function RoomMenu(props: {
   toPreparation: boolean
@@ -169,6 +170,7 @@ export default function RoomMenu(props: {
       <TabPanel>
         {user ? (
           <>
+            <SpecialLobbyCountdown />
             {preparationRooms.length === 0 && (
               <p className="subtitle">
                 {isFreshNewUser ? t("join_a_lobby") : t("click_on_create_room")}

--- a/app/public/src/pages/component/available-room-menu/special-lobby-countdown.tsx
+++ b/app/public/src/pages/component/available-room-menu/special-lobby-countdown.tsx
@@ -1,0 +1,57 @@
+import { t } from "i18next"
+import React, { useState, useEffect } from "react"
+import { EloRank } from "../../../../../types/Config"
+import { formatTimeout } from "../../utils/date"
+import { useAppSelector } from "../../../hooks"
+
+export function SpecialLobbyCountdown() {
+  const [clock, setClock] = useState<Date>(new Date())
+  useEffect(() => {
+    const interval = setInterval(() => setClock(new Date()), 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const nextSpecialLobbyDate = useAppSelector(
+    (state) => state.lobby.nextSpecialLobbyDate
+  )
+  const nextSpecialLobbyType = useAppSelector(
+    (state) => state.lobby.nextSpecialLobbyType
+  )
+
+  let specialLobbyIcon, specialLobbyName
+  if (nextSpecialLobbyType === "GREATBALL_RANKED") {
+    specialLobbyName = `${t("elorank." + EloRank.GREATBALL)} ${t(
+      "ranked_match"
+    )}`
+    specialLobbyIcon = (
+      <img
+        alt={t("minimum_rank")}
+        title={t("minimum_rank") + ": " + t("elorank." + EloRank.GREATBALL)}
+        className="rank icon"
+        src={"/assets/ranks/" + EloRank.GREATBALL + ".svg"}
+      />
+    )
+  } else if (nextSpecialLobbyType === "ULTRABALL_RANKED") {
+    specialLobbyName = `${t("elorank." + EloRank.ULTRABALL)} ${t(
+      "ranked_match"
+    )}`
+    specialLobbyIcon = (
+      <img
+        alt={t("minimum_rank")}
+        title={t("minimum_rank") + ": " + t("elorank." + EloRank.ULTRABALL)}
+        className="rank icon"
+        src={"/assets/ranks/" + EloRank.ULTRABALL + ".svg"}
+      />
+    )
+  }
+
+  const timeUntilNext =
+    nextSpecialLobbyDate - Math.floor(clock.getTime() / 1000)
+
+  return nextSpecialLobbyDate && nextSpecialLobbyType && timeUntilNext > 0 ? (
+    <p className="special-lobby-announcement">
+      {specialLobbyIcon} {specialLobbyName}
+      <span>{formatTimeout(timeUntilNext)}</span>
+    </p>
+  ) : null
+}

--- a/app/public/src/pages/lobby.tsx
+++ b/app/public/src/pages/lobby.tsx
@@ -39,7 +39,9 @@ import {
   setLeaderboard,
   pushBotLog,
   setLanguage,
-  leaveLobby
+  leaveLobby,
+  setNextSpecialLobbyDate,
+  setNextSpecialLobbyType
 } from "../stores/LobbyStore"
 import {
   ICustomLobbyState,
@@ -259,6 +261,14 @@ export async function joinLobbyRoom(
               })
             })
           })
+
+          room.state.listen("nextSpecialLobbyDate", (date) => {
+            dispatch(setNextSpecialLobbyDate(date))
+          });
+
+          room.state.listen("nextSpecialLobbyType", (type) => {
+            dispatch(setNextSpecialLobbyType(type))
+          });
 
           room.state.users.onRemove((u) => {
             dispatch(removeUser(u.id))

--- a/app/public/src/pages/utils/date.ts
+++ b/app/public/src/pages/utils/date.ts
@@ -7,3 +7,13 @@ export function formatDate(n: number) {
     timeStyle: "short"
   }).format(date)
 }
+
+export function formatTimeout(s: number) {
+  const h = Math.floor(s / 3600)
+  s -= h * 3600
+  const m = Math.floor(s / 60)
+  s -= m * 60
+  return `${h > 0 ? h + "h" : ""}${("00" + m).slice(-2)}:${("00" + s).slice(
+    -2
+  )}`
+}

--- a/app/public/src/stores/LobbyStore.ts
+++ b/app/public/src/stores/LobbyStore.ts
@@ -19,6 +19,7 @@ import { IPokemonConfig } from "../../../models/mongo-models/user-metadata"
 import { playSound, SOUNDS } from "../pages/utils/audio"
 import { Language } from "../../../types/enum/Language"
 import { MAX_BOTS_STAGE } from "../pages/component/bot-builder/bot-logic"
+import { SpecialLobbyType } from "../../../types/enum/Game"
 
 export interface IUserLobbyState {
   botLogDatabase: string[]
@@ -39,6 +40,8 @@ export interface IUserLobbyState {
   boosterContent: string[]
   suggestions: ISuggestionUser[]
   language: Language
+  nextSpecialLobbyDate: number
+  nextSpecialLobbyType: SpecialLobbyType | ""
 }
 
 const initialState: IUserLobbyState = {
@@ -69,7 +72,9 @@ const initialState: IUserLobbyState = {
     elo: 1200,
     name: "ditto",
     id: ""
-  }
+  },
+  nextSpecialLobbyDate: 0,
+  nextSpecialLobbyType: ""
 }
 
 export const lobbySlice = createSlice({
@@ -198,7 +203,13 @@ export const lobbySlice = createSlice({
     setLanguage: (state, action: PayloadAction<Language>) => {
       state.language = action.payload
     },
-    leaveLobby: () => initialState
+    leaveLobby: () => initialState,
+    setNextSpecialLobbyDate: (state, action: PayloadAction<number>) => {
+      state.nextSpecialLobbyDate = action.payload
+    },
+    setNextSpecialLobbyType: (state, action: PayloadAction<string>) => {
+      state.nextSpecialLobbyType = action.payload as SpecialLobbyType
+    }
   }
 })
 
@@ -225,7 +236,9 @@ export const {
   setBotData,
   leaveLobby,
   setSuggestions,
-  pushBotLog
+  pushBotLog,
+  setNextSpecialLobbyDate,
+  setNextSpecialLobbyType
 } = lobbySlice.actions
 
 export default lobbySlice.reducer

--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -1073,5 +1073,7 @@ export class OpenRankedLobbyCommand extends Command<
       roomName,
       autoStartDelayInSeconds: 15 * 60
     })
+
+    this.state.getNextSpecialLobbyDate()
   }
 }

--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -1059,10 +1059,13 @@ export class OpenRankedLobbyCommand extends Command<
   execute({ minRank }: { minRank: EloRank }) {
     logger.info("Creating Ranked Lobby " + minRank)
     let roomName = "Ranked Match"
-    if(minRank === EloRank.GREATBALL){
+    if (minRank === EloRank.GREATBALL) {
       roomName = "Great Ball Ranked Match"
     }
-    
+    if (minRank === EloRank.ULTRABALL) {
+      roomName = "Ultra Ball Ranked Match"
+    }
+
     matchMaker.createRoom("preparation", {
       lobbyType: LobbyType.RANKED,
       minRank,

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -228,6 +228,7 @@ export class OnGameStartRequestCommand extends Command<
             noElo: this.state.noElo,
             selectedMap: this.state.selectedMap,
             lobbyType: this.state.lobbyType,
+            minRank: this.state.minRank,
             whenReady: (game) => {
               this.room.setGameStarted(true)
               logger.debug("game start", game.roomId)

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -50,7 +50,7 @@ import {
 } from "./commands/lobby-commands"
 import { Language } from "../types/enum/Language"
 import { CronJob } from "cron"
-import { EloRank } from "../types/Config"
+import { EloRank, GREATBALL_RANKED_LOBBY_CRON, ULTRABALL_RANKED_LOBBY_CRON } from "../types/Config"
 
 export default class CustomLobbyRoom extends Room<LobbyState> {
   discordWebhook: WebhookClient | undefined
@@ -511,8 +511,8 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
       start: true
     })
 
-    const rankedLobbyJob = CronJob.from({
-      cronTime: "0 0 2-22/4 * * *", // every four hours from 2 to 22
+    const greatBallRankedLobbyJob = CronJob.from({
+      cronTime: GREATBALL_RANKED_LOBBY_CRON,
       //cronTime: "0 0/1 * * * *", // DEBUG: trigger every minute
       timeZone: "Europe/Paris",
       onTick: () => {
@@ -523,12 +523,14 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
       start: true
     })
 
-    const rankedLobbyReminderJob = CronJob.from({
-      cronTime: "0 0 1-21/4 * * *", // every four hours from 1 to 21
+    const ultratBallRankedLobbyJob = CronJob.from({
+      cronTime: ULTRABALL_RANKED_LOBBY_CRON,
       //cronTime: "0 0/1 * * * *", // DEBUG: trigger every minute
       timeZone: "Europe/Paris",
       onTick: () => {
-        this.state.addAnnouncement(`Ranked match is starting in 1 hour !`)
+        this.dispatcher.dispatch(new OpenRankedLobbyCommand(), {
+          minRank: EloRank.ULTRABALL
+        })
       },
       start: true
     })

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -100,6 +100,7 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
   async onCreate(): Promise<void> {
     logger.info("create lobby", this.roomId)
     this.setState(new LobbyState())
+    this.state.getNextSpecialLobbyDate()
     this.autoDispose = false
     this.listing.unlisted = true
 

--- a/app/rooms/states/game-state.ts
+++ b/app/rooms/states/game-state.ts
@@ -9,7 +9,8 @@ import {
   StageDuration,
   BOARD_WIDTH,
   BOARD_HEIGHT,
-  DungeonPMDO
+  DungeonPMDO,
+  EloRank
 } from "../../types/Config"
 import { GamePhaseState, LobbyType } from "../../types/enum/Game"
 import { Weather } from "../../types/enum/Weather"
@@ -62,6 +63,7 @@ export default class GameState extends Schema {
   preparationId: string
   shinyEncounter = false
   pveRewards: Item[] = []
+  minRank: EloRank | null = null
 
   constructor(
     preparationId: string,
@@ -69,6 +71,7 @@ export default class GameState extends Schema {
     noElo: boolean,
     selectedMap: DungeonPMDO | "random",
     lobbyType: LobbyType,
+    minRank: EloRank | null
   ) {
     super()
     this.preparationId = preparationId
@@ -77,6 +80,7 @@ export default class GameState extends Schema {
     this.id = selectedMap === "random" ? pickRandomIn(DungeonPMDO) : selectedMap
     this.noElo = noElo
     this.lobbyType = lobbyType
+    this.minRank = minRank
     this.mapName = this.id
     this.mapMusic = pickRandomIn(Object.keys(Dungeon) as Dungeon[])
     this.weather = Weather.NEUTRAL    

--- a/app/rooms/states/lobby-state.ts
+++ b/app/rooms/states/lobby-state.ts
@@ -3,10 +3,18 @@ import { nanoid } from "nanoid"
 import LobbyUser from "../../models/colyseus-models/lobby-user"
 import Message from "../../models/colyseus-models/message"
 import chatV2 from "../../models/mongo-models/chat-v2"
+import { SpecialLobbyType } from "../../types/enum/Game"
+import { sendAt } from "cron"
+import {
+  GREATBALL_RANKED_LOBBY_CRON,
+  ULTRABALL_RANKED_LOBBY_CRON
+} from "../../types/Config"
 
 export default class LobbyState extends Schema {
   @type([Message]) messages = new ArraySchema<Message>()
   @type({ map: LobbyUser }) users = new MapSchema<LobbyUser>()
+  @type("number") nextSpecialLobbyDate: number = 0
+  @type("string") nextSpecialLobbyType: SpecialLobbyType | "" = ""
 
   addMessage(
     payload: string,
@@ -53,5 +61,24 @@ export default class LobbyState extends Schema {
 
   addAnnouncement(message: string) {
     this.addMessage(message, "server", "Server Announcement", "0294/Joyous")
+  }
+
+  getNextSpecialLobbyDate() {
+    const nextGreatBallRanked = sendAt(
+      GREATBALL_RANKED_LOBBY_CRON
+    ).toUnixInteger()
+    const nextUltraBallRanked = sendAt(
+      ULTRABALL_RANKED_LOBBY_CRON
+    ).toUnixInteger()
+    this.nextSpecialLobbyDate = Math.min(
+      nextGreatBallRanked,
+      nextUltraBallRanked
+    )
+
+    if (this.nextSpecialLobbyDate === nextGreatBallRanked) {
+      this.nextSpecialLobbyType = "GREATBALL_RANKED"
+    } else if (this.nextSpecialLobbyDate === nextUltraBallRanked) {
+      this.nextSpecialLobbyType = "ULTRABALL_RANKED"
+    }
   }
 }

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -1045,3 +1045,6 @@ export const DTEF_HEIGHT = 192
 export const DTEF_TILESET_WIDTH = 6
 export const DTEF_TILESET_HEIGHT = 8
 export const DTEF_TILESET_TILE_WIDTH = 24
+
+export const GREATBALL_RANKED_LOBBY_CRON = "0 0 2-22/4 * * *" // every four hours from 2h to 22h
+export const ULTRABALL_RANKED_LOBBY_CRON = "0 0 21 * * 7" // on Sunday at 21h

--- a/app/types/enum/Game.ts
+++ b/app/types/enum/Game.ts
@@ -16,6 +16,8 @@ export enum LobbyType {
   RANKED = "RANKED"
 }
 
+export type SpecialLobbyType = "GREATBALL_RANKED" | "ULTRABALL_RANKED"
+
 export enum GamePhaseState {
   PICK,
   FIGHT,

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -2,7 +2,8 @@ import {
   ArraySchema,
   MapSchema,
   SetSchema,
-  CollectionSchema
+  CollectionSchema,
+  Schema
 } from "@colyseus/schema"
 import Board from "../core/board"
 import Dps from "../core/dps"
@@ -21,6 +22,7 @@ import {
   Orientation,
   PokemonActionState,
   Rarity,
+  SpecialLobbyType,
   Stat
 } from "./enum/Game"
 import { Emotion } from "./enum/Emotion"
@@ -229,15 +231,17 @@ export interface IDragDropCombineMessage {
   itemB: Item
 }
 
-export interface ICustomLobbyState {
+export interface ICustomLobbyState extends Schema {
   messages: ArraySchema<Message>
   users: MapSchema<LobbyUser>
   leaderboard: ILeaderboardInfo[]
   botLeaderboard: ILeaderboardInfo[]
   levelLeaderboard: ILeaderboardInfo[]
+  nextSpecialLobbyDate: number
+  nextSpecialLobbyType: SpecialLobbyType | ""
 }
 
-export interface IGameState {
+export interface IGameState extends Schema {
   afterGameId: string
   roundTime: number
   phase: string


### PR DESCRIPTION
- Next ranked lobby is now shown with a countdown in lobby room menu. Removed ranked lobbies chat announcements.
- Added Ultraball Ranked lobby on a weekly basis, on Sunday at 9pm UTC. 5 boosters for the winner

added minRank in game state
added nextSpecialLobbyDate and nextSpecialLobbyType in lobby state


![chrome_imWIuitrmx](https://github.com/keldaanCommunity/pokemonAutoChess/assets/566536/b870d860-fd0f-4d7a-a878-345705c9b933)

