### PR TITLE
Allow unique pick if already has one

### DIFF
--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -916,19 +916,16 @@ export default class GameRoom extends Room<GameState> {
     const player = this.state.players.get(playerId)
     if (!player || player.pokemonsProposition.length === 0) return
     if (this.state.additionalPokemons.includes(pkm)) return // already picked, probably a double click
-    if (UniqueShop.includes(pkm)) {
-      if (this.state.stageLevel !== PortalCarouselStages[0]) return // should not be pickable at this stage
-      if (
-        values(player.board).some((p) => p.rarity === Rarity.UNIQUE) &&
-        this.state.specialGameRule !== SpecialGameRule.UNIQUE_STARTER
-      )
-        return // already picked a unique
-    }
-    if (LegendaryShop.includes(pkm)) {
-      if (this.state.stageLevel !== PortalCarouselStages[1]) return // should not be pickable at this stage
-      if (values(player.board).some((p) => LegendaryShop.includes(p.name)))
-        return // already picked a legendary
-    }
+    if (
+      UniqueShop.includes(pkm) &&
+      this.state.stageLevel !== PortalCarouselStages[0]
+    )
+      return // should not be pickable at this stage
+    if (
+      LegendaryShop.includes(pkm) &&
+      this.state.stageLevel !== PortalCarouselStages[1]
+    )
+      return // should not be pickable at this stage
 
     const pokemonsObtained: Pokemon[] = (
       pkm in PkmDuos ? PkmDuos[pkm] : [pkm]
@@ -938,10 +935,13 @@ export default class GameRoom extends Room<GameState> {
     if (freeSpace < pokemonsObtained.length && !bypassLackOfSpace) return // prevent picking if not enough space on bench
 
     // at this point, the player is allowed to pick a proposition
+    const selectedIndex = player.pokemonsProposition.indexOf(pkm)
+    player.pokemonsProposition.clear()
+
     if (AdditionalPicksStages.includes(this.state.stageLevel)) {
       this.state.additionalPokemons.push(pkm)
       this.state.shop.addAdditionalPokemon(pkm)
-      const selectedIndex = player.pokemonsProposition.indexOf(pkm)
+
       if (
         player.itemsProposition.length > 0 &&
         player.itemsProposition[selectedIndex] != null
@@ -960,8 +960,6 @@ export default class GameRoom extends Room<GameState> {
         pokemon.onAcquired(player)
       }
     })
-
-    player.pokemonsProposition.clear()
   }
 
   pickItemProposition(playerId: string, item: Item) {


### PR DESCRIPTION
allow picking unique at t10 and legendary at t20 even if player already has one on board (due to golden rod for example)

This previous check was done to avoid picking several uniques by spam clicking, but this is supposed to be covered by the `pokemonsProposition.length === 0` check two lines above. I moved the clearing of pokemonsProposition a bit earlier in code even if this is synchronous so should not be a problem anyway

https://discord.com/channels/737230355039387749/1255598083589279887

hotfix material in my opinion since it can prevent the player to pick a unique at t10