### PR TITLE
add back sleep duration reduction

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -830,6 +830,11 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     if (berry && this.life > 0 && this.life < 0.5 * this.hp) {
       this.eatBerry(berry)
     }
+
+    // Reduce sleep duration
+    if (this.status.sleepCooldown > 0) {
+      this.status.sleepCooldown -= 500
+    }
   }
 
   onCritical({ target, board }: { target: PokemonEntity; board: Board }) {

--- a/app/public/dist/client/changelog/patch-4.7.md
+++ b/app/public/dist/client/changelog/patch-4.7.md
@@ -25,3 +25,4 @@
 # Misc
 
 - Added Ultraball Ranked lobby on a weekly basis, on Sunday at 9pm UTC. 5 boosters for the winner
+- Added back the sleep duration reduction when taking damage: -0.5 seconds per hit received


### PR DESCRIPTION
Added back the sleep duration reduction when taking damage: -0.5 seconds per hit received

can't remember when and why it has been removed