### PR TITLE
Reenable pokemon index react

### DIFF
--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -763,7 +763,7 @@ export default class BattleManager {
           pkm.index = value as IPokemonEntity["index"]
           this.animationManager.animatePokemon(
             pkm,
-            PokemonActionState.EMOTE,
+            PokemonActionState.IDLE,
             this.flip,
             false
           )

--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -758,17 +758,17 @@ export default class BattleManager {
         if (pkm.lifebar) {
           pkm.lifebar.setTeam(value as IPokemonEntity["team"], this.flip)
         }
-      }
-      // } else if (field === "index") {
-      //   pkm.index = value as IPokemonEntity["index"]
-      //   this.animationManager.animatePokemon(
-      //     pkm,
-      //     PokemonActionState.IDLE,
-      //     this.flip,
-      //     "index"
-      //   )
-      // }
-      else if (field === "skill") {
+      } else if (field === "index") {
+        if (pkm.index !== value) {
+          pkm.index = value as IPokemonEntity["index"]
+          this.animationManager.animatePokemon(
+            pkm,
+            PokemonActionState.EMOTE,
+            this.flip,
+            false
+          )
+        }
+      } else if (field === "skill") {
         pkm.skill = value as IPokemonEntity["skill"]
         if (pkm.detail && pkm.detail instanceof PokemonDetail) {
           pkm.detail.updateAbilityDescription(pkm.skill, pkm.stars, pkm.ap)


### PR DESCRIPTION
All the transformations abilities like Hoopa etc. do not work due to this part being commented https://github.com/sylvainpolletvillard/pokemonAutoChess/commit/8957f3a20d14d3d111b80c6c3738fbb1346ff39f#diff-e492df5e8216b0a64db6a785bd0bc7fdda690ccd33deabf25b272fc686ee9922R769
i don't know why this part has been commented, i'm going to make a PR that reenables it but if there's a good  reason for that, please ignore it