### PR TITLE
compute player damage immediately on victory

### DIFF
--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -49,7 +49,7 @@ export default class Player extends Schema implements IPlayer {
   @type(ExperienceManager) experienceManager = new ExperienceManager()
   @type({ map: "uint8" }) synergies = new Synergies()
   @type("uint16") money = process.env.MODE == "dev" ? 999 : 6
-  @type("uint8") life = 100
+  @type("int8") life = 100
   @type("boolean") shopLocked: boolean = false
   @type("uint8") streak: number = 0
   @type("uint8") interest: number = 0

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -33,6 +33,7 @@ import {
   IGameHistorySimplePlayer,
   IGameMetadata,
   IPokemon,
+  IPokemonEntity,
   Role,
   Title,
   Transfer
@@ -950,4 +951,58 @@ export default class GameRoom extends Room<GameState> {
       player.itemsProposition.clear()
     }
   }
+
+  computeRoundDamage(
+    opponentTeam: MapSchema<IPokemonEntity>,
+    stageLevel: number
+  ) {
+    if (this.state.specialGameRule === SpecialGameRule.NINE_LIVES) return 1
+
+    let damage = Math.ceil(stageLevel / 2)
+    if (opponentTeam.size > 0) {
+      opponentTeam.forEach((pokemon) => {
+        if (!pokemon.isClone) {
+          damage += 1
+        }
+      })
+    }
+    return damage
+  }
+
+  rankPlayers() {
+    const rankArray = new Array<{ id: string; life: number; level: number }>()
+    this.state.players.forEach((player) => {
+      if (!player.alive) {
+        return
+      }
+
+      rankArray.push({
+        id: player.id,
+        life: player.life,
+        level: player.experienceManager.level
+      })
+    })
+
+    const sortPlayers = (
+      a: { id: string; life: number; level: number },
+      b: { id: string; life: number; level: number }
+    ) => {
+      let diff = b.life - a.life
+      if (diff == 0) {
+        diff = b.level - a.level
+      }
+      return diff
+    }
+
+    rankArray.sort(sortPlayers)
+
+    rankArray.forEach((rankPlayer, index) => {
+      const player = this.state.players.get(rankPlayer.id)
+      if (player) {
+        player.rank = index + 1
+      }
+    })
+  }
+
+
 }


### PR DESCRIPTION
Player damage is now computed immediately on victory instead of on round change
Show negative player HP to make it clearer how players are ranked when two players are eliminated at the same round