### PR TITLE
weaken flinch status

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -409,19 +409,26 @@ export default class PokemonState {
 
       let residualDamage = reducedDamage
 
-      if (pokemon.shield > 0 && !pokemon.status.flinch) {
-        let damageOnShield = reducedDamage
+      if (pokemon.shield > 0) {
+        let damageOnShield
+        if (pokemon.status.flinch) {
+          damageOnShield = reducedDamage * 0.5
+          residualDamage = reducedDamage * 0.5
+        } else {
+          damageOnShield = reducedDamage
+          residualDamage = 0
+        }
         if (attacker && attacker.items.has(Item.FIRE_GEM)) {
           damageOnShield *= 2 // double damage on shield
         }
         if (damageOnShield > pokemon.shield) {
+          residualDamage += damageOnShield - pokemon.shield
           damageOnShield = pokemon.shield
         }
 
         pokemon.shieldDamageTaken += damageOnShield
         takenDamage += damageOnShield
         pokemon.shield -= damageOnShield
-        residualDamage = min(0)(reducedDamage - damageOnShield)
       }
 
       takenDamage += Math.min(residualDamage, pokemon.life)

--- a/app/public/dist/client/changelog/patch-5.4.md
+++ b/app/public/dist/client/changelog/patch-5.4.md
@@ -58,6 +58,7 @@
 - Increased preparation phase duration for rounds 3, 5, 8, 9, 11, 15 and 19: ~~30~~ 40 seconds ; for rounds 10 and 20: ~~45~~ 50 seconds
 - Increase experience cost for level 6,7,8,9 by 2
 - Reduce sleep duration reduction when taking a hit: 500ms → 300ms
+- Flinch status changed: ~~100~~ 50% of incoming damage bypass shield
 
 # UI
 

--- a/app/public/dist/client/locales/de/translation.json
+++ b/app/public/dist/client/locales/de/translation.json
@@ -2171,7 +2171,7 @@
     "POKERUS": "Alle 2 Sekunden erhältst du 1 ATK und 10% AP, bevor du 2 benachbarte Verbündete mit POKERUS infizierst.",
     "ARMOR_REDUCTION": "Reduzieren Sie DEF und SPE_DEF um 50 %",
     "CHARM": "Verhindert den Angriff auf das Ziel und zwingt dazu, sich ihm zu nähern",
-    "FLINCH": "Alle eingehenden Schäden umgehen SHIELD",
+    "FLINCH": "50 % des eingehenden Schadens umgehen SHIELD",
     "CURSE": "Besiegt das verfluchte Pokémon nach einiger Zeit",
     "RUNE_PROTECT": "Schützt vor Statusänderungen",
     "LOCKED": "Verhindert die Bewegung und setzt RANGE auf 1",

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -2181,7 +2181,7 @@
     "POKERUS": "Every 2 seconds, gain 1 ATK and 10% AP before infecting 2 adjacent allies with POKERUS",
     "ARMOR_REDUCTION": "Reduce DEF & SPE_DEF by 50%",
     "CHARM": "Prevents attacking the target and forces to get closer to it",
-    "FLINCH": "All incoming damage bypass SHIELD",
+    "FLINCH": "50% of incoming damage bypass SHIELD",
     "CURSE": "KOs the cursed Pokémon after some time",
     "RUNE_PROTECT": "Protects from status alterations",
     "LOCKED": "Prevents moving and sets RANGE to 1",

--- a/app/public/dist/client/locales/es/translation.json
+++ b/app/public/dist/client/locales/es/translation.json
@@ -2162,7 +2162,7 @@
     "POKERUS": "Cada 2 segundos, obtiene 1 ATK y 10% AP antes de infectar a 2 aliados adyacentes con POKERUS",
     "ARMOR_REDUCTION": "Reduce la DEF y la SPE_DEF en un 50%",
     "CHARM": "Impide atacar al objetivo y obliga a acercarse a él.",
-    "FLINCH": "El daño entrante atraviesa SHIELD",
+    "FLINCH": "El 50% del daño entrante atraviesa SHIELD",
     "CURSE": "KO al Pokémon maldito después de un tiempo",
     "RUNE_PROTECT": "Protege de alteraciones de estado",
     "LOCKED": "Previene el movimiento y fija el RANGE a 1",

--- a/app/public/dist/client/locales/fr/translation.json
+++ b/app/public/dist/client/locales/fr/translation.json
@@ -2162,7 +2162,7 @@
     "POKERUS": "Toutes les 2 secondes, gagnez 1 ATK et 10% AP avant d'infecter 2 alliés adjacents avec le POKERUS",
     "ARMOR_REDUCTION": "Réduit la DEF et SPE_DEF de 50 %",
     "CHARM": "Empêche d'attaquer la cible et force à s'en rapprocher",
-    "FLINCH": "Tous les dégâts reçus passent à travers le SHIELD",
+    "FLINCH": "50% des dégâts reçus passent à travers le SHIELD",
     "CURSE": "Met KO le pokémon maudit à la fin du compte à rebours",
     "RUNE_PROTECT": "Protège des altérations d'état",
     "LOCKED": "Empêche de bouger et réduit la RANGE à 1",

--- a/app/public/dist/client/locales/it/translation.json
+++ b/app/public/dist/client/locales/it/translation.json
@@ -1629,7 +1629,7 @@
     "POKERUS": "Ogni 2 secondi, guadagna 1 ATTACCO e 10% ATTACCO SPECIALE prima di infettare 2 alleati adiacenti con POKERUS",
     "ARMOR_REDUCTION": "Riduci DEF e SPE_DEF del 50%",
     "CHARM": "Impedisce di attaccare il bersaglio e costringe ad avvicinarsi ad esso",
-    "FLINCH": "Tutti i danni in arrivo bypassano lo SCUDO",
+    "FLINCH": "Il 50% dei danni in arrivo bypassano lo SCUDO",
     "CURSE": "Manda KO il Pokémon maledetto dopo un pò di tempo.",
     "RUNE_PROTECT": "Protegge dalle alterazioni di stato",
     "LOCKED": "Previene i movimenti e modifica il RAGGIO DI AZIONE ad 1.",


### PR DESCRIPTION
Several players pointed out flinch to be responsible of normal decline, so i nerf a bit the status

- Flinch status changed: ~~100~~ 50% of incoming damage bypass shield