### PR TITLE
Remove redundant checks in preparation reconnect

### DIFF
--- a/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
@@ -133,7 +133,7 @@ export default function AvailableRoomMenu() {
     if (reconnectToken) {
       try {
         const room: Room<PreparationState> = await client.reconnect(reconnectToken)
-        if (room.name === "preparation" && room.state.gameMode === GameMode.QUICKPLAY) {
+        if (room.state.gameMode === GameMode.QUICKPLAY) {
           localStore.set(
             LocalStoreKeys.RECONNECTION_PREPARATION,
             { reconnectionToken: room.reconnectionToken, roomId: room.roomId },

--- a/app/public/src/pages/preparation.tsx
+++ b/app/public/src/pages/preparation.tsx
@@ -77,18 +77,6 @@ export default function Preparation() {
                   r = await client.reconnect(
                     cachedReconnectionToken
                   )
-                  if (r.name === "game") {
-                    if (r.connection.isOpen) {
-                      r.connection.close()
-                    }
-                    navigate("/game")
-                    return
-                  } else if (r.name !== "preparation") {
-                    if (r.connection.isOpen) {
-                      r.connection.close()
-                    }
-                    throw new Error("Preparation: Wrong room type.")
-                  }
                 } catch (error) {
                   logger.log(error)
                   localStore.delete(LocalStoreKeys.RECONNECTION_PREPARATION)


### PR DESCRIPTION
Now that the reconnection tokens are split by room type, these checks are no longer needed.