### PR TITLE
Modified pathfinding algorithm to use A* algorithm, fixing the left-right movement loop bug.

### DIFF
--- a/app/core/board.ts
+++ b/app/core/board.ts
@@ -164,6 +164,26 @@ export default class Board {
     return cells
   }
 
+  getOuterRangeCells(cellX: number, cellY: number, range = 1, includesCenter = false) {
+    const cells = new Array<Cell>()
+  
+    // Loop through the outer range cells
+    for (let y = cellY - range; y <= cellY + range; y++) {
+      for (let x = cellX - range; x <= cellX + range; x++) {
+        // Exclude the inner range
+        if (Math.abs(x - cellX) < range && Math.abs(y - cellY) < range) continue
+        // Skip the center if not included
+        if (x == cellX && y == cellY && !includesCenter) continue
+        // Ensure coordinates are within grid bounds
+        if (y >= 0 && y < this.rows && x >= 0 && x < this.columns) {
+          cells.push({ x, y, value: this.cells[this.columns * y + x] })
+        }
+      }
+    }
+  
+    return cells
+  }
+
   getCellsInFront(
     pokemon: PokemonEntity,
     target: PokemonEntity,

--- a/app/core/board.ts
+++ b/app/core/board.ts
@@ -243,6 +243,18 @@ export default class Board {
     }
     return cells
   }
+  getAllPokemonCoordinates(board: Board): { x: number; y: number }[] {
+    let pokemonCoordinates: { x: number; y: number }[] = [];
+  
+    board.forEach((x: number, y: number, value: PokemonEntity | undefined) => {
+      if (value !== undefined) {
+        // Add coordinates of all Pokémon to the list
+        pokemonCoordinates.push({ x, y });
+      }
+    });
+  
+    return pokemonCoordinates;
+  }
 
   getCellsBetween(x0: number, y0: number, x1: number, y1: number) {
     /* Supercover line algorithm from https://www.redblobgames.com/grids/line-drawing.html */

--- a/app/core/moving-state.ts
+++ b/app/core/moving-state.ts
@@ -19,10 +19,13 @@ export default class MovingState extends PokemonState {
     weather: Weather,
     player: Player
   ) {
-    super.update(pokemon, dt, board, weather, player);
+    super.update(pokemon, dt, board, weather, player)
     if (pokemon.cooldown <= 0) {
-      pokemon.cooldown = 500 / getMoveSpeed(pokemon, weather);
-      const targetAtRange = this.getNearestTargetAtRangeCoordinates(pokemon, board);
+      pokemon.cooldown = 500 / getMoveSpeed(pokemon, weather)
+      const targetAtRange = this.getNearestTargetAtRangeCoordinates(
+        pokemon,
+        board
+      )
       if (pokemon.status.charm && pokemon.canMove) {
         if (
           pokemon.status.charmOrigin &&
@@ -47,7 +50,7 @@ export default class MovingState extends PokemonState {
         }
       }
     } else {
-      pokemon.cooldown = Math.max(0, pokemon.cooldown - dt);
+      pokemon.cooldown = Math.max(0, pokemon.cooldown - dt)
       if (pokemon.status.skydiving && pokemon.cooldown <= 0) {
         pokemon.status.skydiving = false;
       }
@@ -69,10 +72,12 @@ export default class MovingState extends PokemonState {
       !pokemon.status.locked
     ) {
       // dark jump
-      const farthestCoordinate = board.getFarthestTargetCoordinateAvailablePlace(pokemon);
+      const farthestCoordinate =
+      board.getFarthestTargetCoordinateAvailablePlace(pokemon)
+    //logger.debug({ farthestCoordinate })
       if (farthestCoordinate) {
-        x = farthestCoordinate.x;
-        y = farthestCoordinate.y;
+        x = farthestCoordinate.x
+        y = farthestCoordinate.y
 
         if (pokemon.passive === Passive.STENCH) {
           board
@@ -87,10 +92,10 @@ export default class MovingState extends PokemonState {
                 });
                 board.effects[board.columns * cell.y + cell.x] = Effect.POISON_GAS;
               }
-            });
+            })
         }
