### PR TITLE
Show number of expected players in room

### DIFF
--- a/app/public/src/pages/component/available-room-menu/room-item.tsx
+++ b/app/public/src/pages/component/available-room-menu/room-item.tsx
@@ -18,9 +18,13 @@ export default function RoomItem(props: {
   const { t } = useTranslation()
   const user = useAppSelector((state) => state.lobby.user)
 
+  const nbPlayersExpected = props.room.metadata?.whitelist
+    ? props.room.metadata?.whitelist.length
+    : MAX_PLAYERS_PER_GAME
+
   let canJoin = true,
     disabledReason: string | null = null
-  if (props.room.clients >= MAX_PLAYERS_PER_GAME) {
+  if (props.room.clients >= nbPlayersExpected) {
     canJoin = false
     disabledReason = t("game_full")
   } else if (props.room.metadata?.gameStarted === true) {
@@ -50,7 +54,16 @@ export default function RoomItem(props: {
 
   return (
     <div className="room-item my-box">
-      <span className="room-name" title={props.room.metadata?.ownerName ? "Owner: "+props.room.metadata?.ownerName : ""}>{props.room.metadata?.name}</span>
+      <span
+        className="room-name"
+        title={
+          props.room.metadata?.ownerName
+            ? "Owner: " + props.room.metadata?.ownerName
+            : ""
+        }
+      >
+        {props.room.metadata?.name}
+      </span>
       {props.room.metadata?.password && (
         <img
           alt={t("private")}
@@ -97,7 +110,7 @@ export default function RoomItem(props: {
         />
       )}
       <span>
-        {props.room.clients}/{MAX_PLAYERS_PER_GAME}
+        {props.room.clients}/{nbPlayersExpected}
       </span>
       <button
         title={disabledReason ?? t("join")}
@@ -108,7 +121,7 @@ export default function RoomItem(props: {
         )}
         onClick={() => {
           if (
-            props.room.clients < MAX_PLAYERS_PER_GAME &&
+            props.room.clients < nbPlayersExpected &&
             props.room.metadata?.gameStarted !== true
           ) {
             props.click(props.room)

--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -6,8 +6,10 @@ import { IGameUser } from "../../../../../models/colyseus-models/game-user"
 import { IBot } from "../../../../../models/mongo-models/bot-v2"
 import PreparationState from "../../../../../rooms/states/preparation-state"
 import { Role } from "../../../../../types"
+import { MAX_PLAYERS_PER_GAME } from "../../../../../types/Config"
 import { BotDifficulty, GameMode } from "../../../../../types/enum/Game"
 import { throttle } from "../../../../../utils/function"
+import { max } from "../../../../../utils/number"
 import { setTitleNotificationIcon } from "../../../../../utils/window"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import {
@@ -62,6 +64,12 @@ export default function PreparationMenu() {
 
   const isAdmin = user?.role === Role.ADMIN
   const isModerator = user?.role === Role.MODERATOR
+
+  const nbExpectedPlayers = useAppSelector((state) =>
+    state.preparation.whitelist
+      ? max(MAX_PLAYERS_PER_GAME)(state.preparation.whitelist.length)
+      : MAX_PLAYERS_PER_GAME
+  )
 
   useEffect(() => {
     if (allUsersReady) {
@@ -287,7 +295,7 @@ export default function PreparationMenu() {
     <div className="preparation-menu my-container is-centered custom-bg">
       <header>
         <h1>
-          {name}: {users.length}/8
+          {name}: {users.length}/{nbExpectedPlayers}
         </h1>
         {headerMessage}
       </header>

--- a/app/public/src/pages/component/profile/profile.tsx
+++ b/app/public/src/pages/component/profile/profile.tsx
@@ -152,6 +152,7 @@ function OtherProfileActions({ resetSearch }) {
           className="bubbly orange"
           onClick={() => {
             dispatch(giveRole({ uid: user.id, role: profileRole }))
+            alert(`Role ${profileRole} given to ${user.name}`)
           }}
         >
           {t("give_role")}
@@ -178,6 +179,7 @@ function OtherProfileActions({ resetSearch }) {
           className="bubbly blue"
           onClick={() => {
             dispatch(giveTitle({ uid: user.id, title: title }))
+            alert(`Title ${title} given to ${user.name}`)
           }}
         >
           {t("give_title")}

--- a/app/public/src/pages/preparation.tsx
+++ b/app/public/src/pages/preparation.tsx
@@ -34,7 +34,9 @@ import {
   setOwnerId,
   setOwnerName,
   setPassword,
-  setUser
+  setUser,
+  setWhiteList,
+  setBlackList
 } from "../stores/PreparationStore"
 import Chat from "./component/chat/chat"
 import { MainSidebar } from "./component/main-sidebar/main-sidebar"
@@ -129,6 +131,14 @@ export default function Preparation() {
 
       r.state.listen("noElo", (value, previousValue) => {
         dispatch(setNoELO(value))
+      })
+
+      r.state.listen("whitelist", (value, previousValue) => {
+        dispatch(setWhiteList(value))
+      })
+
+      r.state.listen("blacklist", (value, previousValue) => {
+        dispatch(setBlackList(value))
       })
 
       r.state.listen("gameMode", (value, previousValue) => {

--- a/app/public/src/stores/PreparationStore.ts
+++ b/app/public/src/stores/PreparationStore.ts
@@ -17,6 +17,8 @@ interface IUserPreparationState {
   user: GameUser | undefined
   botsList: IBot[] | null
   gameMode: GameMode
+  whitelist: string[] | null
+  blacklist: string[] | null
 }
 
 const initialState: IUserPreparationState = {
@@ -30,7 +32,9 @@ const initialState: IUserPreparationState = {
   password: null,
   noElo: false,
   botsList: null,
-  gameMode: GameMode.NORMAL
+  gameMode: GameMode.NORMAL,
+  whitelist: null,
+  blacklist: null
 }
 
 export const preparationSlice = createSlice({
@@ -91,6 +95,12 @@ export const preparationSlice = createSlice({
     leavePreparation: () => initialState,
     setBotsList: (state, action: PayloadAction<IBot[] | null>) => {
       state.botsList = action.payload
+    },
+    setWhiteList: (state, action: PayloadAction<string[] | null>) => {
+      state.whitelist = action.payload
+    },
+    setBlackList: (state, action: PayloadAction<string[] | null>) => {
+      state.blacklist = action.payload
     }
   }
 })
@@ -109,6 +119,8 @@ export const {
   setOwnerName,
   setPassword,
   setNoELO,
+  setWhiteList,
+  setBlackList,
   setGameMode,
   leavePreparation
 } = preparationSlice.actions

--- a/app/rooms/states/preparation-state.ts
+++ b/app/rooms/states/preparation-state.ts
@@ -30,6 +30,8 @@ export default class PreparationState
   @type("string") minRank: EloRank | null
   @type("string") gameMode: GameMode = GameMode.NORMAL
   @type("boolean") noElo: boolean
+  @type(["string"]) whitelist: string[] | null
+  @type(["string"]) blacklist: string[] | null
 
   constructor(params: {
     ownerId?: string
@@ -37,6 +39,8 @@ export default class PreparationState
     minRank?: EloRank
     noElo?: boolean
     gameMode: GameMode
+    whitelist?: string[]
+    blacklist?: string[]
   }) {
     super()
     this.ownerId =
@@ -48,6 +52,8 @@ export default class PreparationState
     this.noElo = params.noElo ?? false
     this.minRank = params.minRank ?? null
     this.gameMode = params.gameMode
+    this.whitelist = params.whitelist ?? null
+    this.blacklist = params.blacklist ?? null
   }
 
   addMessage(params: {


### PR DESCRIPTION
For tournament lobbies with whitelist, show the number of expected players per lobby

![image](https://github.com/keldaanCommunity/pokemonAutoChess/assets/566536/4b67ca3a-41cc-4ddb-bd5c-4aaf444f3bf9)
