### PR TITLE
updated airlock logic

### DIFF
--- a/app/types/enum/Weather.ts
+++ b/app/types/enum/Weather.ts
@@ -24,8 +24,7 @@ export const WeatherPassives: Map<Passive, Weather> = new Map([
   [Passive.SNOW, Weather.SNOW],
   [Passive.STORM, Weather.STORM],
   [Passive.NIGHT, Weather.NIGHT],
-  [Passive.WINDY, Weather.WINDY],
-  [Passive.AIRLOCK, Weather.NEUTRAL]
+  [Passive.WINDY, Weather.WINDY]
 ])
 
 export const PassiveAssociatedToWeather = reverseMap(WeatherPassives)

--- a/app/utils/weather.ts
+++ b/app/utils/weather.ts
@@ -130,6 +130,13 @@ export function getWeather(
             )
           }
         }
+        //Mega Rayquaza AIRLOCK overrules every weather
+        if (pkm.passive === Passive.AIRLOCK) {
+            boardWeatherScore.set(
+                Weather.NEUTRAL,
+                999
+            )
+        }
       }
     })
   })


### PR DESCRIPTION
Changed air lock to a special weather passive that sets neutral weather score to 999 rather than add 100 to neutral weather score.