### PR TITLE
tryfix special lobby countdown timezone issue

### DIFF
--- a/app/public/src/pages/component/available-room-menu/special-lobby-countdown.tsx
+++ b/app/public/src/pages/component/available-room-menu/special-lobby-countdown.tsx
@@ -56,8 +56,12 @@ export function SpecialLobbyCountdown() {
     )
   }
 
-  const timeUntilNext =
-    nextSpecialLobbyDate - Math.floor(clock.getTime() / 1000)
+  let timeUntilNext = -1
+  if (nextSpecialLobbyDate) {
+    timeUntilNext = Math.floor(
+      (new Date(nextSpecialLobbyDate).getTime() - clock.getTime()) / 1000
+    )
+  }
 
   return nextSpecialLobbyDate && nextSpecialLobbyType && timeUntilNext > 0 ? (
     <p className="special-lobby-announcement">

--- a/app/public/src/stores/LobbyStore.ts
+++ b/app/public/src/stores/LobbyStore.ts
@@ -40,7 +40,7 @@ export interface IUserLobbyState {
   boosterContent: string[]
   suggestions: ISuggestionUser[]
   language: Language
-  nextSpecialLobbyDate: number
+  nextSpecialLobbyDate: string | ""
   nextSpecialLobbyType: SpecialLobbyType | ""
 }
 
@@ -73,7 +73,7 @@ const initialState: IUserLobbyState = {
     name: "ditto",
     id: ""
   },
-  nextSpecialLobbyDate: 0,
+  nextSpecialLobbyDate: "",
   nextSpecialLobbyType: ""
 }
 
@@ -204,7 +204,7 @@ export const lobbySlice = createSlice({
       state.language = action.payload
     },
     leaveLobby: () => initialState,
-    setNextSpecialLobbyDate: (state, action: PayloadAction<number>) => {
+    setNextSpecialLobbyDate: (state, action: PayloadAction<string>) => {
       state.nextSpecialLobbyDate = action.payload
     },
     setNextSpecialLobbyType: (state, action: PayloadAction<string>) => {

--- a/app/rooms/states/lobby-state.ts
+++ b/app/rooms/states/lobby-state.ts
@@ -14,7 +14,7 @@ import { SpecialLobbyType } from "../../types/enum/Game"
 export default class LobbyState extends Schema {
   @type([Message]) messages = new ArraySchema<Message>()
   @type({ map: LobbyUser }) users = new MapSchema<LobbyUser>()
-  @type("number") nextSpecialLobbyDate: number = 0
+  @type("string") nextSpecialLobbyDate: string = ""
   @type("string") nextSpecialLobbyType: SpecialLobbyType | "" = ""
 
   addMessage(
@@ -72,17 +72,20 @@ export default class LobbyState extends Schema {
       ULTRABALL_RANKED_LOBBY_CRON
     ).toUnixInteger()
     const nextScribble = sendAt(SCRIBBLE_LOBBY_CRON).toUnixInteger()
-    this.nextSpecialLobbyDate = Math.min(
+    const nextSpecialLobbyDateInt = Math.min(
       nextGreatBallRanked,
       nextUltraBallRanked,
       nextScribble
     )
+    this.nextSpecialLobbyDate = new Date(
+      nextSpecialLobbyDateInt * 1000
+    ).toISOString()
 
-    if (this.nextSpecialLobbyDate === nextGreatBallRanked) {
+    if (nextSpecialLobbyDateInt === nextGreatBallRanked) {
       this.nextSpecialLobbyType = "GREATBALL_RANKED"
-    } else if (this.nextSpecialLobbyDate === nextUltraBallRanked) {
+    } else if (nextSpecialLobbyDateInt === nextUltraBallRanked) {
       this.nextSpecialLobbyType = "ULTRABALL_RANKED"
-    } else if (this.nextSpecialLobbyDate === nextScribble) {
+    } else if (nextSpecialLobbyDateInt === nextScribble) {
       this.nextSpecialLobbyType = "SCRIBBLE"
     }
   }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -278,7 +278,7 @@ export interface ICustomLobbyState extends Schema {
   leaderboard: ILeaderboardInfo[]
   botLeaderboard: ILeaderboardInfo[]
   levelLeaderboard: ILeaderboardInfo[]
-  nextSpecialLobbyDate: number
+  nextSpecialLobbyDate: string
   nextSpecialLobbyType: SpecialLobbyType | ""
 }
 


### PR DESCRIPTION
try to pass the nextSpecialLobbyDate as string instead of number to preserve the ISO Timezone information

this bug only occures on prod because the prod server has a different timezone than my browser, so i can't attest this will fix the issue