### PR TITLE
Asynchronize all double leave calls

### DIFF
--- a/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../../../../types"
 import { MAX_PLAYERS_PER_GAME } from "../../../../../types/Config"
 import { GameMode } from "../../../../../types/enum/Game"
-import { throttle } from "../../../../../utils/function"
+import { throttle, resolveIf } from "../../../../../utils/function"
 import { logger } from "../../../../../utils/logger"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { leaveLobby } from "../../../stores/LobbyStore"
@@ -62,7 +62,10 @@ export default function AvailableRoomMenu() {
           { reconnectionToken: room.reconnectionToken, roomId: room.roomId },
           30
         )
-        await Promise.allSettled([lobby.leave(false), room.leave(false)])
+        await Promise.allSettled([
+          lobby.connection.isOpen && lobby.leave(false),
+          room.connection.isOpen && room.leave(false)
+        ])
         dispatch(leaveLobby())
         navigate("/preparation")
       }

--- a/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
@@ -62,12 +62,7 @@ export default function AvailableRoomMenu() {
           { reconnectionToken: room.reconnectionToken, roomId: room.roomId },
           30
         )
-        if (lobby.connection.isOpen) {
-          await lobby.leave(false)
-        }
-        if (room.connection.isOpen) {
-          await room.leave(false)
-        }
+        await Promise.allSettled([lobby.leave(false), room.leave(false)])
         dispatch(leaveLobby())
         navigate("/preparation")
       }

--- a/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../../../../types"
 import { MAX_PLAYERS_PER_GAME } from "../../../../../types/Config"
 import { GameMode } from "../../../../../types/enum/Game"
-import { throttle, resolveIf } from "../../../../../utils/function"
+import { throttle } from "../../../../../utils/function"
 import { logger } from "../../../../../utils/logger"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { leaveLobby } from "../../../stores/LobbyStore"
@@ -111,12 +111,10 @@ export default function AvailableRoomMenu() {
             { reconnectionToken: room.reconnectionToken, roomId: room.roomId },
             30
           )
-          if (lobby.connection.isOpen) {
-            await lobby.leave(false)
-          }
-          if (room.connection.isOpen) {
-            await room.leave(false)
-          }
+          await Promise.allSettled([
+            lobby.connection.isOpen && lobby.leave(false),
+            room.connection.isOpen && room.leave(false)
+          ])
           dispatch(leaveLobby())
           navigate("/preparation")
         } catch (error) {

--- a/app/public/src/pages/component/available-room-menu/game-rooms-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/game-rooms-menu.tsx
@@ -44,12 +44,10 @@ export function GameRoomsMenu() {
                     { reconnectionToken: game.reconnectionToken, roomId: game.roomId },
                     30
                 )
-                if (lobby.connection.isOpen) {
-                    await lobby.leave(false)
-                }
-                if (game.connection.isOpen) {
-                    await game.leave(false)
-                }
+                await Promise.allSettled([
+                    lobby.connection.isOpen && lobby.leave(false),
+                    game.connection.isOpen && game.leave(false)
+                ])
                 dispatch(leaveLobby())
                 navigate("/game")
             }

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -221,11 +221,8 @@ export default function Game() {
     }
     dispatch(leaveGame())
     navigate("/after")
-
-    try {
-      await room?.leave()
-    } catch (error) {
-      logger.warn("Room already closed")
+    if (room?.connection.isOpen) {
+      room.leave()
     }
   }, [client, dispatch, room])
 

--- a/app/public/src/pages/preparation.tsx
+++ b/app/public/src/pages/preparation.tsx
@@ -217,12 +217,10 @@ export default function Preparation() {
             { reconnectionToken: game.reconnectionToken, roomId: game.roomId },
             5 * 60
           ) // 5 minutes allowed to start game
-          if (r.connection.isOpen) {
-            await r.leave()
-          }
-          if (game.connection.isOpen) {
-            await game.leave(false)
-          }
+          await Promise.allSettled([
+            r.connection.isOpen && r.leave(),
+            game.connection.isOpen && game.leave(false)
+          ])
           dispatch(leavePreparation())
           navigate("/game")
         }


### PR DESCRIPTION
A simple optimization, make all of the double leave calls execute simultaneously instead of one after the other using `Promise.allSettled`.