-
-        board.swapValue(pokemon.positionX, pokemon.positionY, x, y);
+        // logger.debug(`pokemon ${pokemon.name} jumped from (${pokemon.positionX},${pokemon.positionY}) to (${x},${y}), (desired direction (${coordinates.x}, ${coordinates.y})), orientation: ${pokemon.orientation}`);
+        board.swapValue(pokemon.positionX, pokemon.positionY, x, y)
         pokemon.orientation = board.orientation(
           x,
           y,
@@ -98,7 +103,7 @@ export default class MovingState extends PokemonState {
           pokemon.targetY,
           pokemon,
           undefined
-        );
+        )
       }
     } else {
       // Using pathfinding to get optimal path
@@ -125,25 +130,18 @@ export default class MovingState extends PokemonState {
           pokemon,
           undefined
         );
-      
-        //console.debug(`Updated orientation for Pokémon ${pokemon.name}: ${pokemon.orientation}`);
-      
         board.swapValue(pokemon.positionX, pokemon.positionY, x, y);
-      
-        //console.debug(`Moved Pokémon ${pokemon.name} from (${pokemon.positionX}, ${pokemon.positionY}) to (${x}, ${y})`);
-      } else {
-        //console.debug('No valid path found for Pokémon ${pokemon.name}');
       }
     }
   }
 
   onEnter(pokemon: PokemonEntity) {
-    super.onEnter(pokemon);
-    pokemon.action = PokemonActionState.WALK;
-    pokemon.cooldown = 0;
+    super.onEnter(pokemon)
+    pokemon.action = PokemonActionState.WALK
+    pokemon.cooldown = 0
   }
 
   onExit(pokemon: PokemonEntity) {
-    super.onExit(pokemon);
+    super.onExit(pokemon)
   }
 }

--- a/app/core/moving-state.ts
+++ b/app/core/moving-state.ts
@@ -116,19 +116,23 @@ export default class MovingState extends PokemonState {
       // Using pathfinding to get optimal path
       //console.debug('Current Pokemon:', pokemon.name, 'Position:', pokemon.positionX, pokemon.positionY);
       //console.debug('target Pokemons position:', coordinates.x , coordinates.y);
-      const path = findPath(board, [pokemon.positionX, pokemon.positionY],[coordinates.x, coordinates.y])
-      
-      //console.debug('Path found:', path);
-      
-      if (path.length > 0) {
-        // Move Pokémon along the path
-        const nextStep = path[0]; // Get the next step in the path
-        x = nextStep[0];
-        y = nextStep[1];
-      
-        //console.debug(`Next step for Pokémon ${pokemon.name}: (${x}, ${y})`);
-      
-        // Update Pokémon's orientation and position
+      const cells = board.getOuterRangeCells(pokemon.positionX, pokemon.positionY, pokemon.range)
+      let distance = 999
+
+      cells.forEach((cell) => {
+        if (cell.value === undefined) {
+          const candidateDistance = findPath(board, [pokemon.positionX, pokemon.positionY],[coordinates.x, coordinates.y])
+          //logger.debug(`${pokemon.name} - Candidate (${cell.x},${cell.y}) to ${coordinates.x},${coordinates.y}, distance: ${candidateDistance}`);
+          if (candidateDistance.length < distance) {
+            distance = candidateDistance.length
+            const nextStep = candidateDistance[0];
+            x = nextStep[0];
+            y = nextStep[1];
+          }
+        }
+      })
+
+      if (x !== undefined && y !== undefined) {
         pokemon.orientation = board.orientation(
           pokemon.positionX,
           pokemon.positionY,
@@ -142,7 +146,7 @@ export default class MovingState extends PokemonState {
       }
     }
   }
-
+  
   onEnter(pokemon: PokemonEntity) {
     super.onEnter(pokemon)
     pokemon.action = PokemonActionState.WALK

--- a/app/core/moving-state.ts
+++ b/app/core/moving-state.ts
@@ -39,7 +39,7 @@ export default class MovingState extends PokemonState {
           this.move(pokemon, board, {
             x: pokemon.status.charmOrigin.positionX,
             y: pokemon.status.charmOrigin.positionY
-          });
+          })
         }
       } else if (targetAtRange) {
         pokemon.toAttackingState()
@@ -65,6 +65,8 @@ export default class MovingState extends PokemonState {
     board: Board,
     coordinates: { x: number; y: number }
   ) {
+    //logger.debug('move attempt');
+    
     let x: number | undefined = undefined
     let y: number | undefined = undefined
 
@@ -76,8 +78,8 @@ export default class MovingState extends PokemonState {
     ) {
       // dark jump
       const farthestCoordinate =
-      board.getFarthestTargetCoordinateAvailablePlace(pokemon)
-    //logger.debug({ farthestCoordinate })
+        board.getFarthestTargetCoordinateAvailablePlace(pokemon)
+      //logger.debug({ farthestCoordinate })
       if (farthestCoordinate) {
         x = farthestCoordinate.x
         y = farthestCoordinate.y
@@ -98,6 +100,7 @@ export default class MovingState extends PokemonState {
               }
             })
         }
+        
         // logger.debug(`pokemon ${pokemon.name} jumped from (${pokemon.positionX},${pokemon.positionY}) to (${x},${y}), (desired direction (${coordinates.x}, ${coordinates.y})), orientation: ${pokemon.orientation}`);
         board.swapValue(pokemon.positionX, pokemon.positionY, x, y)
         pokemon.orientation = board.orientation(

--- a/app/core/moving-state.ts
+++ b/app/core/moving-state.ts
@@ -42,17 +42,20 @@ export default class MovingState extends PokemonState {
           });
         }
       } else if (targetAtRange) {
-        pokemon.toAttackingState();
+        pokemon.toAttackingState()
       } else {
-        const targetAtSight = this.getNearestTargetAtSightCoordinates(pokemon, board);
+        const targetAtSight = this.getNearestTargetAtSightCoordinates(
+          pokemon,
+          board
+        )
         if (targetAtSight && pokemon.canMove) {
-          this.move(pokemon, board, targetAtSight);
+          this.move(pokemon, board, targetAtSight)
         }
       }
     } else {
       pokemon.cooldown = Math.max(0, pokemon.cooldown - dt)
       if (pokemon.status.skydiving && pokemon.cooldown <= 0) {
-        pokemon.status.skydiving = false;
+        pokemon.status.skydiving = false
       }
     }
   }
