### PR TITLE
Removed on-crit effects for abilities

### DIFF
--- a/app/core/abilities/ability-strategy.ts
+++ b/app/core/abilities/ability-strategy.ts
@@ -69,10 +69,6 @@ export class AbilityStrategy {
       pokemon.count.starDustCount++
     }
 
-    if (crit) {
-      pokemon.onCritical({ target, board })
-    }
-
     if (pokemon.items.has(Item.LEPPA_BERRY)) {
       pokemon.eatBerry(Item.LEPPA_BERRY)
     }

--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -136,7 +136,7 @@ export default class AttackingState extends PokemonState {
       let totalTakenDamage = 0
 
       if (Math.random() * 100 < pokemon.critChance) {
-        pokemon.onCritical({ target, board })
+        pokemon.onCriticalAttack({ target, board })
         if (target.items.has(Item.ROCKY_HELMET) === false) {
           let opponentCritDamage = pokemon.critDamage
           if (target.effects.has(Effect.BATTLE_ARMOR)) {

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -522,10 +522,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
 
     if (this.effects.has(Effect.TELEPORT_NEXT_ATTACK)) {
       const crit =
-        this.items.has(Item.REAPER_CLOTH) && chance(this.critChance / 100)
-      if (crit) {
-        this.onCritical({ target, board })
-      }
+        this.items.has(Item.REAPER_CLOTH) && chance(this.critChance / 100)      
       target.handleSpecialDamage(
         [15, 30, 60][this.stars - 1],
         board,
@@ -832,7 +829,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     }
   }
 
-  onCritical({ target, board }: { target: PokemonEntity; board: Board }) {
+  onCriticalAttack({ target, board }: { target: PokemonEntity; board: Board }) {
     target.count.crit++
 
     // proc fairy splash damage for both the attacker and the target

--- a/app/public/dist/client/changelog/patch-4.7.md
+++ b/app/public/dist/client/changelog/patch-4.7.md
@@ -12,6 +12,7 @@
 
 # Gameplay
 
+- Removed on-crit effects for abilities: scope lens PP gain, fairy splash and razor fang armor reduction no longer apply for abilities crit
 - Comfey floral heal and Leppa berry consumption are now done before casting the ability
 
 # UI


### PR DESCRIPTION
Removed on-crit effects for abilities: scope lens PP gain, fairy splash and razor fang armor reduction no longer apply for abilities crit

this was being abused with AoE + full crit stuff