### PR TITLE
avoid infinite damage when board event + fluffy tail

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -32,7 +32,7 @@ import {
   Stat,
   Team
 } from "../types/enum/Game"
-import { Berries, Item, SpecialItems } from "../types/enum/Item"
+import { Berries, Item } from "../types/enum/Item"
 import { Passive } from "../types/enum/Passive"
 import { Pkm, PkmIndex } from "../types/enum/Pokemon"
 import { SpecialGameRule } from "../types/enum/SpecialGameRule"
@@ -88,7 +88,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   @type("uint16") healDone: number
   @type("string") emotion: Emotion
   cooldown = 500
-  manaCooldown = 1000
+  oneSecondCooldown = 1000
   state: PokemonState
   simulation: Simulation
   baseAtk: number

--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -124,53 +124,6 @@ export default class Status extends Schema implements IStatus {
       this.triggerParalysis(2000, pokemon)
     }
 
-    if (
-      pokemon.effects.has(Effect.STEALTH_ROCKS) &&
-      !pokemon.types.has(Synergy.ROCK) &&
-      !pokemon.types.has(Synergy.FLYING) &&
-      !this.wound
-    ) {
-      pokemon.handleDamage({
-        damage: 10,
-        board,
-        attackType: AttackType.PHYSICAL,
-        attacker: null,
-        shouldTargetGainMana: true
-      })
-      this.triggerWound(1000, pokemon, undefined)
-    }
-
-    if (
-      pokemon.effects.has(Effect.SPIKES) &&
-      !pokemon.types.has(Synergy.FLYING) &&
-      !this.armorReduction
-    ) {
-      pokemon.handleDamage({
-        damage: 10,
-        board,
-        attackType: AttackType.TRUE,
-        attacker: null,
-        shouldTargetGainMana: true
-      })
-      this.triggerArmorReduction(1000, pokemon)
-    }
-
-    if (
-      pokemon.effects.has(Effect.HAIL) &&
-      !pokemon.types.has(Synergy.ICE) &&
-      !this.freeze
-    ) {
-      pokemon.handleDamage({
-        damage: 10,
-        board,
-        attackType: AttackType.SPECIAL,
-        attacker: null,
-        shouldTargetGainMana: true
-      })
-      this.triggerFreeze(1000, pokemon)
-      pokemon.effects.delete(Effect.HAIL)
-    }
-
     if (pokemon.status.runeProtect) {
       this.updateRuneProtect(dt)
     }


### PR DESCRIPTION
I used status conditions as a way to clock the damage per second for the board efefcts like stealth rocks, spikes and hail. But when the enemy has rune protect status, the status never procs and the damage is applied at every update ,leading to much more damage than expected

I moved the check to the manaCooldown that applies every second, and renamed it to oneSecondCooldown because we have many effects to update every second now