@@ -62,8 +65,8 @@ export default class MovingState extends PokemonState {
     board: Board,
     coordinates: { x: number; y: number }
   ) {
-    let x: number | undefined = undefined;
-    let y: number | undefined = undefined;
+    let x: number | undefined = undefined
+    let y: number | undefined = undefined
 
     if (
       pokemon.types.has(Synergy.DARK) &&
@@ -89,8 +92,9 @@ export default class MovingState extends PokemonState {
                   type: BoardEvent.POISON_GAS,
                   x: cell.x,
                   y: cell.y
-                });
-                board.effects[board.columns * cell.y + cell.x] = Effect.POISON_GAS;
+                })
+                board.effects[board.columns * cell.y + cell.x] =
+                  Effect.POISON_GAS
               }
             })
         }
@@ -109,7 +113,7 @@ export default class MovingState extends PokemonState {
       // Using pathfinding to get optimal path
       //console.debug('Current Pokemon:', pokemon.name, 'Position:', pokemon.positionX, pokemon.positionY);
       //console.debug('target Pokemons position:', coordinates.x , coordinates.y);
-      const path = findPath(board, [pokemon.positionX, pokemon.positionY],[coordinates.x, coordinates.y]);
+      const path = findPath(board, [pokemon.positionX, pokemon.positionY],[coordinates.x, coordinates.y])
       
       //console.debug('Path found:', path);
       
@@ -129,8 +133,9 @@ export default class MovingState extends PokemonState {
           y,
           pokemon,
           undefined
-        );
-        board.swapValue(pokemon.positionX, pokemon.positionY, x, y);
+        )
+        // logger.debug(`pokemon ${pokemon.name} moved from (${pokemon.positionX},${pokemon.positionY}) to (${x},${y}), (desired direction (${coordinates.x}, ${coordinates.y})), orientation: ${pokemon.orientation}`);
+        board.swapValue(pokemon.positionX, pokemon.positionY, x, y)
       }
     }
   }

