### PR TITLE
Tryfix stale rooms

### DIFF
--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -223,6 +223,7 @@ export class OnGameStartRequestCommand extends Command<
         })
       } else {
         this.state.gameStarted = true
+        this.room.lock()
         const gameRoom = await matchMaker.createRoom("game", {
           users: this.state.users.toJSON(),
           name: this.state.name,

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -239,6 +239,7 @@ export class OnGameStartRequestCommand extends Command<
           gameId: gameRoom.roomId,
           preparationId: this.room.roomId
         })
+        this.clock.setTimeout(() => this.room.disconnect(), 30000) // TRYFIX: remove stale rooms
       }
     } catch (error) {
       logger.error(error)

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -302,7 +302,7 @@ export default class PreparationRoom extends Room<PreparationState> {
         this.setGameStarted(true)
         //logger.debug("game start", game.roomId)
         this.broadcast(Transfer.GAME_START, gameId)
-        this.clock.setTimeout(() => this.disconnect(), 30000) // TRYFIX: ranked lobbies prep rooms not being removed
+        this.clock.setTimeout(() => this.disconnect(), 30000) // TRYFIX: remove stale rooms
       }
     })
   }


### PR DESCRIPTION
lock and auto disconnect after 30 seconds from original process

i have some doubts regarding the need to go through presence API to trigger disconnect/lock. I think this is already covered by colyseus ? Anyway, this is a tryfix without much impact, worth a try IMO