### PR TITLE
kick to login page for inactivity only if on lobby page

### DIFF
--- a/app/public/src/game/lobby-logic.ts
+++ b/app/public/src/game/lobby-logic.ts
@@ -101,9 +101,10 @@ export async function joinLobbyRoom(
           room.onLeave((code: number) => {
             logger.info(`left lobby with code ${code}`)
             const shouldGoToLoginPage =
-              code === CloseCodes.USER_INACTIVE ||
-              code === CloseCodes.USER_BANNED ||
-              code === CloseCodes.USER_NOT_AUTHENTICATED
+              window.location.pathname === "/lobby" &&
+              (code === CloseCodes.USER_INACTIVE ||
+                code === CloseCodes.USER_BANNED ||
+                code === CloseCodes.USER_NOT_AUTHENTICATED)
             if (shouldGoToLoginPage) {
               const errorMessage = CloseCodesMessages[code]
               if (errorMessage) {


### PR DESCRIPTION
prevent kicking someone for inactivity if they are ingame or in prep room and have the lobby page opened in another tab

fix https://discord.com/channels/737230355039387749/1284242023595118704
https://discord.com/channels/737230355039387749/1284038046798450761