### PR TITLE
add max simulation delta time

### DIFF
--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -9,7 +9,6 @@ import { getPath } from "../public/src/pages/utils/utils"
 import GameRoom from "../rooms/game-room"
 import { IPokemon, IPokemonEntity, ISimulation, Transfer } from "../types"
 import { BOARD_HEIGHT, BOARD_WIDTH, ItemStats } from "../types/Config"
-import { Ability } from "../types/enum/Ability"
 import { Effect } from "../types/enum/Effect"
 import {
   AttackType,
@@ -21,12 +20,7 @@ import {
   Stat,
   Team
 } from "../types/enum/Game"
-import {
-  Berries,
-  CraftableItems,
-  Item,
-  ItemComponents
-} from "../types/enum/Item"
+import { Berries, CraftableItems, Item } from "../types/enum/Item"
 import { Passive } from "../types/enum/Passive"
 import { Pkm } from "../types/enum/Pokemon"
 import { Synergy } from "../types/enum/Synergy"

--- a/app/public/dist/client/changelog/patch-5.4.md
+++ b/app/public/dist/client/changelog/patch-5.4.md
@@ -53,3 +53,4 @@
 
 - New accounts now start with a random avatar among Pokemon Mystery Dungeon starters
 - Vietnamese translation has been started thanks to Camchanh
+- Improved fight simulation accuracy in case of high server stress

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -43,13 +43,19 @@ import {
   EloRank,
   ExpPlace,
   LegendaryShop,
+  MAX_SIMULATION_DELTA_TIME,
   PortalCarouselStages,
   RequiredStageLevelForXpElligibility,
   UniqueShop
 } from "../types/Config"
 import { GameMode, PokemonActionState } from "../types/enum/Game"
 import { Item } from "../types/enum/Item"
-import { Pkm, PkmDuos, PkmProposition, PkmRegionalVariants } from "../types/enum/Pokemon"
+import {
+  Pkm,
+  PkmDuos,
+  PkmProposition,
+  PkmRegionalVariants
+} from "../types/enum/Pokemon"
 import { SpecialGameRule } from "../types/enum/SpecialGameRule"
 import { Synergy } from "../types/enum/Synergy"
 import { removeInArray } from "../utils/array"
@@ -499,6 +505,9 @@ export default class GameRoom extends Room<GameState> {
     if (this.state.gameLoaded) return // already started
     this.state.gameLoaded = true
     this.setSimulationInterval((deltaTime: number) => {
+      /* in case of lag spikes, the game should feel slower, 
+      but this max simulation dt helps preserving the correctness of simulation result */
+      deltaTime = Math.min(MAX_SIMULATION_DELTA_TIME, deltaTime)
       if (!this.state.gameFinished) {
         try {
           this.dispatcher.dispatch(new OnUpdateCommand(), { deltaTime })

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -729,4 +729,6 @@ export const DUST_PER_SHINY = 250
 export const TOURNAMENT_REGISTRATION_TIME = 60 * 60 * 1000 // 1 hour
 export const TOURNAMENT_CLEANUP_DELAY = 24 * 60 * 60 * 1000 // 1 day
 
+export const MAX_SIMULATION_DELTA_TIME = 50 // milliseconds
+
 export { EloRank }


### PR DESCRIPTION
in case of lag spikes, the game should feel slower, but this max simulation dt helps preserving the correctness of simulation result

set as 50 ms for now, just like default value for colyseus patch rate