### PR TITLE
Pokemon starter + 5 gold

### DIFF
--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -3,7 +3,7 @@ import type GameState from "../../rooms/states/game-state"
 import type { IPlayer, Role, Title } from "../../types"
 import { SynergyTriggers, UniqueShop } from "../../types/Config"
 import { DungeonPMDO } from "../../types/enum/Dungeon"
-import { BattleResult } from "../../types/enum/Game"
+import { BattleResult, Rarity } from "../../types/enum/Game"
 import {
   ArtificialItems,
   Berries,
@@ -49,7 +49,7 @@ export default class Player extends Schema implements IPlayer {
   @type(["string"]) shop = new ArraySchema<Pkm>()
   @type(ExperienceManager) experienceManager = new ExperienceManager()
   @type({ map: "uint8" }) synergies = new Synergies()
-  @type("uint16") money = process.env.MODE == "dev" ? 999 : 6
+  @type("uint16") money = process.env.MODE == "dev" ? 999 : 5
   @type("int8") life = 100
   @type("boolean") shopLocked: boolean = false
   @type("uint8") streak: number = 0
@@ -138,6 +138,16 @@ export default class Player extends Schema implements IPlayer {
       this.life = 9
       this.canRegainLife = false
     }
+
+    const randomStarter = state.shop.getRandomPokemonFromPool(
+      Rarity.COMMON,
+      this
+    )
+    const pokemon = PokemonFactory.createPokemonFromName(randomStarter, this)
+    pokemon.positionX = getFirstAvailablePositionInBench(this.board) ?? 0
+    pokemon.positionY = 0
+    this.board.set(pokemon.id, pokemon)
+    pokemon.onAcquired(this)
 
     if (state.specialGameRule === SpecialGameRule.UNIQUE_STARTER) {
       const randomUnique = pickRandomIn(UniqueShop)

--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -345,7 +345,7 @@ export default class Shop {
   getRandomPokemonFromPool(
     rarity: Rarity,
     player: Player,
-    finals: Set<Pkm>,
+    finals: Set<Pkm> = new Set(),
     specificTypeWanted?: Synergy
   ): Pkm {
     let pkm = Pkm.MAGIKARP

--- a/app/public/dist/client/changelog/patch-5.4.md
+++ b/app/public/dist/client/changelog/patch-5.4.md
@@ -39,6 +39,7 @@
 
 # Gameplay
 
+- Players now start the game with 5 gold and one random common pokemon instead of 6 gold
 - Extra PP generated when reaching max PP are now saved and restored after casting ability
 - Attacks and abilities now have a frame delay specific to each pokemon before damage and effects are applied
 - Projectiles now have travel time


### PR DESCRIPTION
Players now start the game with 5 gold and one random common pokemon instead of 6 gold. This allows players with connectivity issues to still win round 1, while preventing player to buy the entire first shop, which gives a bit of strategy to stage 1