### PR TITLE
Fixed bug with preparation onAuth checking already in room.

### DIFF
--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -312,7 +312,7 @@ export default class PreparationRoom extends Room<PreparationState> {
       const numberOfHumanPlayers = values(this.state.users).filter(
         (u) => !u.isBot
       ).length
-      if (numberOfHumanPlayers >= MAX_PLAYERS_PER_GAME) {
+      if (numberOfHumanPlayers >= MAX_PLAYERS_PER_GAME && !isAlreadyInRoom) {
         throw "Room is full"
       } else if (this.state.gameStartedAt != null) {
         throw "Game already started"
@@ -322,8 +322,6 @@ export default class PreparationRoom extends Room<PreparationState> {
         throw "User banned"
       } else if (this.metadata.blacklist.includes(user.uid)) {
         throw "User previously kicked"
-      } else if (isAlreadyInRoom) {
-        throw "User already in room"
       } else {
         return user
       }


### PR DESCRIPTION
Fixed a bug with the onAuth which would prevent a user from joining a room they are already in.
This could cause an error where the user is in the room but can't navigate to the page.
In testing, rejoining a room you're already in doesn't cause any error, it won't duplicate someone in the list, so this check is unnecessary.