### PR TITLE
add boost animations for board polemons

### DIFF
--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -515,8 +515,7 @@ export default class PokemonSprite extends DraggableObject {
     })
   }
 
-  evolutionAnimation() {
-    this.displayAnimation("EVOLUTION")
+  emoteAnimation() {
     const g = <GameScene>this.scene
     g.animationManager?.animatePokemon(
       this,
@@ -526,15 +525,14 @@ export default class PokemonSprite extends DraggableObject {
     )
   }
 
+  evolutionAnimation() {
+    this.displayAnimation("EVOLUTION")
+    this.emoteAnimation()
+  }
+
   spawnAnimation() {
     this.displayAnimation("SPAWN")
-    const g = <GameScene>this.scene
-    g.animationManager?.animatePokemon(
-      this,
-      PokemonActionState.EMOTE,
-      this.flip,
-      false
-    )
+    this.emoteAnimation()
   }
 
   hatchAnimation() {

--- a/app/public/src/game/game-container.ts
+++ b/app/public/src/game/game-container.ts
@@ -374,11 +374,10 @@ class GameContainer {
 
     const listenForPokemonChanges = (pokemon: Pokemon) => {
       pokemon.onChange(() => {
-        const fields: NonFunctionPropNames<Pokemon>[] = [
+        const fields: NonFunctionPropNames<IPokemon>[] = [
           "positionX",
           "positionY",
           "action",
-          "types",
           "hp",
           "atk",
           "ap"
@@ -386,7 +385,12 @@ class GameContainer {
         fields.forEach((field) => {
           pokemon.listen(field, (value, previousValue) => {
             if (field && player.id === this.spectatedPlayerId) {
-              this.gameScene?.board?.changePokemon(pokemon, field, value)
+              this.gameScene?.board?.changePokemon(
+                pokemon,
+                field,
+                value as IPokemon[typeof field],
+                previousValue as IPokemon[typeof field]
+              )
             }
           })
         })


### PR DESCRIPTION
Add boost stat animations on board pokemons too. Currently only works with AP and Attack stats, but this already allows a better animation for fire shard drop