### PR TITLE
fix end game draw edgecase

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -923,10 +923,18 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
     if (playersAlive.length <= 1) {
       this.state.gameFinished = true
       const winner = playersAlive[0]
-      const client = this.room.clients.find((cli) => cli.auth.uid === winner.id)
-      if (client) {
-        client.send(Transfer.FINAL_RANK, 1)
+      if (winner) {
+        /* there is a case where none of the players is alive because
+         all the remaining players are dead due to a draw battle.
+         In that case, they all already received their rank with checkDeath function */
+        const client = this.room.clients.find(
+          (cli) => cli.auth.uid === winner.id
+        )
+        if (client) {
+          client.send(Transfer.FINAL_RANK, 1)
+        }
       }
+
       setTimeout(() => {
         // dispose the room automatically after 30 seconds
         this.room.broadcast(Transfer.GAME_END)


### PR DESCRIPTION
there is a case where none of the players is alive at the end of a game because all the remaining players are dead due to a draw battle. In that case, they all already received their rank with checkDeath function. Added a safecheck to prevent an exception in prod