### PR TITLE
optimization: do not send other lobby users pokemon collection

### DIFF
--- a/app/models/colyseus-models/lobby-user.ts
+++ b/app/models/colyseus-models/lobby-user.ts
@@ -63,7 +63,7 @@ export default class LobbyUser extends Schema implements ILobbyUser {
     donor: boolean,
     history: GameRecord[],
     honors: string[],
-    pokemonCollection: Map<string, IPokemonConfig>,
+    pokemonCollection: Map<string, IPokemonConfig> | null,
     booster: number,
     titles: Title[],
     title: "" | Title,

--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -109,7 +109,7 @@ export class OnJoinCommand extends Command<
               user.donor,
               records,
               user.honors,
-              user.pokemonCollection,
+              user.uid === client.auth.uid ? user.pokemonCollection : null,
               user.booster,
               user.titles,
               user.title,

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://biomejs.dev/schemas/1.7.1/schema.json",
+	"files": {
+		"ignore": ["node_modules/**/*"]
+	},
 	"formatter": {
 		"enabled": true,
 		"formatWithErrors": false,


### PR DESCRIPTION
The entire pokemon collection is sent for each online lobby user, but doesn't seem to be used on client side apart from current user collection

I changed it so only your collection is sent. This should reduce a lot lobby loading time