### PR TITLE
emote menu fixes

### DIFF
--- a/app/public/dist/client/changelog/patch-5.1.md
+++ b/app/public/dist/client/changelog/patch-5.1.md
@@ -47,5 +47,7 @@
 - Add an option to disable damage numbers
 
 # Bugfix
+- Fixed emote keyboard shortcut changing tab
+- Fixed emote menu when player uses a shiny avatar
 
 # Misc

--- a/app/public/src/game/components/emote-menu.tsx
+++ b/app/public/src/game/components/emote-menu.tsx
@@ -33,7 +33,8 @@ export function EmoteMenuComponent(props: {
   ) : (
     <ul>
       {emotions.map((emotion, i) => {
-        const unlocked = pConfig && pConfig.emotions.includes(emotion)
+        const emotions = props.shiny ? pConfig.shinyEmotions : pConfig.emotions
+        const unlocked = pConfig && emotions.includes(emotion)
         return (
           <li key={emotion}>
             <img

--- a/app/public/src/game/components/pokemon-avatar.ts
+++ b/app/public/src/game/components/pokemon-avatar.ts
@@ -82,6 +82,7 @@ export default class PokemonAvatar extends PokemonSprite {
     NUM_KEYS.forEach((keycode, i) => {
       const onKeydown = (event) => {
         if (this.isCurrentPlayerAvatar && this.scene?.game && event.ctrlKey) {
+          event.preventDefault()
           this.sendEmote(AvatarEmotions[i])
         }
       }
@@ -210,7 +211,8 @@ export default class PokemonAvatar extends PokemonSprite {
     )
     const pokemonCollection = player?.pokemonCollection
     const pConfig = pokemonCollection?.[this.index]
-    const unlocked = pConfig && pConfig.emotions.includes(emotion)
+    const emotions = this.shiny ? pConfig.shinyEmotions : pConfig.emotions
+    const unlocked = pConfig && emotions.includes(emotion)
     if (unlocked) {
       store.dispatch(
         showEmote(getAvatarString(this.index, this.shiny, emotion))


### PR DESCRIPTION
- Fixed emote keyboard shortcut changing tab
- Fixed emote menu when player uses a shiny avatar