### PR TITLE
hotfix Quickplay ready button

### DIFF
--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -76,7 +76,8 @@ export default function PreparationMenu() {
   }, [nbUsersReady, users.length])
 
   const humans = users.filter((u) => !u.isBot)
-  const isElligibleForELO = gameMode === GameMode.QUICKPLAY || users.filter((u) => !u.isBot).length >= 2
+  const isElligibleForELO =
+    gameMode === GameMode.QUICKPLAY || users.filter((u) => !u.isBot).length >= 2
   const averageElo = Math.round(
     humans.reduce((acc, u) => acc + u.elo, 0) / humans.length
   )
@@ -162,7 +163,9 @@ export default function PreparationMenu() {
         <p>{t("not_elligible_elo_hint")}</p>
       ) : null}
 
-      {gameMode === GameMode.NORMAL && users.length === 1 && <p>{t("add_bot_or_wait_hint")}</p>}
+      {gameMode === GameMode.NORMAL && users.length === 1 && (
+        <p>{t("add_bot_or_wait_hint")}</p>
+      )}
     </>
   )
 
@@ -190,7 +193,8 @@ export default function PreparationMenu() {
       </button>
     )
 
-  const roomNameInput = gameMode === GameMode.NORMAL && (isOwner || isModerator || isAdmin) &&
+  const roomNameInput = gameMode === GameMode.NORMAL &&
+    (isOwner || isModerator || isAdmin) &&
     user &&
     !user.anonymous && (
       <div className="my-input-group">
@@ -255,7 +259,7 @@ export default function PreparationMenu() {
     </p>
   )
 
-  const readyButton = gameMode === GameMode.NORMAL && (
+  const readyButton = gameMode === GameMode.NORMAL && users.length > 0 && (
     <button
       className={cc("bubbly", "ready-button", isReady ? "green" : "orange")}
       onClick={() => {

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -480,6 +480,9 @@ export class OnToggleReadyCommand extends Command<
 > {
   execute({ client, ready }) {
     try {
+      // cannot toggle ready in quick play / ranked / tournament game mode
+      if (this.room.state.gameMode !== GameMode.NORMAL) return
+
       // logger.debug(this.state.users.get(client.auth.uid).ready);
       if (client.auth?.uid && this.state.users.has(client.auth.uid)) {
         const user = this.state.users.get(client.auth.uid)!


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1254872823802105987

The ready button is displayed during the the loading of the room information, if a player press it during that time, it will be set as non-ready. Once prep room is loaded, the ready button is no longer displayed as intended

Change it to hide ready button when loading (waiting for users.length > 0, i know it's suboptimal but for the hotfix i don't have time to properly manage a good loading phase for prep room). Also change server side it to make it impossible to unready in non-normal lobbies