### PR TITLE
reduce pve shiny chance

### DIFF
--- a/app/models/pve-stages.ts
+++ b/app/models/pve-stages.ts
@@ -28,7 +28,7 @@ export const PVEStages: { [turn: number]: PVEStage } = {
       [Pkm.MAGIKARP, 3, 1],
       [Pkm.MAGIKARP, 5, 1]
     ],
-    shinyChance: 1 / 20,
+    shinyChance: 1 / 40,
     getRewards(player: Player) {
       const randomComponent = pickRandomIn(NonSpecialItemComponents)
       player.randomComponentsGiven.push(randomComponent)
@@ -76,7 +76,7 @@ export const PVEStages: { [turn: number]: PVEStage } = {
   9: {
     name: "pkm.GYARADOS",
     avatar: Pkm.GYARADOS,
-    shinyChance: 1 / 20,
+    shinyChance: 1 / 40,
     board: [[Pkm.GYARADOS, 4, 2]],
     getRewards(player: Player) {
       const randomComponents = pickNRandomIn(ItemComponents, 1)
@@ -102,7 +102,7 @@ export const PVEStages: { [turn: number]: PVEStage } = {
     name: "tower_duo",
     avatar: Pkm.LUGIA,
     emotion: Emotion.DETERMINED,
-    shinyChance: 1 / 20,
+    shinyChance: 1 / 40,
     board: [
       [Pkm.LUGIA, 3, 1],
       [Pkm.HO_OH, 5, 1]

--- a/app/public/dist/client/changelog/patch-5.3.md
+++ b/app/public/dist/client/changelog/patch-5.3.md
@@ -99,3 +99,4 @@
 - Initiated Korean translation thanks to Mrkim-0
 - Initiated Polski translation thanks to dil25kop
 - New titles: Blob, Tactician, Strategist, Primal
+- Shiny PVE rounds are twice as rare

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1196,7 +1196,6 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
         ) {
           eggChance = 1
           nbMaxEggs = 8
-          shinyChance = 1 / 20
         }
 
         const eggsOnBench = values(player.board).filter(


### PR DESCRIPTION
Shiny PVE rounds are twice as rare. 1/20 was too much