### PR TITLE
Starter avatars

### DIFF
--- a/app/models/colyseus-models/pokemon-avatar.ts
+++ b/app/models/colyseus-models/pokemon-avatar.ts
@@ -7,7 +7,7 @@ import { Pkm, PkmIndex } from "../../types/enum/Pokemon"
 
 export class PokemonAvatarModel extends Schema implements IPokemonAvatar {
   @type("string") id: string
-  @type("string") name: Pkm = Pkm.RATTATA
+  @type("string") name: Pkm
   @type("boolean") shiny: boolean
   @type("number") x: number
   @type("number") y: number

--- a/app/public/dist/client/changelog/patch-5.4.md
+++ b/app/public/dist/client/changelog/patch-5.4.md
@@ -42,4 +42,5 @@
 
 # Misc
 
+- New accounts now start with a random avatar among Pokemon Mystery Dungeon starters
 - Vietnamese translation has been started thanks to Camchanh

--- a/app/public/dist/client/changelog/patch-5.4.md
+++ b/app/public/dist/client/changelog/patch-5.4.md
@@ -38,6 +38,8 @@
 
 # Bugfix
 
+- Regional lists was not correctly updated when picking an additional pick with a regional variant
+
 # Misc
 
 - Vietnamese translation has been started thanks to Camchanh

--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -42,6 +42,7 @@ import {
   DUST_PER_SHINY,
   getEmotionCost
 } from "../../types/Config"
+import { StarterAvatars } from "../../types/enum/Starters"
 import { EloRank } from "../../types/enum/EloRank"
 import { GameMode, Rarity } from "../../types/enum/Game"
 import { Language } from "../../types/enum/Language"
@@ -126,9 +127,11 @@ export class OnJoinCommand extends Command<
       } else {
         // create new user account
         const numberOfBoosters = 3
+        const starterAvatar = pickRandomIn(StarterAvatars)
         UserMetadata.create({
           uid: client.auth.uid,
           displayName: client.auth.displayName,
+          avatar: starterAvatar,
           booster: numberOfBoosters,
           pokemonCollection: new Map<string, IPokemonConfig>()
         })
@@ -138,7 +141,7 @@ export class OnJoinCommand extends Command<
             client.auth.uid,
             client.auth.displayName,
             1000,
-            "0019/Normal",
+            starterAvatar,
             0,
             0,
             0,

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -8,7 +8,7 @@ import { CountEvolutionRule, ItemEvolutionRule } from "../core/evolution-rules"
 import { MiniGame } from "../core/matter/mini-game"
 import { IGameUser } from "../models/colyseus-models/game-user"
 import Player from "../models/colyseus-models/player"
-import { Pokemon } from "../models/colyseus-models/pokemon"
+import { Pokemon, PokemonClasses } from "../models/colyseus-models/pokemon"
 import BannedUser from "../models/mongo-models/banned-user"
 import { BotV2 } from "../models/mongo-models/bot-v2"
 import DetailledStatistic from "../models/mongo-models/detailled-statistic-v2"
@@ -47,9 +47,9 @@ import {
   RequiredStageLevelForXpElligibility,
   UniqueShop
 } from "../types/Config"
-import { GameMode, PokemonActionState, Rarity } from "../types/enum/Game"
+import { GameMode, PokemonActionState } from "../types/enum/Game"
 import { Item } from "../types/enum/Item"
-import { Pkm, PkmDuos, PkmProposition } from "../types/enum/Pokemon"
+import { Pkm, PkmDuos, PkmProposition, PkmRegionalVariants } from "../types/enum/Pokemon"
 import { SpecialGameRule } from "../types/enum/SpecialGameRule"
 import { Synergy } from "../types/enum/Synergy"
 import { removeInArray } from "../utils/array"
@@ -968,6 +968,18 @@ export default class GameRoom extends Room<GameState> {
     if (AdditionalPicksStages.includes(this.state.stageLevel)) {
       this.state.additionalPokemons.push(pkm as Pkm)
       this.state.shop.addAdditionalPokemon(pkm)
+      if (pkm in PkmRegionalVariants) {
+        const variant = PkmRegionalVariants[pkm]
+        if (
+          PokemonClasses[variant].prototype.isInRegion(
+            variant,
+            player.map,
+            this.state
+          )
+        ) {
+          player.regionalPokemons.push(variant)
+        }
+      }
 
       if (
         player.itemsProposition.length > 0 &&

--- a/app/types/enum/Starters.ts
+++ b/app/types/enum/Starters.ts
@@ -1,0 +1,29 @@
+import { Pkm, PkmIndex } from './Pokemon';
+
+export const Starters: Pkm[] = [
+    Pkm.BULBASAUR,
+    Pkm.CHARMANDER,
+    Pkm.SQUIRTLE,
+    Pkm.PIKACHU,
+    Pkm.MEOWTH,
+    Pkm.PSYDUCK,
+    Pkm.MACHOP,
+    Pkm.CUBONE,
+    Pkm.EEVEE,
+    Pkm.CHIKORITA,
+    Pkm.CYNDAQUIL,
+    Pkm.TOTODILE,
+    Pkm.TREECKO,
+    Pkm.TORCHIC,
+    Pkm.MUDKIP,
+    Pkm.TURTWIG,
+    Pkm.CHIMCHAR,
+    Pkm.PIPLUP,
+    Pkm.MUNCHLAX,
+    Pkm.VULPIX,
+    Pkm.PHANPY,
+    Pkm.SHINX,
+    Pkm.RIOLU
+]
+
+export const StarterAvatars:string[] = Starters.map(p => PkmIndex[p]+"/Normal")


### PR DESCRIPTION
- New accounts now start with a random avatar among Pokemon Mystery Dungeon starters
- bugfix: Regional lists was not correctly updated when picking an additional pick with a regional variant