### PR TITLE
Negative ap

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -4007,8 +4007,7 @@ export class FleurCannonStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, state, board, target, crit)
-    const damage = 140
-    pokemon.addAbilityPower(-20)
+    const damage = 120
     effectInLine(board, pokemon, target, (targetInLine) => {
       if (targetInLine != null && targetInLine.team !== pokemon.team) {
         targetInLine.handleSpecialDamage(
@@ -4020,6 +4019,7 @@ export class FleurCannonStrategy extends AbilityStrategy {
         )
       }
     })
+    pokemon.addAbilityPower(-20)
   }
 }
 

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -84,7 +84,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   @type(Count) count: Count
   @type("uint8") critChance = DEFAULT_CRIT_CHANCE
   @type("float32") critDamage = DEFAULT_CRIT_DAMAGE
-  @type("uint16") ap = 0
+  @type("int16") ap = 0
   @type("uint16") healDone: number
   @type("string") emotion: Emotion
   cooldown = 500
@@ -375,7 +375,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
 
   addAbilityPower(value: number, apBoost = false) {
     const boost = apBoost ? (value * this.ap) / 100 : 0
-    this.ap = min(0)(Math.round(this.ap + Math.round(value + boost)))
+    this.ap = min(-100)(Math.round(this.ap + Math.round(value + boost)))
   }
 
   addDefense(value: number, apBoost = false) {

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -1068,9 +1068,9 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
 
   // called after killing an opponent (does not proc if resurection)
   onKill({ target, board }: { target: PokemonEntity; board: Board }) {
-    if (this.passive === Passive.SOUL_HEART && this.pp < this.maxPP / 2) {
-      this.addPP(this.maxPP / 2 - this.pp)
-      this.addAbilityPower(30, false)
+    if (this.passive === Passive.SOUL_HEART) {
+      this.addPP(10)
+      this.addAbilityPower(10, false)
     }
 
     if (this.items.has(Item.AMULET_COIN) && this.player) {

--- a/app/public/dist/client/changelog/patch-4.9.md
+++ b/app/public/dist/client/changelog/patch-4.9.md
@@ -49,6 +49,8 @@
 
 # Gameplay
 
+- Ability Power can now go to negative values, down to -100% minimum, after a debuff from various abilities and effects in the game. Negative AP scales down the special damage and other scaled values for abilities.
+
 # UI
 
 - Add a visual feedback when hovering one of your pokemons to drag or sell

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -1344,7 +1344,7 @@
     "PETAL_BLIZZARD": "Deals [30,SP] SPECIAL to surounding enemies and gain 10% AP",
     "SUNSTEEL_STRIKE": "Jumps and lands in the middle of the enemy team with the power of a meteor, inflicting [100,SP] SPECIAL to adjacent enemies and BURN for 3 seconds",
     "MOONGEIST_BEAM": "Deal [100,SP] SPECIAL to all enemy Pokémon in a straight line and make them PARALYSIS for 3 seconds",
-    "FLEUR_CANNON": "Sends a devastating laser beam that inflicts [140,SP] SPECIAL on all enemies in the beam. Reduces the AP of the caster by 20"
+    "FLEUR_CANNON": "Sends a devastating laser beam that inflicts [120,SP] SPECIAL on all enemies in the beam. Reduces the AP of the caster by 20"
   },
   "effect": {
     "INGRAIN": "Ingrain",
@@ -1852,7 +1852,7 @@
     "LYCANROC": "Lycanroc turns into night form during NIGHT and day form during SUN",
     "COSMOG": "$t(pkm.COSMOG) is feeding with the energy of the stars. Gain 10 permanent max HP every time you evolve a unit. Evolve after 10 times.",
     "COSMOEM": "$t(pkm.COSMOEM) is feeding with the energy of the stars. Gain 10 permanent max HP every time you evolve a unit. Evolve after 10 times into $t(pkm.SOLGALEO) if in the light spot, or $t(pkm.LUNALA) instead.",
-    "SOUL_HEART": "Restores half its PP and increases AP by 30 for each KO inflicted by the caster"
+    "SOUL_HEART": "Every time the caster gets a KO, gain 10 AP and 10 PP"
   },
   "stat": {
     "ATK": "Attack",

--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -650,7 +650,7 @@ export default class BattleManager {
               this.displayBoost(Stat.AP, pkm.positionX, pkm.positionY)
             pkm.ap = pokemon.ap
             if (pkm.detail && pkm.detail instanceof PokemonDetail) {
-              pkm.detail.ap.textContent = pokemon.ap.toString()
+              pkm.detail.updateValue(pkm.detail.ap, previousValue, value)
               pkm.detail.updateAbilityDescription(pkm.skill, pkm.stars, pkm.ap)
               if (pokemon.passive != Passive.NONE) {
                 pkm.detail.updatePassiveDescription(

--- a/app/public/src/game/components/pokemon-detail.tsx
+++ b/app/public/src/game/components/pokemon-detail.tsx
@@ -89,6 +89,7 @@ export default class PokemonDetail extends GameObjects.DOMElement {
 
     this.ap = document.createElement("p")
     this.ap.textContent = ap.toString()
+    this.ap.classList.toggle("negative", ap < 0)
 
     this.pp = document.createElement("p")
     this.pp.innerHTML = pp.toString()
@@ -200,6 +201,7 @@ export default class PokemonDetail extends GameObjects.DOMElement {
 
   updateValue(el: HTMLElement, previousValue: number, value: number) {
     el.textContent = value.toString()
+    el.classList.toggle("negative", value < 0)
   }
 
   updateAbilityDescription(skill: Ability, abilityTier: number, ap: number) {

--- a/app/public/src/pages/component/game/game-pokemon-detail.css
+++ b/app/public/src/pages/component/game/game-pokemon-detail.css
@@ -90,6 +90,10 @@
   vertical-align: middle;
 }
 
+.game-pokemon-detail-stats .negative {
+  color: red;
+}
+
 .game-pokemon-detail-ult {
   grid-area: ult;
 }


### PR DESCRIPTION
Ability Power can now go to negative values, down to -100% minimum, after a debuff from various abilities and effects in the game. Negative AP scales down the special damage and other scaled values for abilities.

This opens the gate to large AP debuffs as a new mechanic to counter AP oriented teams (could replace global Silence of Ghastly/old Lucario)

Also adjusted Magearna:
- fixed AP being reduced before and not after casting
- fixed passive not giving AP if pp is over 50%
- balanced fleur cannon damage and passive boosts in compensation

![chrome_A43xLCGO1p](https://github.com/keldaanCommunity/pokemonAutoChess/assets/566536/8b337639-829a-4081-9859-41a250ce0f40)
