### PR TITLE
show negative ap scaled values in ability descriptions

### DIFF
--- a/app/public/dist/client/changelog/patch-4.10.md
+++ b/app/public/dist/client/changelog/patch-4.10.md
@@ -36,6 +36,7 @@
 # Bugfix
 
 - Fix Meteor Mash ability targeting
+- Ability descriptions now show properly scaled values when AP is negative
 
 # Misc
 

--- a/app/public/src/pages/utils/descriptions.tsx
+++ b/app/public/src/pages/utils/descriptions.tsx
@@ -131,8 +131,7 @@ export function addIconsToDescription(description: string, tier = 0, ap = 0) {
             )}
             {array.map((v, j) => {
               const separator = j < array.length - 1 ? "/" : ""
-              const value =
-                ap > 0 ? Math.round(Number(v) * (1 + (scale * ap) / 100)) : v
+              const value = Math.round(Number(v) * (1 + (scale * ap) / 100))
               const active =
                 tier === undefined ||
                 array.length === 1 ||


### PR DESCRIPTION
Ability descriptions now show properly scaled values when AP is negative

https://discord.com/channels/737230355039387749/1226643236601204902