### PR TITLE
Add await to quick play was reverted

### DIFF
--- a/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
@@ -152,9 +152,9 @@ export default function AvailableRoomMenu() {
       (room) => room.metadata?.gameMode === GameMode.QUICKPLAY && room.clients < MAX_PLAYERS_PER_GAME
     )
     if (existingQuickPlayRoom) {
-      joinPrepRoom(existingQuickPlayRoom)
+      await joinPrepRoom(existingQuickPlayRoom)
     } else {
-      createRoom(GameMode.QUICKPLAY)
+      await createRoom(GameMode.QUICKPLAY)
     }
   }, 1000)
 


### PR DESCRIPTION
It was originally merged in #2138, but it was reverted.
Was this intentional?