### PR TITLE
change item merging behavior

### DIFF
--- a/app/core/evolution-rules.ts
+++ b/app/core/evolution-rules.ts
@@ -7,7 +7,7 @@ import { ItemComponents, Item, ShinyItems } from "../types/enum/Item"
 import { Passive } from "../types/enum/Passive"
 import { Pkm } from "../types/enum/Pokemon"
 import { logger } from "../utils/logger"
-import { pickRandomIn } from "../utils/random"
+import { pickRandomIn, shuffleArray } from "../utils/random"
 import { values } from "../utils/schemas"
 
 type DivergentEvolution = (
@@ -140,23 +140,26 @@ export class CountEvolutionRule extends EvolutionRule {
       pokemon.onEvolve({ pokemonEvolved, pokemonsBeforeEvolution, player })
     }
 
-    for (let i = 0; i < 3; i++) {
-      const itemToAdd = itemsToAdd.pop()
-      if (itemToAdd) {
-        if (pokemonEvolved.items.has(itemToAdd)) {
-          player.items.push(itemToAdd)
-        } else {
-          pokemonEvolved.items.add(itemToAdd)
-        }
+    shuffleArray(itemsToAdd)
+    for (const item of itemsToAdd) {
+      if (pokemonEvolved.items.has(item) || pokemonEvolved.items.size >= 3) {
+        player.items.push(item)
+      } else {
+        pokemonEvolved.items.add(item)
       }
     }
 
-    itemsToAdd.forEach((item) => {
-      player.items.push(item)
-    })
-    itemComponentsToAdd.forEach((item) => {
-      player.items.push(item)
-    })
+    shuffleArray(itemComponentsToAdd)
+    for (const itemComponent of itemComponentsToAdd) {
+      if (
+        pokemonEvolved.items.has(itemComponent) ||
+        pokemonEvolved.items.size >= 3
+      ) {
+        player.items.push(itemComponent)
+      } else {
+        pokemonEvolved.items.add(itemComponent)
+      }
+    }
 
     if (coord) {
       // logger.debug(coord, pokemonEvolved.name)

--- a/app/public/dist/client/changelog/patch-5.4.md
+++ b/app/public/dist/client/changelog/patch-5.4.md
@@ -63,6 +63,7 @@
 - Increase experience cost for level 6,7,8,9 by 2
 - Reduce sleep duration reduction when taking a hit: 500ms → 300ms
 - Flinch status changed: ~~100~~ 50% of incoming damage bypass shield
+- Changed behavior when more than 3 items are merged after an evolution: the excessive items dropped are now random, but item components still are dropped in priority
 
 # UI
 

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -163,7 +163,7 @@ export class OnGameStartRequestCommand extends Command<
         }
       })
 
-      if (nbHumanPlayers < MIN_HUMAN_PLAYERS) {
+      if (nbHumanPlayers < MIN_HUMAN_PLAYERS && process.env.MODE !== "dev") {
         this.state.addMessage({
           authorId: "Server",
           payload: `Due to the current high traffic on the game, to limit the resources used server side, only games with a minimum of 8 players are authorized.`,


### PR DESCRIPTION
Changed behavior when more than 3 items are merged after an evolution: the excessive items dropped are now random, but item components still are dropped in priority

particularly useful to avoid easy redistribution of rare candy