### PR TITLE
fairy splash handleSpecialDamage

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -1032,12 +1032,12 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
 
         if (distance <= 1) {
           // melee range
-          splashTarget.handleDamage({
+          splashTarget.handleSpecialDamage({
             damage,
             board,
             attackType: AttackType.SPECIAL,
             attacker: pokemon,
-            shouldTargetGainMana: false
+            crit: false
           })
         }
 


### PR DESCRIPTION
Fairy splash damage was handled by handleDamage instead of handleSpecialDamage, preventing interactions with power lens, magic bounce, and pokenomicon