### PR TITLE
prevent basic attacks from missing if target moved to another cell

### DIFF
--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -101,8 +101,8 @@ export default class AttackingState extends PokemonState {
           new AttackCommand(
             delayBeforeShoot + travelTime,
             pokemon,
-            board,
-            targetCoordinate
+            target,
+            board
           )
         )
       }

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -20,13 +20,8 @@ import Board, { Cell } from "./board"
 import { PokemonEntity } from "./pokemon-entity"
 
 export default class PokemonState {
-  attack(
-    pokemon: PokemonEntity,
-    board: Board,
-    coordinates: { x: number; y: number }
-  ) {
-    const target = board.getValue(coordinates.x, coordinates.y)
-    if (target) {
+  attack(pokemon: PokemonEntity, board: Board, target: PokemonEntity) {
+    if (target.life > 0) {
       let damage = pokemon.atk
       let physicalDamage = 0
       let specialDamage = 0

--- a/app/core/simulation-command.ts
+++ b/app/core/simulation-command.ts
@@ -35,23 +35,23 @@ export class AbilityCommand extends SimulationCommand {
 
 export class AttackCommand extends SimulationCommand {
   pokemon: PokemonEntity
+  target: PokemonEntity
   board: Board
-  targetCoordinate: { x: number; y: number }
 
   constructor(
     delay: number,
     pokemon: PokemonEntity,
-    board: Board,
-    targetCoordinate: { x: number; y: number }
+    target: PokemonEntity,
+    board: Board
   ) {
     super(delay)
     this.pokemon = pokemon
     this.board = board
-    this.targetCoordinate = targetCoordinate
+    this.target = target
   }
 
   execute(): void {
-    this.pokemon.state.attack(this.pokemon, this.board, this.targetCoordinate)
+    this.pokemon.state.attack(this.pokemon, this.board, this.target)
     if (
       this.pokemon.effects.has(Effect.RISING_VOLTAGE) ||
       this.pokemon.effects.has(Effect.OVERDRIVE) ||
@@ -69,19 +69,11 @@ export class AttackCommand extends SimulationCommand {
       }
       if (isTripleAttack) {
         this.pokemon.count.tripleAttackCount++
-        this.pokemon.state.attack(
-          this.pokemon,
-          this.board,
-          this.targetCoordinate
-        )
-        this.pokemon.state.attack(
-          this.pokemon,
-          this.board,
-          this.targetCoordinate
-        )
+        this.pokemon.state.attack(this.pokemon, this.board, this.target)
+        this.pokemon.state.attack(this.pokemon, this.board, this.target)
         if (isPowerSurge) {
           this.board
-            .getAdjacentCells(this.targetCoordinate.x, this.targetCoordinate.y)
+            .getAdjacentCells(this.target.positionX, this.target.positionY)
             .forEach((cell) => {
               if (cell) {
                 const enemy = this.board.getValue(cell.x, cell.y)
@@ -96,8 +88,8 @@ export class AttackCommand extends SimulationCommand {
                   this.pokemon.simulation.room.broadcast(Transfer.ABILITY, {
                     id: this.pokemon.simulation.id,
                     skill: "LINK_CABLE_link",
-                    positionX: this.targetCoordinate.x,
-                    positionY: this.targetCoordinate.y,
+                    positionX: this.target.positionX,
+                    positionY: this.target.positionY,
                     targetX: enemy.positionX,
                     targetY: enemy.positionY
                   })

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -1930,7 +1930,7 @@
     "SHELL_BELL": "Holder heals for 33% of all damages inflicted",
     "LUCKY_EGG": "+40 AP for holder and adjacent allies in the same row",
     "AQUA_EGG": "The holder gains +50 starting PP and regains 20 PP after casting its ability",
-    "BLUE_ORB": "Every third attack from the holder unleashes a chain lightning that bounces to the 2 closing enemies, dealing 10 SPECIAL and burning 20 PP",
+    "BLUE_ORB": "Every third attack dealt unleashes a chain lightning that bounces to the 2 closing enemies, dealing 10 SPECIAL and burning 20 PP",
     "SCOPE_LENS": "Critical hits steal 15 PP from the target.",
     "STAR_DUST": "After casting ability, gain 60% of max PP as SHIELD",
     "GREEN_ORB": "Holder and adjacent allies regain 4% of their max HP every second",


### PR DESCRIPTION
While this has presumably been done on purpose, it seems players all agree they prefer ranged attacks to never miss

https://discord.com/channels/737230355039387749/1277871131017351199