### PR TITLE
tryfix missing ghost matchup

### DIFF
--- a/app/core/matchmaking.ts
+++ b/app/core/matchmaking.ts
@@ -2,6 +2,7 @@ import Player from "../models/colyseus-models/player"
 import GameState from "../rooms/states/game-state"
 import { IPlayer } from "../types"
 import { sum } from "../utils/array"
+import { logger } from "../utils/logger"
 import { pickRandomIn } from "../utils/random"
 import { values } from "../utils/schemas"
 
@@ -71,6 +72,10 @@ function completeMatchupCombination(
     const remainingMatchups = matchups.filter(
       (m) => remainingPlayers.includes(m.a) && remainingPlayers.includes(m.b)
     )
+    if (remainingMatchups.length === 0) {
+      // no more matchups, need to complete with a ghost matchup
+      return completeMatchupCombination([...combination], matchups, players)
+    }
     return remainingMatchups.flatMap((m) =>
       completeMatchupCombination([...combination, m], matchups, players)
     )
@@ -79,7 +84,7 @@ function completeMatchupCombination(
 
 export function selectMatchups(state: GameState): Matchup[] {
   /* step 1) establish all the matchups possible with players alive and their associated count
-  count = number of times A fought B or his ghost) +(number of times B fought A or his ghost) */
+  count = number of times A fought B or his ghost) + (number of times B fought A or his ghost) */
   const players = values(state.players).filter((p) => p.alive)
   if (players.length <= 1) return []
   const matchups = getAllPossibleMatchups(players)

--- a/app/public/dist/client/changelog/patch-5.5.md
+++ b/app/public/dist/client/changelog/patch-5.5.md
@@ -23,8 +23,7 @@
 
 # Bugfix
 
-- Regional lists was not correctly updated when picking an additional pick with a regional variant
-- Fixed Ghost curses status afflictions not reapplied correctly after status is cleared
+- 
 
 # Misc
 


### PR DESCRIPTION
try to fix this bug https://discord.com/channels/737230355039387749/1273426639883206747

never reproduced it locally but i think what's happening is that in completeMatchupCombination function, if there is no remaining matchups the last ghost matchup will never been added to the matchup combination list. So i add another condition to call again completeMatchupCombination  if remainingMatchups.length === 0