### PR TITLE
Post-fight-fixes

### DIFF
--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -266,7 +266,7 @@ export default class Status extends Schema implements IStatus {
   }
 
   updateRage(dt: number, pokemon: PokemonEntity) {
-    if (this.enrageDelay - dt <= 0) {
+    if (this.enrageDelay - dt <= 0 && !pokemon.simulation.finished) {
       this.enraged = true
       this.protect = false
       pokemon.addAttackSpeed(100)

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -655,9 +655,9 @@ export class OnUpdateCommand extends Command<
 
         this.state.simulations.forEach((simulation) => {
           if (!simulation.finished) {
+            simulation.update(deltaTime)
             everySimulationFinished = false
           }
-          simulation.update(deltaTime)
         })
 
         if (everySimulationFinished && !this.state.updatePhaseNeeded) {


### PR DESCRIPTION
stop calling simulation.update when its finished, so that board effects / status do not proc after victory

fix https://discord.com/channels/737230355039387749/1210983859408207953

i'm not sure if this should land in prod or not, not really a hotfix but some players may expect that, considering the bug report above