### PR TITLE
Dynamically resize game screen to fit to more various screen resolutions, especially on lower aspect ratios

### DIFF
--- a/app/core/design.ts
+++ b/app/core/design.ts
@@ -46,7 +46,7 @@ export default class Design {
   bitmask: Mask[][] = []
   layers: TileMapping[][] = []
   width = 42
-  height = 22
+  height = 32
   frequency: number
   persistance: number
   tileset: Tileset

--- a/app/public/dist/client/changelog/patch-4.8.md
+++ b/app/public/dist/client/changelog/patch-4.8.md
@@ -66,6 +66,7 @@
 
 # UI
 
+- Dynamically resize game screen to fit to more various screen resolutions, especially on lower aspect ratios
 - Add a keyboard shortcut "E" when hovering a portrait in shop to quickly buy/resell the unit
 - Add a sort filter and search bar on Collection screen
 - Add a search box to Pokemons wiki

--- a/app/public/src/game/game-container.ts
+++ b/app/public/src/game/game-container.ts
@@ -36,6 +36,7 @@ import {
 import { Synergy } from "../../../types/enum/Synergy"
 import { Weather } from "../../../types/enum/Weather"
 import { logger } from "../../../utils/logger"
+import { clamp } from "../../../utils/number"
 import { getPath, transformCoordinate } from "../pages/utils/utils"
 import store from "../stores"
 import { changePlayer } from "../stores/GameStore"
@@ -247,6 +248,21 @@ class GameContainer {
       tilemap: this.tilemap,
       spectate: this.spectate
     })
+    this.game.scale.on("resize", this.resize, this)
+  }
+
+  resize() {
+    const screenWidth = window.innerWidth - 60
+    const screenHeight = window.innerHeight
+    const screenRatio = screenWidth / screenHeight
+    const WIDTH = 42 * 48
+    const MIN_HEIGHT = 1008
+    const MAX_HEIGHT = 32 * 48
+    const height = clamp(WIDTH / screenRatio, MIN_HEIGHT, MAX_HEIGHT)
+
+    if (this.game && this.game.scale.height !== height) {
+      this.game.scale.setGameSize(WIDTH, height)
+    }
   }
 
   initializeEvents() {


### PR DESCRIPTION
Extend game tilemap height to 32 tiles, and dynamically resize the height of the game container on window resize. This allow to make the game screen fit the entire space available for more various screen resolutions