### PR TITLE
Show ready button if not ready on quickplay lobbies

### DIFF
--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -273,7 +273,7 @@ export default function PreparationMenu() {
     </p>
   )
 
-  const readyButton = gameMode === GameMode.NORMAL && users.length > 0 && (
+  const readyButton = (gameMode === GameMode.NORMAL || !isReady) && users.length > 0 && (
     <button
       className={cc("bubbly", "ready-button", isReady ? "green" : "orange")}
       onClick={() => {


### PR DESCRIPTION
workaround for the people not auto ready with quickplay lobbies

while waiting for a proper bugfix for the auto ready (i am clueless)