### PR TITLE
fix a bug causing to fish always epic Pokémon

### DIFF
--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -370,6 +370,7 @@ export default class Shop {
       threshold += rarityProbability[r]
       if (rarity_seed < threshold) {
         rarity = r as Rarity
+        break
       }
     }
 


### PR DESCRIPTION
Due to a missing break only epic Pokémon could be fished. This PR fixes this issue. 