### PR TITLE
Update translation.json

### DIFF
--- a/app/public/dist/client/locales/vi/translation.json
+++ b/app/public/dist/client/locales/vi/translation.json
@@ -14,7 +14,7 @@
   "pool": {
     "regular": "Thường xuyên",
     "additional": "Thêm vào",
-    "regional": "Vùng miền"
+    "regional": "Khu vực"
   },
   "damage": {
     "SPECIAL": "Sát thương phép",


### PR DESCRIPTION
Change "Vùng miền" to "Khu vực" for regional; suggest changing Region to appropriate word also. "Vùng miền" means more like populated area by humans, whereas "Khu vực" means an area in general

Đổi "Vùng miền" thành Khu vực. Vùng miền giống với khu người ở, trong khi khu vực chỉ nghĩa chung (bao gồm khu vực hoang dã cho Pokemon)