### PR TITLE
Add automatic reconnect logic to game

### DIFF
--- a/app/public/src/game/reconnect-logic.ts
+++ b/app/public/src/game/reconnect-logic.ts
@@ -68,7 +68,7 @@ export function enableAutoReconnect<T = any>(client: Client, room: Room<T>, reco
   }
 
   // update to new reconnection token after reconnecting
-  room.onJoin(() => {
+  (room as any).onJoin(() => {
     localStore.set(
       reconnectStoreKey,
       { reconnectionToken: room.reconnectionToken, roomId: room.roomId },

--- a/app/public/src/game/reconnect-logic.ts
+++ b/app/public/src/game/reconnect-logic.ts
@@ -72,7 +72,7 @@ export function enableAutoReconnect<T = any>(client: Client, room: Room<T>, reco
   transport.ws.onmessage = room.connection.events.onmessage = function onmessage(messageEvent: MessageEvent) {
     originalOnmessage(messageEvent)
     const code = Array.from(new Uint8Array(messageEvent.data))[0]
-    if (code == Protocol.JOIN_ROOM) {
+    if (code === Protocol.JOIN_ROOM) {
       localStore.set(
         reconnectStoreKey,
         { reconnectionToken: room.reconnectionToken, roomId: room.roomId },

--- a/app/public/src/game/reconnect-logic.ts
+++ b/app/public/src/game/reconnect-logic.ts
@@ -1,0 +1,88 @@
+import { Client, Room } from "colyseus.js"
+import { WebSocketTransport } from "colyseus.js/lib/transport/WebSocketTransport"
+import { logger } from "../../../utils/logger"
+import { CloseCodes } from "../../../types/enum/CloseCodes"
+import { Transfer } from "../../../types"
+import { localStore, LocalStoreKeys } from "../pages/utils/store"
+
+const MAX_RECONNECT_TRIES = 3
+
+/**
+ * Automatically reconnects when the connection closes unexpectedly or times out.
+ * @param client The colyseus.js client-side Client.
+ * @param room The colyseus.js client-side Room.
+ * @param reconnectStoreKey The localStorage key string to save the reconnection token.
+ * @param tokenExpirationTime The expiration time in seconds for the localStorage key expiration.
+ */
+export function enableAutoReconnect<T = any>(client: Client, room: Room<T>, reconnectStoreKey: LocalStoreKeys, tokenExpirationTime: number) {
+
+  // override web socket onclose event with a custom function
+  const transport: WebSocketTransport = room.connection.transport as any
+  const originalOnclose: (event: CloseEvent) => any = transport.ws.onclose as any
+  transport.ws.onclose = room.connection.events.onclose = function onclose(closeEvent: CloseEvent) {
+    // only reconnect for abnormal closure or timeout
+    if (closeEvent.code !== CloseCodes.ABNORMAL_CLOSURE && closeEvent.code !== CloseCodes.TIMEOUT) {
+      return originalOnclose(closeEvent)
+    }
+
+    logger.log("Connection closed unexpectedly or timed out. Attempting to reconnect.")
+
+    const token = room.reconnectionToken.slice(room.reconnectionToken.indexOf(":") + 1)
+
+    const reconnect = function reconnect(tries = 1) {
+      logger.log(`Reconnect try ${tries}/${MAX_RECONNECT_TRIES}`)
+
+      // request reconnect from the server
+      client.http.post(`matchmake/reconnect/${room.roomId}`, {
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ reconnectionToken: token })
+
+      // receive server response
+      }).then((response) => {
+        const responseData = response.data
+        if (responseData.error) {
+          throw new Error(responseData.error)
+        }
+        // create url endpoint and connect web socket
+        const roomData = responseData.room
+        const sessionId = responseData.sessionId
+        const endpoint = `${window.location.protocol.replace("http", "ws")}//${window.location.hostname}${(window.location.port && `:${window.location.port}`)}`
+          + `/${roomData.processId}/${roomData.roomId}?sessionId=${sessionId}&reconnectionToken=${token}`
+        room.connection.connect(endpoint)
+
+      // if error, try again to reconnect after 1 second
+      }).catch((error) => {
+        logger.log("reconnection error", error)
+        if (tries < MAX_RECONNECT_TRIES) {
+          setTimeout(() => reconnect(tries + 1), 1000)
+        } else {
+          originalOnclose(closeEvent)
+        }
+      })
+    }
+
+    reconnect()
+  }
+
+  // update to new reconnection token after reconnecting
+  room.onJoin(() => {
+    localStore.set(
+      reconnectStoreKey,
+      { reconnectionToken: room.reconnectionToken, roomId: room.roomId },
+      tokenExpirationTime
+    )
+  })
+
+  // wrap send method with a connection check
+  const originalSend = room.send
+  room.send = function send<T = any>(type: string | number, message?: T): void {
+    if (this.connection.isOpen) {
+      originalSend.apply(this, [type, message])
+    } else if (type !== Transfer.LOADING_PROGRESS) {
+      logger.log("message failed", { type, message })
+    }
+  }
+}

--- a/app/public/src/game/reconnect-logic.ts
+++ b/app/public/src/game/reconnect-logic.ts
@@ -1,4 +1,4 @@
-import { Client, Room } from "colyseus.js"
+import { Client, Protocol, Room } from "colyseus.js"
 import { WebSocketTransport } from "colyseus.js/lib/transport/WebSocketTransport"
 import { logger } from "../../../utils/logger"
 import { CloseCodes } from "../../../types/enum/CloseCodes"
@@ -68,13 +68,18 @@ export function enableAutoReconnect<T = any>(client: Client, room: Room<T>, reco
   }
 
   // update to new reconnection token after reconnecting
-  (room as any).onJoin(() => {
-    localStore.set(
-      reconnectStoreKey,
-      { reconnectionToken: room.reconnectionToken, roomId: room.roomId },
-      tokenExpirationTime
-    )
-  })
+  const originalOnmessage: (event: any) => any = transport.ws.onmessage as any
+  transport.ws.onmessage = room.connection.events.onmessage = function onmessage(messageEvent: MessageEvent) {
+    originalOnmessage(messageEvent)
+    const code = Array.from(new Uint8Array(messageEvent.data))[0]
+    if (code == Protocol.JOIN_ROOM) {
+      localStore.set(
+        reconnectStoreKey,
+        { reconnectionToken: room.reconnectionToken, roomId: room.roomId },
+        tokenExpirationTime
+      )
+    }
+  }
 
   // wrap send method with a connection check
   const originalSend = room.send

--- a/app/public/src/game/reconnect-logic.ts
+++ b/app/public/src/game/reconnect-logic.ts
@@ -12,7 +12,7 @@ const MAX_RECONNECT_TRIES = 3
  * @param client The colyseus.js client-side Client.
  * @param room The colyseus.js client-side Room.
  * @param reconnectStoreKey The localStorage key string to save the reconnection token.
- * @param tokenExpirationTime The expiration time in seconds for the localStorage key expiration.
+ * @param tokenExpirationTime The expiration time in seconds for the localStorage key.
  */
 export function enableAutoReconnect<T = any>(client: Client, room: Room<T>, reconnectStoreKey: LocalStoreKeys, tokenExpirationTime: number) {
 

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -73,6 +73,7 @@ import { MainSidebar } from "./component/main-sidebar/main-sidebar"
 import { playMusic, preloadMusic } from "./utils/audio"
 import { LocalStoreKeys, localStore } from "./utils/store"
 import { FIREBASE_CONFIG } from "./utils/utils"
+import { enableAutoReconnect } from "../game/reconnect-logic"
 
 let gameContainer: GameContainer
 
@@ -134,6 +135,7 @@ export default function Game() {
               { reconnectionToken: room.reconnectionToken, roomId: room.roomId },
               60 * 60
             )
+            enableAutoReconnect(client, room, LocalStoreKeys.RECONNECTION_GAME, 60 * 60)
             dispatch(joinGame(room))
             connected.current = true
             connecting.current = false


### PR DESCRIPTION
The simplest code needed for an automatic reconnect.

Directly reconnects the web socket without creating a new room instance or affecting any other game system.