### PR TITLE
Change lobbyJoined back to useRef

### DIFF
--- a/app/public/src/pages/lobby.tsx
+++ b/app/public/src/pages/lobby.tsx
@@ -242,22 +242,23 @@ export async function joinLobbyRoom(
         dispatch(logIn(user))
         try {
           const token = await user.getIdToken()
-
-          const reconnectToken: string = localStore.get(LocalStoreKeys.RECONNECTION_TOKEN)
-          if (reconnectToken) {
-            try {
-              const lobbyRoom: Room<ICustomLobbyState> = await client.reconnect(reconnectToken)
-              if (lobbyRoom.name === "lobby") {
-                dispatch(joinLobby(lobbyRoom))
-              } else if (lobbyRoom.connection.isOpen) {
-                lobbyRoom.connection.close()
+          const lobby = store.getState().network.lobby
+          if (!lobby) {
+            const reconnectToken: string = localStore.get(LocalStoreKeys.RECONNECTION_TOKEN)
+            if (reconnectToken) {
+              try {
+                const lobbyRoom: Room<ICustomLobbyState> = await client.reconnect(reconnectToken)
+                if (lobbyRoom.name === "lobby") {
+                  dispatch(joinLobby(lobbyRoom))
+                } else if (lobbyRoom.connection.isOpen) {
+                  lobbyRoom.connection.close()
+                }
+              } catch (error) {
+                logger.log(error)
+                localStore.delete(LocalStoreKeys.RECONNECTION_TOKEN)
               }
-            } catch (error) {
-              logger.log(error)
-              localStore.delete(LocalStoreKeys.RECONNECTION_TOKEN)
             }
           }
-          const lobby = store.getState().network.lobby
           const room: Room<ICustomLobbyState> = lobby ?? await client.join("lobby", {
             idToken: token
           })

--- a/app/public/src/pages/lobby.tsx
+++ b/app/public/src/pages/lobby.tsx
@@ -1,7 +1,7 @@
 import { type NonFunctionPropNames } from "@colyseus/schema/lib/types/HelperTypes"
 import { Client, Room, RoomAvailable } from "colyseus.js"
 import firebase from "firebase/compat/app"
-import React, { useCallback, useEffect, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import {
@@ -64,7 +64,7 @@ export default function Lobby() {
   const navigate = useNavigate()
   const lobby = useAppSelector((state) => state.network.lobby)
 
-  const [lobbyJoined, setLobbyJoined] = useState<boolean>(false)
+  const lobbyJoined = useRef<boolean>(false)
   const [gameToReconnect, setGameToReconnect] = useState<string | null>(
     localStore.get(LocalStoreKeys.RECONNECTION_GAME)
   )
@@ -89,7 +89,7 @@ export default function Lobby() {
 
   useEffect(() => {
     const client = store.getState().network.client
-    if (!lobbyJoined) {
+    if (!lobbyJoined.current) {
       joinLobbyRoom(dispatch, client, onLeave).catch((err) => {
         logger.error(err)
         const errorMessage = CloseCodesMessages[err] ?? "UNKNOWN_ERROR"
@@ -98,7 +98,7 @@ export default function Lobby() {
         }
         navigate("/")
       })
-      setLobbyJoined(true)
+      lobbyJoined.current = true
     }
   }, [lobbyJoined, dispatch])
 


### PR DESCRIPTION
Changes added in #2132 are causing an error with the login reconnect.
Specifically these changes:
```ts
// app\public\src\pages\lobby.tsx
const [lobbyJoined, setLobbyJoined] = useState<boolean>(false)
//...
if (!lobbyJoined) {
//...
setLobbyJoined(true)
```
This is now forcing the page to reload twice. `useEffect` already forced a reload once, and now `useState` reloads it again. So, the reconnect will try to reconnect when it's already connected causing the "seat reservation" error.
`useRef` was fine, I think. It's the same function as `useState` except it doesn't force the page to reload when the variable changes.

Any variable referenced in `useEffect` will force a refresh when it changes.
```ts
// variable being changed
lobbyJoined.current = true
// ...
// variables that are referenced
}, [lobbyJoined, dispatch])
```