### PR TITLE
tweak early game components rng

### DIFF
--- a/app/core/abilities/hidden-power.ts
+++ b/app/core/abilities/hidden-power.ts
@@ -4,7 +4,7 @@ import { PRECOMPUTED_POKEMONS_PER_TYPE_AND_CATEGORY } from "../../models/precomp
 import { Transfer } from "../../types"
 import { Ability } from "../../types/enum/Ability"
 import { AttackType, PokemonActionState, Rarity } from "../../types/enum/Game"
-import { BasicItems, Berries, Item } from "../../types/enum/Item"
+import { ItemComponents, Berries, Item } from "../../types/enum/Item"
 import { Pkm, getUnownsPoolPerStage } from "../../types/enum/Pokemon"
 import { Synergy } from "../../types/enum/Synergy"
 import { pickNRandomIn, pickRandomIn } from "../../utils/random"
@@ -227,7 +227,7 @@ export class HiddenPowerIStrategy extends HiddenPowerStrategy {
   ) {
     super.process(unown, state, board, target, crit)
     if (unown.player) {
-      unown.player.items.push(pickRandomIn(BasicItems))
+      unown.player.items.push(pickRandomIn(ItemComponents))
     }
   }
 }

--- a/app/core/evolution-rules.ts
+++ b/app/core/evolution-rules.ts
@@ -3,7 +3,7 @@ import { Pokemon } from "../models/colyseus-models/pokemon"
 import PokemonFactory from "../models/pokemon-factory"
 import { EvolutionTime } from "../types/Config"
 import { PokemonActionState } from "../types/enum/Game"
-import { BasicItems, Item } from "../types/enum/Item"
+import { ItemComponents, Item } from "../types/enum/Item"
 import { Passive } from "../types/enum/Passive"
 import { Pkm } from "../types/enum/Pokemon"
 import { logger } from "../utils/logger"
