### PR TITLE
bugfix: Ghost curse statuses not re-applying after being cleansed

### DIFF
--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -259,7 +259,7 @@ export default class Status extends Schema implements IStatus {
     }
 
     if (pokemon.curseFate && !pokemon.status.curse) {
-      this.triggerCurse(6000)
+      this.triggerCurse(5000) //Intentionally at 5s to account for status update delay
     }
   }
 

--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -238,28 +238,28 @@ export default class Status extends Schema implements IStatus {
     }
 
     if (
-      pokemon.effects.has(Effect.CURSE_OF_VULNERABILITY) &&
+      pokemon.status.curseVulnerability &&
       !pokemon.status.flinch
     ) {
       this.triggerFlinch(30000, pokemon)
     }
 
     if (
-      pokemon.effects.has(Effect.CURSE_OF_WEAKNESS) &&
+      pokemon.status.curseWeakness &&
       !pokemon.status.paralysis
     ) {
       this.triggerParalysis(30000, pokemon)
     }
 
     if (
-      pokemon.effects.has(Effect.CURSE_OF_TORMENT) &&
+      pokemon.status.curseTorment &&
       !pokemon.status.silence
     ) {
       this.triggerSilence(30000, pokemon)
     }
 
-    if (pokemon.effects.has(Effect.CURSE_OF_FATE) && !pokemon.status.curse) {
-      this.triggerCurse(5000)
+    if (pokemon.curseFate && !pokemon.status.curse) {
+      this.triggerCurse(6000)
     }
   }
 


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1267637117442461738

applyCurse only sets the curseFlag, it never adds the curse effect to list of effects on the pokemon, this the status   never reapplies if removed.

since the curseFlags are set with applyCurse, checking the appropriate flag should fix the issue.