### PR TITLE
better handle max players on lobby error

### DIFF
--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -18,6 +18,8 @@ import UserMetadata from "../models/mongo-models/user-metadata"
 import { Emotion, IPlayer, Role, Title, Transfer } from "../types"
 import {
   GREATBALL_RANKED_LOBBY_CRON,
+  MAX_CONCURRENT_PLAYERS_ON_LOBBY,
+  MAX_CONCURRENT_PLAYERS_ON_SERVER,
   SCRIBBLE_LOBBY_CRON,
   TOURNAMENT_CLEANUP_DELAY,
   TOURNAMENT_REGISTRATION_TIME,
@@ -60,8 +62,6 @@ import {
 } from "./commands/lobby-commands"
 import LobbyState from "./states/lobby-state"
 
-const MAX_CCU = 700
-
 export default class CustomLobbyRoom extends Room<LobbyState> {
   bots: Map<string, IBot>
   unsubscribeLobby: (() => void) | undefined
@@ -72,8 +72,6 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
 
   constructor() {
     super()
-    this.maxClients = 50
-
     this.dispatcher = new Dispatcher(this)
     this.bots = new Map<string, IBot>()
     this.tournamentCronJobs = new Map<string, CronJob>()
@@ -426,7 +424,8 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
       } else if (isBanned) {
         throw new Error("Account banned")
       } else if (
-        this.state.ccu > MAX_CCU &&
+        (this.state.ccu > MAX_CONCURRENT_PLAYERS_ON_SERVER ||
+          this.clients.length > MAX_CONCURRENT_PLAYERS_ON_LOBBY) &&
         userProfile?.role !== Role.ADMIN &&
         userProfile?.role !== Role.MODERATOR
       ) {

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -139,8 +139,8 @@ export const BoosterRarityProbability: { [key in Rarity]: number } = {
 }
 
 export const DITTO_RATE = 0.005
-export const KECLEON_RATE = 1/100
-export const ARCEUS_RATE = 1/100
+export const KECLEON_RATE = 1 / 100
+export const ARCEUS_RATE = 1 / 100
 
 export const AttackTypeColor: { [key in AttackType] } = {
   [AttackType.PHYSICAL]: "#FF6E55",
@@ -349,6 +349,8 @@ export const FishRarityProbability: {
   }
 }
 
+export const MAX_CONCURRENT_PLAYERS_ON_SERVER = 700
+export const MAX_CONCURRENT_PLAYERS_ON_LOBBY = 1
 export const MAX_PLAYERS_PER_GAME = 8
 export const MIN_HUMAN_PLAYERS = process.env.MIN_HUMAN_PLAYERS
   ? parseInt(process.env.MIN_HUMAN_PLAYERS)

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -350,7 +350,7 @@ export const FishRarityProbability: {
 }
 
 export const MAX_CONCURRENT_PLAYERS_ON_SERVER = 700
-export const MAX_CONCURRENT_PLAYERS_ON_LOBBY = 1
+export const MAX_CONCURRENT_PLAYERS_ON_LOBBY = 50
 export const MAX_PLAYERS_PER_GAME = 8
 export const MIN_HUMAN_PLAYERS = process.env.MIN_HUMAN_PLAYERS
   ? parseInt(process.env.MIN_HUMAN_PLAYERS)


### PR DESCRIPTION
replace "no room found with provided criteria" error by "The servers are full..." when too many players in lobby room

move MAX_CCU to MAX_CONCURRENT_PLAYERS_ON_SERVER and MAX_CONCURRENT_PLAYERS_ON_LOBBY in Config vars