### PR TITLE
Add await operators to quick play function.

### DIFF
--- a/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
@@ -129,9 +129,9 @@ export default function AvailableRoomMenu() {
       (room) => room.metadata?.gameMode === GameMode.QUICKPLAY && room.clients < MAX_PLAYERS_PER_GAME
     )
     if (existingQuickPlayRoom) {
-      joinPrepRoom(existingQuickPlayRoom)
+      await joinPrepRoom(existingQuickPlayRoom)
     } else {
-      createRoom(GameMode.QUICKPLAY)
+      await createRoom(GameMode.QUICKPLAY)
     }
   }, 1000)
 


### PR DESCRIPTION
Adding `await` to make sure the `throttle` function will wait for the quick play function to finish.