### PR TITLE
only show best fishing rod

### DIFF
--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -386,11 +386,23 @@ export default class Player extends Schema implements IPlayer {
     if (this.items.includes(Item.SUPER_ROD) && fishingLevel !== 3)
       removeInArray<Item>(this.items, Item.SUPER_ROD)
 
-    if (this.items.includes(Item.OLD_ROD) === false && fishingLevel === 1)
+    if (
+      this.items.includes(Item.OLD_ROD) === false &&
+      this.items.includes(Item.GOLDEN_ROD) === false &&
+      fishingLevel === 1
+    )
       this.items.push(Item.OLD_ROD)
-    if (this.items.includes(Item.GOOD_ROD) === false && fishingLevel === 2)
+    if (
+      this.items.includes(Item.GOOD_ROD) === false &&
+      this.items.includes(Item.GOLDEN_ROD) === false &&
+      fishingLevel === 2
+    )
       this.items.push(Item.GOOD_ROD)
-    if (this.items.includes(Item.SUPER_ROD) === false && fishingLevel === 3)
+    if (
+      this.items.includes(Item.SUPER_ROD) === false &&
+      this.items.includes(Item.GOLDEN_ROD) === false &&
+      fishingLevel === 3
+    )
       this.items.push(Item.SUPER_ROD)
   }
 

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1036,10 +1036,10 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
     const commands = new Array<Command>()
 
     this.state.players.forEach((player: Player) => {
-      const rod = FishingRods.find((rod) => player.items.includes(rod))
+      const bestRod = FishingRods.find((rod) => player.items.includes(rod))
 
-      if (rod && getFreeSpaceOnBench(player.board) > 0 && !isAfterPVE) {
-        const fish = this.state.shop.pickFish(player, rod)
+      if (bestRod && getFreeSpaceOnBench(player.board) > 0 && !isAfterPVE) {
+        const fish = this.state.shop.pickFish(player, bestRod)
         this.room.fishPokemon(player, fish)
       }
 

--- a/app/types/enum/Item.ts
+++ b/app/types/enum/Item.ts
@@ -127,7 +127,7 @@ export const FishingRods = [
   Item.SUPER_ROD,
   Item.GOOD_ROD,
   Item.OLD_ROD
-] as const
+] as const // order matters
 
 export type FishingRod = (typeof FishingRods)[number]
 


### PR DESCRIPTION
hide regular fishing rods when a player has the golden rod, to make it more clear that only one rod is used at a time