### PR TITLE
reenable confusion self damage

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -767,7 +767,8 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
         if (
           ally &&
           ally.passive === Passive.SHARED_VISION &&
-          this.team === ally.team
+          this.team === ally.team &&
+          !(this.targetX === ally.positionX && this.targetY === ally.positionY) // do not self inflict damage if ally is confused and targeting you
         ) {
           ally.targetX = this.targetX
           ally.targetY = this.targetY

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -1016,8 +1016,7 @@ export default class PokemonState {
       }
     })
 
-    // Removed as a potential sinner for an orientation error.
-    //candidatesCoordinates.push({ x: pokemon.positionX, y: pokemon.positionY }) // sometimes attack itself when confused
+    candidatesCoordinates.push({ x: pokemon.positionX, y: pokemon.positionY }) // sometimes attack itself when confused
 
     if (candidatesCoordinates.length > 0) {
       return pickRandomIn(candidatesCoordinates)


### PR DESCRIPTION
confusion can self damage again but shared vision now handle that edgecase of not self-targeting if the ally is confused