### PR TITLE
Add timeout to loading-manager

### DIFF
--- a/app/public/src/game/components/loading-manager.ts
+++ b/app/public/src/game/components/loading-manager.ts
@@ -33,6 +33,7 @@ export default class LoadingManager {
 
   async preload() {
     const scene = this.scene
+    scene.load.xhr.timeout = 5000 // help avoiding failed loading of assets when server is overloaded
     scene.load.scenePlugin(
       "animatedTiles",
       AnimatedTiles,


### PR DESCRIPTION
added a 5 second timeout option to loading manager XHR settings, that applies on all asset loading requests

Hopefully should help avoiding the green boxes bug when server is too slow to respond immediately to requests