### PR TITLE
automatically set ready from client side as an attempt to fix mislaunched games

### DIFF
--- a/app/public/dist/client/changelog/patch-5.2.md
+++ b/app/public/dist/client/changelog/patch-5.2.md
@@ -90,6 +90,7 @@
 # Bugfix
 
 - Fix shop unit highlight when using regional variants
+- Quick play and other automated-start lobbies now wait for an automatic ready flag from all players before starting the game. This should fix the issue where the game was not starting for the 8th player despite the player being counted in the players list.
 
 # Misc
 

--- a/app/public/src/pages/preparation.tsx
+++ b/app/public/src/pages/preparation.tsx
@@ -13,7 +13,12 @@ import { Transfer } from "../../../types"
 import { logger } from "../../../utils/logger"
 import { PreloadingScene } from "../game/scenes/preloading-scene"
 import { useAppDispatch, useAppSelector } from "../hooks"
-import { joinPreparation, logIn, setProfile } from "../stores/NetworkStore"
+import {
+  joinPreparation,
+  logIn,
+  setProfile,
+  toggleReady
+} from "../stores/NetworkStore"
 import {
   addUser,
   changeUser,
@@ -34,10 +39,11 @@ import {
 import Chat from "./component/chat/chat"
 import { MainSidebar } from "./component/main-sidebar/main-sidebar"
 import PreparationMenu from "./component/preparation/preparation-menu"
-import "./preparation.css"
 import { SOUNDS, playSound } from "./utils/audio"
 import { LocalStoreKeys, localStore } from "./utils/store"
 import { FIREBASE_CONFIG } from "./utils/utils"
+import { GameMode } from "../../../types/enum/Game"
+import "./preparation.css"
 
 export default function Preparation() {
   const { t } = useTranslation()
@@ -127,6 +133,9 @@ export default function Preparation() {
 
       r.state.listen("gameMode", (value, previousValue) => {
         dispatch(setGameMode(value))
+        if (value !== GameMode.NORMAL) {
+          dispatch(toggleReady(true)) // automatically set users ready in non-classic game mode
+        }
       })
 
       r.state.users.onAdd((u) => {

--- a/app/public/src/stores/NetworkStore.ts
+++ b/app/public/src/stores/NetworkStore.ts
@@ -168,8 +168,8 @@ export const networkSlice = createSlice({
     listBots: (state) => {
       state.preparation?.send(Transfer.REQUEST_BOT_LIST)
     },
-    toggleReady: (state) => {
-      state.preparation?.send(Transfer.TOGGLE_READY)
+    toggleReady: (state, action: PayloadAction<boolean | undefined>) => {
+      state.preparation?.send(Transfer.TOGGLE_READY, action.payload)
     },
     toggleEloRoom: (state, action: PayloadAction<boolean>) => {
       state.preparation?.send(Transfer.TOGGLE_NO_ELO, action.payload)

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -220,9 +220,9 @@ export default class PreparationRoom extends Room<PreparationState> {
       }
     })
 
-    this.onMessage(Transfer.TOGGLE_READY, (client) => {
+    this.onMessage(Transfer.TOGGLE_READY, (client, ready?: boolean) => {
       try {
-        this.dispatcher.dispatch(new OnToggleReadyCommand(), { client })
+        this.dispatcher.dispatch(new OnToggleReadyCommand(), { client, ready })
       } catch (error) {
         logger.error(error)
       }
@@ -345,8 +345,8 @@ export default class PreparationRoom extends Room<PreparationState> {
       if (consented) {
         throw new Error("consented leave")
       }
-      // allow disconnected client to reconnect into this room until 10 seconds
-      await this.allowReconnection(client, 10)
+      // allow disconnected client to reconnect into this room until 3 seconds
+      await this.allowReconnection(client, 3)
     } catch (e) {
       if (client && client.auth && client.auth.displayName) {
         /*logger.info(


### PR DESCRIPTION
Code review requested

Instead of automatically set user ready on server side on non-normal gamemodes, I wait for client-side event listeners to be set before making client send the ready flag to true automatically. Because event listeners are set, I have the guarantee the prep room is initialized correctly and the game is supposed to launch properly

Also reduced allowed reconnection for prep room from 10 seconds to 3 seconds

Fixes:

https://discord.com/channels/737230355039387749/1250249988706140193
https://discord.com/channels/737230355039387749/1246990936689479680
https://discord.com/channels/737230355039387749/1245534071073804448

and probably much more