### PR TITLE
show regional add pick when in appropriate region

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1050,14 +1050,11 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
             if (p) {
               // If the Pokemon has a regional variant in the player's region, show that instead of the base form.
               // Base form will still be added to the pool for all players
-              const regionalVariants =
-                p in PkmRegionalVariants
-                  ? PkmRegionalVariants[p]!.filter((pkm) =>
-                      PokemonClasses[pkm].prototype.isInRegion(pkm, player.map)
-                    )
-                  : undefined
-
-              if (regionalVariants && regionalVariants.length > 0) {
+              const regionalVariants = (PkmRegionalVariants[p] ?? []).filter(
+                (pkm) =>
+                  PokemonClasses[pkm].prototype.isInRegion(pkm, player.map)
+              )
+              if (regionalVariants.length > 0) {
                 player.pokemonsProposition.push(pickRandomIn(regionalVariants))
               } else {
                 player.pokemonsProposition.push(p)

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -54,7 +54,8 @@ import {
   Pkm,
   PkmDuos,
   PkmProposition,
-  PkmRegionalVariants
+  PkmRegionalVariants,
+  RegionalPkmBaseForms
 } from "../types/enum/Pokemon"
 import { SpecialGameRule } from "../types/enum/SpecialGameRule"
 import { Synergy } from "../types/enum/Synergy"
@@ -974,21 +975,15 @@ export default class GameRoom extends Room<GameState> {
     player.pokemonsProposition.clear()
 
     if (AdditionalPicksStages.includes(this.state.stageLevel)) {
-      this.state.additionalPokemons.push(pkm as Pkm)
-      this.state.shop.addAdditionalPokemon(pkm)
-      if (pkm in PkmRegionalVariants) {
-        const variants: Pkm[] = PkmRegionalVariants[pkm]
-        for (const variant of variants) {
-          if (
-            PokemonClasses[variant].prototype.isInRegion(
-              variant,
-              player.map,
-              this.state
-            )
-          ) {
-            player.regionalPokemons.push(variant)
-          }
-        }
+      // If player picked their regional variant, we need to add the base pokemon to the shop pool
+      if (pkm in RegionalPkmBaseForms) {
+        const basePkm = RegionalPkmBaseForms[pkm]
+        this.state.additionalPokemons.push(basePkm)
+        this.state.shop.addAdditionalPokemon(basePkm)
+        player.regionalPokemons.push(pkm as Pkm)
+      } else {
+        this.state.additionalPokemons.push(pkm as Pkm)
+        this.state.shop.addAdditionalPokemon(pkm)
       }
 
       if (

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -54,8 +54,7 @@ import {
   Pkm,
   PkmDuos,
   PkmProposition,
-  PkmRegionalVariants,
-  RegionalPkmBaseForms
+  PkmRegionalVariants
 } from "../types/enum/Pokemon"
 import { SpecialGameRule } from "../types/enum/SpecialGameRule"
 import { Synergy } from "../types/enum/Synergy"
@@ -976,8 +975,10 @@ export default class GameRoom extends Room<GameState> {
 
     if (AdditionalPicksStages.includes(this.state.stageLevel)) {
       // If player picked their regional variant, we need to add the base pokemon to the shop pool
-      if (pkm in RegionalPkmBaseForms) {
-        const basePkm = RegionalPkmBaseForms[pkm]
+      if (pokemonsObtained[0]?.regional) {
+        const basePkm = (Object.keys(PkmRegionalVariants).find((p) =>
+          PkmRegionalVariants[p].includes(pokemonsObtained[0].name)
+        ) ?? pokemonsObtained[0].name) as Pkm
         this.state.additionalPokemons.push(basePkm)
         this.state.shop.addAdditionalPokemon(basePkm)
         player.regionalPokemons.push(pkm as Pkm)

--- a/app/types/enum/Pokemon.ts
+++ b/app/types/enum/Pokemon.ts
@@ -2472,7 +2472,7 @@ export const PkmFamily: { [key in Pkm]: Pkm } = {
   [Pkm.PAWMOT]: Pkm.PAWMI
 }
 
-export const PkmRegionalVariants: { [key in Pkm]?: Pkm[] } = {
+export const PkmRegionalVariants: { [key in Pkm]?: readonly Pkm[] } = {
   [Pkm.RATTATA]: [Pkm.ALOLAN_RATTATA],
   [Pkm.GROWLITHE]: [Pkm.HISUI_GROWLITHE],
   [Pkm.VULPIX]: [Pkm.ALOLAN_VULPIX],
@@ -2482,19 +2482,7 @@ export const PkmRegionalVariants: { [key in Pkm]?: Pkm[] } = {
   [Pkm.GRIMER]: [Pkm.ALOLAN_GRIMER],
   [Pkm.NIDORANF]: [Pkm.NIDORANM],
   [Pkm.SNEASEL]: [Pkm.HISUI_SNEASEL]
-}
-
-export const RegionalPkmBaseForms: { [key in Pkm]?: Pkm } = {
-  [Pkm.ALOLAN_RATTATA]: Pkm.RATTATA,
-  [Pkm.HISUI_GROWLITHE]: Pkm.GROWLITHE,
-  [Pkm.ALOLAN_VULPIX]: Pkm.VULPIX,
-  [Pkm.ALOLAN_GEODUDE]: Pkm.GEODUDE,
-  [Pkm.ALOLAN_DIGLETT]: Pkm.DIGLETT,
-  [Pkm.HISUI_ZORUA]: Pkm.ZORUA,
-  [Pkm.ALOLAN_GRIMER]: Pkm.GRIMER,
-  [Pkm.NIDORANM]: Pkm.NIDORANF,
-  [Pkm.HISUI_SNEASEL]: Pkm.SNEASEL
-}
+} as const
 
 export enum PkmDuo {
   LATIOS_LATIAS = "LATIOS_LATIAS",

--- a/app/types/enum/Pokemon.ts
+++ b/app/types/enum/Pokemon.ts
@@ -2484,6 +2484,18 @@ export const PkmRegionalVariants: { [key in Pkm]?: Pkm[] } = {
   [Pkm.SNEASEL]: [Pkm.HISUI_SNEASEL]
 }
 
+export const RegionalPkmBaseForms: { [key in Pkm]?: Pkm } = {
+  [Pkm.ALOLAN_RATTATA]: Pkm.RATTATA,
+  [Pkm.HISUI_GROWLITHE]: Pkm.GROWLITHE,
+  [Pkm.ALOLAN_VULPIX]: Pkm.VULPIX,
+  [Pkm.ALOLAN_GEODUDE]: Pkm.GEODUDE,
+  [Pkm.ALOLAN_DIGLETT]: Pkm.DIGLETT,
+  [Pkm.HISUI_ZORUA]: Pkm.ZORUA,
+  [Pkm.ALOLAN_GRIMER]: Pkm.GRIMER,
+  [Pkm.NIDORANM]: Pkm.NIDORANF,
+  [Pkm.HISUI_SNEASEL]: Pkm.SNEASEL
+}
+
 export enum PkmDuo {
   LATIOS_LATIAS = "LATIOS_LATIAS",
   PLUSLE_MINUN = "PLUSLE_MINUN",


### PR DESCRIPTION
Per idea submitted here in discord: https://discord.com/channels/737230355039387749/1278470326732193803

If player is in a region with a regional form of an add pick, the regional form will be proposed instead. The base form is still added to the shop pool.

Tested locally and verified that it works as expected, but let me know if I missed anything or if there's a better way to do any of it.