### PR TITLE
temporarely disable lobbies of less than 4 players

### DIFF
--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -201,7 +201,8 @@ export class OnGameStartRequestCommand extends Command<
           ).toFixed(2)} % free (${totalMemory - freeMemory} / ${totalMemory})`
         )*/
 
-      if(nbHumanPlayers < 4){
+      if (nbHumanPlayers < 4) {
+        //TEMP
         this.state.addMessage({
           author: "Server",
           authorId: "server",

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -184,23 +184,31 @@ export class OnGameStartRequestCommand extends Command<
         return
       }
 
-      let freeMemory = os.freemem()
+      /*let freeMemory = os.freemem()
       let totalMemory = os.totalmem()
-      /*logger.info(
+      logger.info(
           `Memory freemem/totalmem: ${(
             (100 * freeMemory) /
             totalMemory
           ).toFixed(2)} % free (${totalMemory - freeMemory} / ${totalMemory})`
         )*/
-      freeMemory = memoryUsage().heapUsed
-      totalMemory = memoryUsage().heapTotal
+      const freeMemory = memoryUsage().heapUsed
+      const totalMemory = memoryUsage().heapTotal
       /*logger.info(
           `Memory heapUsed/heapTotal: ${(
             (100 * freeMemory) /
             totalMemory
           ).toFixed(2)} % free (${totalMemory - freeMemory} / ${totalMemory})`
         )*/
-      if (freeMemory < 0.1 * totalMemory) {
+
+      if(nbHumanPlayers < 4){
+        this.state.addMessage({
+          author: "Server",
+          authorId: "server",
+          payload: `Due to the influx of a large number of players, lobbies with fewer than 4 players are temporarily disabled. Sorry for the inconvenience.`,
+          avatar: "0025/Pain"
+        })
+      } else if (freeMemory < 0.1 * totalMemory) {
         // if less than 10% free memory available, prevents starting another game to avoid out of memory crash
         this.state.addMessage({
           author: "Server",


### PR DESCRIPTION
temporarely disable lobbies of less than 4 players

"Due to the influx of a large number of players, lobbies with fewer than 4 players are temporarily disabled. Sorry for the inconvenience."