### PR TITLE
autokick when not ready after 10 seconds in non-normal gamemodes

### DIFF
--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -81,6 +81,7 @@ export class OnJoinCommand extends Command<
               auth.email === undefined && auth.photoURL === undefined
             )
           )
+
           if (u.uid == this.state.ownerId) {
             // logger.debug(user.displayName);
             this.state.ownerName = u.displayName
@@ -88,6 +89,20 @@ export class OnJoinCommand extends Command<
               ownerName: this.state.ownerName
             })
           }
+
+          if (this.state.gameMode !== GameMode.NORMAL) {
+            this.clock.setTimeout(() => {
+              if (
+                this.state.users.has(u.uid) &&
+                !this.state.users.get(u.uid)!.ready
+              ) {
+                this.state.users.delete(u.uid)
+                client.send(Transfer.KICK)
+                client.leave()
+              }
+            }, 10000)
+          }
+
           this.state.addMessage({
             authorId: "server",
             payload: `${u.displayName} joined.`,


### PR DESCRIPTION
I don't know the cause of players joining a prep room server side but not loading the prep room client side.

So this is a naive attempt to kick them out when that happens, if they are not ready after 10 seconds. 10 seconds should be enough even with the biggest lag.

This won't solve the root cause but at least avoid stuck lobbies where a moderator has to kick manually someone

If you have any better idea, i'm listening