### PR TITLE
Flame toxic orb rune protect

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -606,7 +606,7 @@ export class CorruptedNatureStrategy extends AbilityStrategy {
     const cells = board.getAdjacentCells(target.positionX, target.positionY)
     cells.forEach((cell) => {
       if (cell.value && cell.value.team !== pokemon.team) {
-        cell.value.status.triggerWound(5000, cell.value, pokemon, board)
+        cell.value.status.triggerWound(5000, cell.value, pokemon)
         cell.value.handleSpecialDamage(
           damage,
           board,
@@ -1525,7 +1525,7 @@ export class TriAttackStrategy extends AbilityStrategy {
         target.status.triggerFreeze(2000, target)
         break
       case 2:
-        target.status.triggerBurn(5000, target, pokemon, board)
+        target.status.triggerBurn(5000, target, pokemon)
         break
       case 3:
         target.status.triggerParalysis(5000, target)
@@ -1953,7 +1953,7 @@ export class HealBlockStrategy extends AbilityStrategy {
 
     cells.forEach((cell) => {
       if (cell.value && pokemon.team != cell.value.team) {
-        cell.value.status.triggerWound(timer, cell.value, pokemon, board)
+        cell.value.status.triggerWound(timer, cell.value, pokemon)
       }
     })
   }
@@ -2061,7 +2061,7 @@ export class BurnStrategy extends AbilityStrategy {
     }
     board.forEach((x: number, y: number, value: PokemonEntity | undefined) => {
       if (value && pokemon.team != value.team) {
-        value.status.triggerBurn(duration, value, pokemon, board)
+        value.status.triggerBurn(duration, value, pokemon)
       }
     })
   }
@@ -2421,7 +2421,7 @@ export class InfernalParadeStrategy extends AbilityStrategy {
         })
 
         if (Math.random() > 0.5) {
-          enemy.status.triggerBurn(3000, cell.value, pokemon, board)
+          enemy.status.triggerBurn(3000, cell.value, pokemon)
         }
 
         repeat(2)(() =>
@@ -2531,7 +2531,7 @@ export class SolarBeamStrategy extends AbilityStrategy {
     effectInLine(board, pokemon, target, (targetInLine) => {
       if (targetInLine != null && targetInLine.team !== pokemon.team) {
         if (pokemon.simulation.weather === Weather.SUN) {
-          targetInLine.status.triggerBurn(3000, targetInLine, pokemon, board)
+          targetInLine.status.triggerBurn(3000, targetInLine, pokemon)
         }
 
         targetInLine.handleSpecialDamage(
@@ -3017,7 +3017,7 @@ export class SmokeScreenStrategy extends AbilityStrategy {
             pokemon,
             crit
           )
-          cell.value.status.triggerBurn(duration, cell.value, pokemon, board)
+          cell.value.status.triggerBurn(duration, cell.value, pokemon)
           cell.value.status.triggerArmorReduction(duration)
           pokemon.simulation.room.broadcast(Transfer.ABILITY, {
             id: pokemon.simulation.id,
@@ -3308,7 +3308,7 @@ export class SteamEruptionStrategy extends AbilityStrategy {
 
     const cells = board.getAdjacentCells(target.positionX, target.positionY)
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    target.status.triggerBurn(burnDuration, target, pokemon, board)
+    target.status.triggerBurn(burnDuration, target, pokemon)
 
     cells.forEach((cell) => {
       if (cell.value && pokemon.team != cell.value.team) {
@@ -3319,7 +3319,7 @@ export class SteamEruptionStrategy extends AbilityStrategy {
           pokemon,
           crit
         )
-        cell.value.status.triggerBurn(burnDuration, cell.value, pokemon, board)
+        cell.value.status.triggerBurn(burnDuration, cell.value, pokemon)
       }
     })
   }
@@ -4123,7 +4123,7 @@ export class SpiritShackleStrategy extends AbilityStrategy {
           pokemon,
           crit
         )
-        targetInLine.status.triggerWound(4000, targetInLine, pokemon, board)
+        targetInLine.status.triggerWound(4000, targetInLine, pokemon)
       }
     })
   }
@@ -4520,7 +4520,7 @@ export class FireSpinStrategy extends AbilityStrategy {
     const damage = [20, 40, 80][pokemon.stars - 1] ?? 80
     const cells = board.getAdjacentCells(target.positionX, target.positionY)
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    target.status.triggerBurn(3000, target, pokemon, board)
+    target.status.triggerBurn(3000, target, pokemon)
     cells.forEach((cell) => {
       if (cell.value && pokemon.team != cell.value.team) {
         cell.value.handleSpecialDamage(
@@ -4530,7 +4530,7 @@ export class FireSpinStrategy extends AbilityStrategy {
           pokemon,
           crit
         )
-        cell.value.status.triggerBurn(3000, target, pokemon, board)
+        cell.value.status.triggerBurn(3000, target, pokemon)
       }
     })
   }
@@ -4560,7 +4560,7 @@ export class SearingShotStrategy extends AbilityStrategy {
           pokemon,
           crit
         )
-        cell.value.status.triggerBurn(3000, target, pokemon, board)
+        cell.value.status.triggerBurn(3000, target, pokemon)
       }
     })
   }
@@ -4871,7 +4871,7 @@ export class SlashingClawStrategy extends AbilityStrategy {
       damage = Math.ceil(damage * 1.3)
     }
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    target.status.triggerWound(5000, target, pokemon, board)
+    target.status.triggerWound(5000, target, pokemon)
   }
 }
 
@@ -4912,7 +4912,7 @@ export class EruptionStrategy extends AbilityStrategy {
     }
 
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    target.status.triggerBurn(5000, target, pokemon, board)
+    target.status.triggerBurn(5000, target, pokemon)
   }
 }
 
@@ -5303,7 +5303,7 @@ export class PyroBallStrategy extends AbilityStrategy {
     )
     cells.forEach((cell) => {
       if (cell.value && cell.value.team != pokemon.team) {
-        cell.value.status.triggerBurn(2000, cell.value, pokemon, board)
+        cell.value.status.triggerBurn(2000, cell.value, pokemon)
         cell.value.handleSpecialDamage(
           damage,
           board,

--- a/app/core/abilities/hidden-power.ts
+++ b/app/core/abilities/hidden-power.ts
@@ -71,7 +71,7 @@ export class HiddenPowerBStrategy extends HiddenPowerStrategy {
     super.process(unown, state, board, target, crit)
     board.forEach((x: number, y: number, enemy: PokemonEntity | undefined) => {
       if (enemy && unown.team != enemy.team) {
-        enemy.status.triggerBurn(30000, enemy, unown, board)
+        enemy.status.triggerBurn(30000, enemy, unown)
       }
     })
   }

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -274,8 +274,8 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
         attacker.items.has(Item.POKEMONOMICON) &&
         attackType === AttackType.SPECIAL
       ) {
-        this.status.triggerBurn(3000, this, attacker, board)
-        this.status.triggerWound(3000, this, attacker, board)
+        this.status.triggerBurn(3000, this, attacker)
+        this.status.triggerWound(3000, this, attacker)
       }
       if (
         this.items.has(Item.POWER_LENS) &&
@@ -690,7 +690,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
         this.addAttack(3)
       }
       if (chance(burnChance)) {
-        target.status.triggerBurn(2000, target, this, board)
+        target.status.triggerBurn(2000, target, this)
       }
     }
 
@@ -744,7 +744,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
 
     // Ability effects on hit
     if (target.status.spikeArmor && this.range === 1) {
-      this.status.triggerWound(2000, this, target, board)
+      this.status.triggerWound(2000, this, target)
       this.handleDamage({
         damage: Math.round(target.def * (1 + target.ap / 100)),
         board,

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -513,6 +513,17 @@ export default class PokemonState {
     if (pokemon.fairySplashCooldown > 0) {
       pokemon.fairySplashCooldown = min(0)(pokemon.fairySplashCooldown - dt)
     }
+
+    if (pokemon.items.has(Item.FLAME_ORB) && !pokemon.status.burn) {
+      pokemon.status.triggerBurn(60000, pokemon, pokemon)
+    }
+
+    if (
+      pokemon.items.has(Item.TOXIC_ORB) &&
+      pokemon.status.poisonStacks === 0
+    ) {
+      pokemon.status.triggerPoison(60000, pokemon, pokemon)
+    }
   }
 
   onEnter(pokemon: PokemonEntity) {}

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -549,8 +549,7 @@ export default class Simulation extends Schema implements ISimulation {
           pokemon.status.triggerBurn(
             60000,
             pokemon as PokemonEntity,
-            pokemon as PokemonEntity,
-            this.board
+            pokemon as PokemonEntity
           )
         }
 

--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -341,12 +341,7 @@ export default class Status extends Schema implements IStatus {
     pkm: PokemonEntity,
     origin: PokemonEntity | undefined
   ) {
-    // fluffy tail prevents burn but not rune protect
-    if (
-      !pkm.effects.has(Effect.IMMUNITY_BURN) &&
-      (!this.runeProtect ||
-        (pkm.items.has(Item.FLAME_ORB) && !pkm.items.has(Item.FLUFFY_TAIL))) // can escape flame orb burn only with fluffy tail
-    ) {
+    if (!pkm.effects.has(Effect.IMMUNITY_BURN) && !this.runeProtect) {
       this.burn = true
       if (timer > this.burnCooldown) {
         this.burnCooldown = timer
@@ -436,11 +431,7 @@ export default class Status extends Schema implements IStatus {
     pkm: PokemonEntity,
     origin: PokemonEntity | undefined
   ) {
-    if (
-      !pkm.effects.has(Effect.IMMUNITY_POISON) &&
-      (!this.runeProtect ||
-        (pkm.items.has(Item.TOXIC_ORB) && !pkm.items.has(Item.FLUFFY_TAIL))) // can escape toxic orb poison only with fluffy tail
-    ) {
+    if (!pkm.effects.has(Effect.IMMUNITY_POISON) && !this.runeProtect) {
       let maxStacks = 3
       if (origin) {
         this.poisonOrigin = origin

--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -108,7 +108,7 @@ export default class Status extends Schema implements IStatus {
         attacker: null,
         shouldTargetGainMana: true
       })
-      this.triggerWound(1000, pokemon, undefined, board)
+      this.triggerWound(1000, pokemon, undefined)
     }
 
     if (pokemon.status.runeProtect) {
@@ -302,13 +302,13 @@ export default class Status extends Schema implements IStatus {
       this.synchro = false
       this.triggerSynchro()
       if (this.burn && this.burnOrigin) {
-        this.burnOrigin.status.triggerBurn(3000, this.burnOrigin, pkm, board)
+        this.burnOrigin.status.triggerBurn(3000, this.burnOrigin, pkm)
       }
       if (this.poisonStacks && this.poisonOrigin) {
         this.poisonOrigin.status.triggerPoison(3000, this.poisonOrigin, pkm)
       }
       if (this.wound && this.woundOrigin) {
-        this.woundOrigin.status.triggerWound(3000, this.woundOrigin, pkm, board)
+        this.woundOrigin.status.triggerWound(3000, this.woundOrigin, pkm)
       }
       if (this.silence && this.silenceOrigin) {
         this.silenceOrigin.status.triggerSilence(3000, pkm)
@@ -339,8 +339,7 @@ export default class Status extends Schema implements IStatus {
   triggerBurn(
     timer: number,
     pkm: PokemonEntity,
-    origin: PokemonEntity | undefined,
-    board: Board
+    origin: PokemonEntity | undefined
   ) {
     // fluffy tail prevents burn but not rune protect
     if (
@@ -643,8 +642,7 @@ export default class Status extends Schema implements IStatus {
   triggerWound(
     timer: number,
     pkm: PokemonEntity,
-    origin: PokemonEntity | undefined,
-    board: Board
+    origin: PokemonEntity | undefined
   ) {
     if (!this.runeProtect) {
       this.wound = true

--- a/app/public/dist/client/changelog/patch-4.7.md
+++ b/app/public/dist/client/changelog/patch-4.7.md
@@ -79,6 +79,7 @@ Base components stats have been reviewed to be closer to each other:
 - Adjusted Gracidea flower: ~~1 attack 25% attack speed~~ 3 attack 20% attack speed~~
 - Buff Big Nugget: def & special def ~~3~~ 5
 - Buff Toxic Orb: spe def ~~1~~ 2
+- Burn and poison from Flame Orb and Toxic Orb can now be healed with Rune Protect, but are reapplied at the end of Rune protect effect.FLAME_OR
 
 # Gameplay
 


### PR DESCRIPTION
allow burn/poison to be cleared with all items, but reapply the burn/poison every second when holding the item to mitigate the importance of rune protect

as discussed in #dev