### PR TITLE
Send user profile on reconnect to lobby (urgent) ⚠️

### DIFF
--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -459,7 +459,12 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
       if (consented) {
         throw new Error("consented leave")
       }
+      const userProfile = this.users.get(client.auth.uid)
+      if (!userProfile) {
+        throw new Error("Missing User Profile.")
+      }
       await this.allowReconnection(client, 30)
+      client.send(Transfer.USER_PROFILE, userProfile)
     } catch (error) {
       this.dispatcher.dispatch(new OnLeaveCommand(), { client })
     }


### PR DESCRIPTION
This is a fix for the prejoin lobby code.
This is needed for the join code to work correctly.
It won't currently work on the release build.