@@ -92,7 +92,7 @@ export class CountEvolutionRule extends EvolutionRule {
 
     let coord: { x: number; y: number } | undefined
     const itemsToAdd = new Array<Item>()
-    const basicItemsToAdd = new Array<Item>()
+    const itemComponentsToAdd = new Array<Item>()
 
     const pokemonsBeforeEvolution: Pokemon[] = []
 
@@ -114,8 +114,8 @@ export class CountEvolutionRule extends EvolutionRule {
         }
 
         pkm.items.forEach((el) => {
-          if (BasicItems.includes(el)) {
-            basicItemsToAdd.push(el)
+          if (ItemComponents.includes(el)) {
+            itemComponentsToAdd.push(el)
           } else {
             itemsToAdd.push(el)
           }
@@ -147,7 +147,7 @@ export class CountEvolutionRule extends EvolutionRule {
     itemsToAdd.forEach((item) => {
       player.items.push(item)
     })
-    basicItemsToAdd.forEach((item) => {
+    itemComponentsToAdd.forEach((item) => {
       player.items.push(item)
     })
 

--- a/app/core/matter/mini-game.ts
+++ b/app/core/matter/mini-game.ts
@@ -15,7 +15,7 @@ import Player from "../../models/colyseus-models/player"
 import { getOrientation } from "../../public/src/pages/utils/utils"
 import { PokemonActionState, Rarity } from "../../types/enum/Game"
 import {
-  BasicItems,
+  ItemComponents,
   CraftableItems,
   Item,
   SynergyStones
@@ -366,7 +366,7 @@ export class MiniGame {
 
     let nbItemsToPick = clamp(this.alivePlayers.length + 3, 5, 9)
     let maxCopiesPerItem = 2
-    let itemsSet = BasicItems
+    let itemsSet = ItemComponents
 
     if (stageLevel >= 20) {
       // Carousels after stage 20 propose full items and no longer components, and have one more proposition

--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -85,6 +85,7 @@ export default class Player extends Schema implements IPlayer {
   titles: Set<Title> = new Set<Title>()
   rerollCount: number = 0
   artificialItems: Item[] = pickNRandomIn(ArtificialItems, 3)
+  randomComponentsGiven: Item[] = []
   lightX: number
   lightY: number
   canRegainLife: boolean = true

--- a/app/models/pve-stages.ts
+++ b/app/models/pve-stages.ts
@@ -1,7 +1,7 @@
 import { Emotion } from "../types"
 import {
   ArtificialItems,
-  BasicItems,
+  ItemComponents,
   CraftableItems,
   Item,
   NonSpecialItemComponents,
@@ -29,8 +29,10 @@ export const PVEStages: { [turn: number]: PVEStage } = {
       [Pkm.MAGIKARP, 3, 1],
       [Pkm.MAGIKARP, 5, 1]
     ],
-    getRewards() {
-      return [pickRandomIn(BasicItems)]
+    getRewards(shiny, player) {
+      const randomComponent = pickRandomIn(NonSpecialItemComponents)
+      player.randomComponentsGiven.push(randomComponent)
+      return [randomComponent]
     }
   },
 
@@ -41,8 +43,14 @@ export const PVEStages: { [turn: number]: PVEStage } = {
       [Pkm.RATTATA, 3, 1],
       [Pkm.RATTATA, 5, 1]
     ],
-    getRewards() {
-      return [pickRandomIn(BasicItems)]
+    getRewards(shiny, player) {
+      const randomComponent = pickRandomIn(
+        NonSpecialItemComponents.filter(
+          (i) => player.randomComponentsGiven.includes(i) === false
+        )
+      )
+      player.randomComponentsGiven.push(randomComponent)
+      return [randomComponent]
     }
   },
 
@@ -54,8 +62,14 @@ export const PVEStages: { [turn: number]: PVEStage } = {
       [Pkm.SPEAROW, 5, 1],
       [Pkm.SPEAROW, 4, 2]
     ],
-    getRewards() {
-      return [pickRandomIn(BasicItems)]
+    getRewards(shiny, player) {
+      const randomComponent = pickRandomIn(
+        NonSpecialItemComponents.filter(
+          (i) => player.randomComponentsGiven.includes(i) === false
+        )
+      )
+      player.randomComponentsGiven.push(randomComponent)
+      return [randomComponent]
     }
   },
 
@@ -64,12 +78,9 @@ export const PVEStages: { [turn: number]: PVEStage } = {
     avatar: Pkm.GYARADOS,
     shinyChance: 1 / 20,
     board: [[Pkm.GYARADOS, 4, 2]],
-    getRewards(shiny) {
-      if (shiny) {
-        return pickNRandomIn(BasicItems, 3)
-      } else {
-        return [pickRandomIn(BasicItems)]
-      }
+    getRewards(shiny, player) {
+      const randomComponents = pickNRandomIn(ItemComponents, shiny ? 3 : 1)
+      return randomComponents
     }
   },
 

--- a/app/public/dist/client/changelog/patch-5.1.md
+++ b/app/public/dist/client/changelog/patch-5.1.md
@@ -42,6 +42,7 @@
 
 # Changes to Items
 
+- You are now guaranteed to have different components in PvE rewards of rounds 1, 2 and 3, and these rewards cannot be fossil stones
 - Removed Leftovers
 - Removed Delta Orb
 - New item: Soothe Bell (charcoal + seed): the holder attack gives 25% of damage dealt as Shield to the ally closest to the target

--- a/app/public/src/pages/component/bot-builder/bot-logic.ts
+++ b/app/public/src/pages/component/bot-builder/bot-logic.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../../types/Config"
 import { Rarity } from "../../../../../types/enum/Game"
 import {
-  BasicItems,
+  ItemComponents,
   CraftableItems,
   Item
 } from "../../../../../types/enum/Item"
@@ -154,7 +154,11 @@ export function getNbComponentsOnBoard(board: IDetailledPokemon[]): number {
     .reduce(
       (nbComponents: number, item: Item) =>
         nbComponents +
-        (CraftableItems.includes(item) ? 2 : BasicItems.includes(item) ? 1 : 0),
+        (CraftableItems.includes(item)
+          ? 2
+          : ItemComponents.includes(item)
+            ? 1
+            : 0),
       0
     )
 }

--- a/app/public/src/pages/component/bot-builder/item-picker.tsx
+++ b/app/public/src/pages/component/bot-builder/item-picker.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from "react-tooltip"
 import { PkmWithConfig } from "../../../../../types"
 import {
   ArtificialItems,
-  BasicItems,
+  ItemComponents,
   Berries,
   CraftableItems,
   Item
@@ -25,7 +25,7 @@ export default function ItemPicker(props: {
   }
 
   const tabs = [
-    { label: t("components"), key: "components", items: BasicItems },
+    { label: t("components"), key: "components", items: ItemComponents },
     { label: t("craftable_items"), key: "craftable", items: CraftableItems },
     { label: t("berries"), key: "berries", items: Berries },
     {

--- a/app/public/src/pages/component/meta-report/item-report.tsx
+++ b/app/public/src/pages/component/meta-report/item-report.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../../../../models/mongo-models/items-statistic"
 import {
   ArtificialItems,
-  BasicItems,
+  ItemComponents,
   Berries,
   CraftableItems
 } from "../../../../../types/enum/Item"
@@ -39,7 +39,7 @@ export function ItemReport() {
       key: "artificial_items",
       items: ArtificialItems
     },
-    { label: t("components"), key: "components", items: BasicItems },
+    { label: t("components"), key: "components", items: ItemComponents },
     { label: t("berries"), key: "berries", items: Berries }
   ]
 

--- a/app/public/src/pages/component/wiki/wiki-items.tsx
+++ b/app/public/src/pages/component/wiki/wiki-items.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { Tooltip } from "react-tooltip"
 import {
   ArtificialItems,
-  BasicItems,
+  ItemComponents,
   Berries,
   Item,
   ItemRecipe,
@@ -32,7 +32,7 @@ export default function WikiItems() {
               >
                 +
               </td>
-              {BasicItems.map((i) => {
+              {ItemComponents.map((i) => {
                 return (
                   <th
                     key={i}
@@ -47,7 +47,7 @@ export default function WikiItems() {
                 )
               })}
             </tr>
-            {BasicItems.map((i) => {
+            {ItemComponents.map((i) => {
               return (
                 <tr key={"tr-" + i}>
                   <td
@@ -59,7 +59,7 @@ export default function WikiItems() {
                       className="item"
                     ></img>
                   </td>
-                  {BasicItems.map((j) => {
+                  {ItemComponents.map((j) => {
                     let tier2Item
                     Object.keys(ItemRecipe).forEach((recipeName) => {
                       if (

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -47,7 +47,7 @@ import {
 } from "../../types/enum/Game"
 import {
   ArtificialItems,
-  BasicItems,
+  ItemComponents,
   Berries,
   Item,
   ItemRecipe,
@@ -422,9 +422,9 @@ export class OnDragDropItemCommand extends Command<
       return
     }
 
-    const isBasicItem = BasicItems.includes(item)
+    const isBasicItem = ItemComponents.includes(item)
     const existingBasicItemToCombine = values(pokemon.items).find((i) =>
-      BasicItems.includes(i)
+      ItemComponents.includes(i)
     )
 
     // check if full items and nothing to combine
@@ -918,7 +918,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
     // Item propositions stages
     if (ItemProposalStages.includes(this.state.stageLevel)) {
       this.state.players.forEach((player: Player) => {
-        let itemSet = BasicItems
+        let itemSet = ItemComponents
         if (this.state.specialGameRule === SpecialGameRule.TECHNOLOGIC) {
           itemSet = ArtificialItems
         }
@@ -937,7 +937,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
       let remainingAddPicks = 8
       this.state.players.forEach((player: Player) => {
         if (!player.isBot) {
-          const items = pickNRandomIn(BasicItems, 3)
+          const items = pickNRandomIn(ItemComponents, 3)
           for (let i = 0; i < 3; i++) {
             const p = pool.pop()
             if (p) {

--- a/app/types/enum/Item.ts
+++ b/app/types/enum/Item.ts
@@ -101,7 +101,7 @@ export const SpecialItems: Item[] = [
   Item.BERRY_JUICE
 ]
 
-export const BasicItems: Item[] = [
+export const ItemComponents: Item[] = [
   Item.FOSSIL_STONE,
   Item.TWISTED_SPOON,
   Item.MAGNET,


### PR DESCRIPTION
You are now guaranteed to have different components in PvE rewards of rounds 1, 2 and 3, and these rewards cannot be fossil stones

players were complaining that early game pve rewards could be unfair