### PR TITLE
Fix Flying skydive landing animation and retargeting

### DIFF
--- a/app/core/moving-state.ts
+++ b/app/core/moving-state.ts
@@ -55,7 +55,6 @@ export default class MovingState extends PokemonState {
       pokemon.cooldown = Math.max(0, pokemon.cooldown - dt)
       if (pokemon.status.skydiving && pokemon.cooldown <= 0) {
         pokemon.status.skydiving = false
-        pokemon.cooldown = 500 // adding a cooldown again just for moving from landing cell to final cell after skydiving
       }
     }
   }
@@ -69,7 +68,11 @@ export default class MovingState extends PokemonState {
 
     let x: number | undefined = undefined
     let y: number | undefined = undefined
-    if (pokemon.types.has(Synergy.DARK) && pokemon.baseRange === 1 && pokemon.passive !== Passive.GUZZLORD) {
+    if (
+      pokemon.types.has(Synergy.DARK) &&
+      pokemon.baseRange === 1 &&
+      pokemon.passive !== Passive.GUZZLORD
+    ) {
       // dark jump
       const farthestCoordinate = this.getFarthestTargetCoordinateAvailablePlace(
         pokemon,

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -1059,6 +1059,8 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
               targetY: destination.target.positionY
             })
             this.skydiveTo(destination.x, destination.y, board)
+            this.targetX = destination.target.positionX
+            this.targetY = destination.target.positionY
             this.flyingProtection--
             setTimeout(() => {
               this.simulation.room.broadcast(Transfer.ABILITY, {

--- a/app/public/dist/client/changelog/patch-5.2.md
+++ b/app/public/dist/client/changelog/patch-5.2.md
@@ -94,6 +94,7 @@
 # Bugfix
 
 - Fix shop unit highlight when using regional variants
+- Fix Flying skydive landing animation and retargeting
 - Quick play and other automated-start lobbies now wait for an automatic ready flag from all players before starting the game. This should fix the issue where the game was not starting for the 8th player despite the player being counted in the players list.
 
 # Misc

--- a/app/public/src/game/components/minigame-manager.ts
+++ b/app/public/src/game/components/minigame-manager.ts
@@ -57,7 +57,11 @@ export default class MinigameManager {
   }
 
   initialize() {
-    this.addKecleon()
+    if (
+      this.scene.room?.state?.specialGameRule === SpecialGameRule.KECLEONS_SHOP
+    ) {
+      this.addKecleon()
+    }
   }
 
   dispose() {
@@ -341,19 +345,15 @@ export default class MinigameManager {
   }
 
   addKecleon() {
-    if (
-      this.scene.room?.state?.specialGameRule === SpecialGameRule.KECLEONS_SHOP
-    ) {
-      this.kecleon = new PokemonSpecial(
-        this.scene,
-        1000,
-        408,
-        Pkm.KECLEON,
-        this.animationManager,
-        t("kecleon_dialog.tell_price"),
-        t("kecleon_dialog.welcome")
-      )
-    }
+    this.kecleon = new PokemonSpecial(
+      this.scene,
+      1000,
+      408,
+      Pkm.KECLEON,
+      this.animationManager,
+      t("kecleon_dialog.tell_price"),
+      t("kecleon_dialog.welcome")
+    )
   }
 
   showEmote(id: string, emote: Emotion) {
@@ -368,7 +368,7 @@ export default class MinigameManager {
       pokemonAvatar.drawSpeechBubble(emote, false)
     }
   }
-  
+
   onNpcDialog({ npc, dialog }: { npc: string; dialog: string }) {
     if (npc === "kecleon" && this.kecleon) {
       this.scene.board?.displayText(960, 370, t(`kecleon_dialog.${dialog}`))

--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -117,6 +117,7 @@ export default class PokemonSprite extends DraggableObject {
   shouldShowTooltip: boolean
   flip: boolean
   animationLocked: boolean /* will prevent another anim to play before current one is completed */
+  skydiving: boolean
 
   constructor(
     scene: GameScene | DebugScene,
@@ -837,28 +838,34 @@ export default class PokemonSprite extends DraggableObject {
   }
 
   skydiveUp() {
-    // animation where pokemon is flying up out of the screen for a screen dive animation. Should take <= 500 milliseconds
-    this.moveManager.setSpeed(800)
-    this.moveManager.moveTo(this.x, -100)
+    if (!this.skydiving) {
+      // animation where pokemon is flying up out of the screen for a screen dive animation. Should take <= 500 milliseconds
+      this.skydiving = true
+      this.moveManager.setSpeed(800)
+      this.moveManager.moveTo(this.x, -100)
+    }
   }
 
   skydiveDown() {
-    // animation after a skydiving attack where pokemon moves from its target cell to its final reserved adjacent cell
-    const landingCoordinates = transformAttackCoordinate(
-      this.targetX ?? this.positionX,
-      this.targetY ?? this.positionY,
-      this.flip
-    )
-    const finalCoordinates = transformAttackCoordinate(
-      this.positionX,
-      this.positionY,
-      this.flip
-    )
+    if (this.skydiving) {
+      // animation after a skydiving attack where pokemon moves from its target cell to its final reserved adjacent cell
+      const landingCoordinates = transformAttackCoordinate(
+        this.targetX ?? this.positionX,
+        this.targetY ?? this.positionY,
+        this.flip
+      )
+      const finalCoordinates = transformAttackCoordinate(
+        this.positionX,
+        this.positionY,
+        this.flip
+      )
 
-    this.x = landingCoordinates[0]
-    this.y = landingCoordinates[1]
-    this.moveManager.setSpeed(3)
-    this.moveManager.moveTo(finalCoordinates[0], finalCoordinates[1])
+      this.x = landingCoordinates[0]
+      this.y = landingCoordinates[1]
+      this.moveManager.setSpeed(3)
+      this.moveManager.moveTo(finalCoordinates[0], finalCoordinates[1])
+      this.skydiving = false
+    }
   }
 
   addResurection() {

--- a/app/public/src/game/scenes/game-scene.ts
+++ b/app/public/src/game/scenes/game-scene.ts
@@ -244,7 +244,7 @@ export default class GameScene extends Scene {
       this.board?.battleMode()
     } else if (newPhase === GamePhaseState.MINIGAME) {
       this.board?.minigameMode()
-      this.minigameManager.initialize()
+      this.minigameManager?.initialize()
     } else {
       this.board?.pickMode()
     }
@@ -380,7 +380,9 @@ export default class GameScene extends Scene {
             outline.remove(previouslyHovered.sprite)
           }
 
-          const thickness = Math.round(1 + Math.log(gameObject.def + gameObject.speDef))
+          const thickness = Math.round(
+            1 + Math.log(gameObject.def + gameObject.speDef)
+          )
           this.pokemonHovered = gameObject
           outline.add(gameObject.sprite, {
             thickness,


### PR DESCRIPTION
Fix a few bugs around skydive animation
Now targets properly the skydived enemy after the landing
prevent calling skydiveDown() anim on all units at fight start

also fixes an exception case when loading game during a carousel phase

https://discord.com/channels/737230355039387749/1253070786688848053