### PR TITLE
Fixed English "Resurrection" typo.

### DIFF
--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -2158,7 +2158,7 @@
     "CONFUSION": "Confused",
     "WOUND": "Wound",
     "RAGE": "Enraged",
-    "RESURECTION": "Resurection",
+    "RESURECTION": "Resurrection",
     "PARALYSIS": "Paralyzed",
     "POKERUS": "Pokérus",
     "LOCKED": "Locked",


### PR DESCRIPTION
It's missing an R.