### PR TITLE
Bugfix: Removed self as a target for confusion

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -1009,7 +1009,8 @@ export default class PokemonState {
       }
     })
 
-    candidatesCoordinates.push({ x: pokemon.positionX, y: pokemon.positionY }) // sometimes attack itself when confused
+    // Removed as a potential sinner for an orientation error.
+    //candidatesCoordinates.push({ x: pokemon.positionX, y: pokemon.positionY }) // sometimes attack itself when confused
 
     if (candidatesCoordinates.length > 0) {
       return pickRandomIn(candidatesCoordinates)


### PR DESCRIPTION
When choosing self as a target it should result in an orientation error as pokemon x/y will be the same as target x/y.