--- a/app/utils/pathfind.ts
+++ b/app/utils/pathfind.ts
@@ -1,0 +1,111 @@
+import Board from "../core/board";
+const defaultGrid: number[][] = [
+    [0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0]
+];
+
+export type Node = {
+    x: number;
+    y: number;
+    g: number; // Cost from start node
+    h: number; // Heuristic cost to goal
+    f: number; // Total cost
+    parent?: Node; // To reconstruct the path
+};
+
+export const getHeuristic = (a: Node, b: Node): number => {
+    return Math.max(Math.abs(b.x - a.x), Math.abs(b.y - a.y));
+};
+
+export const getNeighbors = (node: Node, grid: number[][]): Node[] => {
+    const directions = [
+        { x: 1, y: 0 },  // Right
+        { x: -1, y: 0 }, // Left
+        { x: 0, y: 1 },  // Down
+        { x: 0, y: -1 }, // Up
+        { x: 1, y: 1 },  // Down-right
+        { x: -1, y: -1 },// Up-left
+        { x: 1, y: -1 }, // Up-right
+        { x: -1, y: 1 }, // Down-left
+    ];
+
+    return directions.map(dir => ({
+        x: node.x + dir.x,
+        y: node.y + dir.y,
+        g: 0,
+        h: 0,
+        f: 0
+    })).filter(neighbor => {
+        const x = neighbor.x;
+        const y = neighbor.y;
+        return x >= 0 && x < grid[0].length && y >= 0 && y < grid.length && grid[y][x] !== 1;
+    });
+};
+
+export const findPath = (board: Board, start: [number, number], goal: [number, number]): [number, number][] => {
+    const gridCopy = defaultGrid.map(row => row.slice()); // Copy grid to modify for path
+    const pokemonCoordinates = board.getAllPokemonCoordinates(board);
+    //console.log('Pokémon coordinates:', pokemonCoordinates);
+    pokemonCoordinates.forEach(({ x, y }) => {
+        // Ensure the goal coordinates are not set to 1 on the matrix
+        if (gridCopy[y] && gridCopy[y][x] !== undefined && !(x === goal[0] && y === goal[1])) {
+            gridCopy[y][x] = 1; // Set the cell to 1 where Pokémon are located. Creates a 2d matrix map of obstacles(pokemon)
+        }
+    });
+    // visualizeGrid(gridCopy); //uncomment to see obstacle map
+
+    //below is A* algorithm that calculates path given a start coord and a goal coord.
+    const startNode: Node = { x: start[0], y: start[1], g: 0, h: getHeuristic({ x: start[0], y: start[1], g: 0, h: 0, f: 0 }, { x: goal[0], y: goal[1], g: 0, h: 0, f: 0 }), f: 0 };
+    startNode.f = startNode.g + startNode.h;
+    const goalNode: Node = { x: goal[0], y: goal[1], g: 0, h: 0, f: 0 };
+    const openList: Node[] = [startNode];
+    const closedList: Set<string> = new Set();
+
+    while (openList.length > 0) {
+        openList.sort((a, b) => a.f - b.f);
+        const currentNode = openList.shift()!;
+        closedList.add(`${currentNode.x},${currentNode.y}`);
+
+        if (currentNode.x === goalNode.x && currentNode.y === goalNode.y) {
+            const path: [number, number][] = [];
+            let node: Node | undefined = currentNode;
+            while (node) {
+                if (!(node.x === start[0] && node.y === start[1]) && !(node.x === goal[0] && node.y === goal[1])) {
+                    path.unshift([node.x, node.y]);
+                }
+                node = node.parent;
+            }
+            return path;
+        }
+
+        for (const neighbor of getNeighbors(currentNode, gridCopy)) {
+            if (closedList.has(`${neighbor.x},${neighbor.y}`)) continue;
+
+            const g = currentNode.g + (neighbor.x !== currentNode.x && neighbor.y !== currentNode.y ? Math.SQRT2 : 1);
+            const h = getHeuristic({ x: neighbor.x, y: neighbor.y, g: 0, h: 0, f: 0 }, goalNode);
+            const f = g + h;
+
+            const openNode = openList.find(n => n.x === neighbor.x && n.y === neighbor.y);
+            if (openNode && f >= openNode.f) continue;
+
+            const newNode: Node = { x: neighbor.x, y: neighbor.y, g, h, f, parent: currentNode };
+            openList.push(newNode);
+        }
+    }
+
+    return [];
+};
+
+export const visualizeGrid = (grid: number[][]): void => {
+    console.log('Grid Visualization:');
+    // Iterate through each row of the grid in reverse order (displays 0,0 on bottom left)
+    for (let y = grid.length - 1; y >= 0; y--) {
+        // Convert each cell in the row to a string and join with spaces
+        const rowString = grid[y].map(cell => cell.toString()).join(' ');
+        console.log(rowString);
+    }
+};


### PR DESCRIPTION
This is my attempt at solving pathing issues caused by the current pathfinding algorithm. Since the current one does not account for obstacles(pokemon), the Chebyshev distance scores calculated do not reflect the true optimal pathing. This causes the left-right movement looping seen in the gif below. Moving left is seen as the best move, then right, and so on.

![pac1](https://github.com/user-attachments/assets/9b902c6a-46b1-4b74-a3d0-26dcadcbb417)

For my solution, I utilized the A* algorithm which is guaranteed to find the optimal path between two coordinates. During each pokemon movement, I call the findpath() function I created which performs the A* algorithm, returning an array of coordinates of the optimal movements. This function is ran on all outer ring cells that are within pokemon.range's distance to target Pokemon. The shortest path is selected and the first movement in the array is performed. Only 1 movement is used since the optimal path changes with every board change. This process repeats until pokemon is in attacking range of an enemy pokemon.

Below is the same position as the above gif, using the optimized pathfinder. 
![pac2](https://github.com/user-attachments/assets/68c70042-d799-4415-9a55-b3153bf8ec6b)

Hopefully this contribution is usable or at least have given some inspiration :)





