### PR TITLE
Porygon-Z Rare Candy

### DIFF
--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -900,16 +900,20 @@ export default class GameRoom extends Room<GameState> {
         )
         if (pokemonEvolved) {
           hasEvolved = true
-          // check item evolution rule after count evolution (example: Clefairy)
-          this.checkEvolutionsAfterItemAcquired(playerId, pokemonEvolved)
 
+          // Drop Rare Candy if no further count based evo
           if (
             pokemonEvolved.items.has(Item.RARE_CANDY) &&
-            pokemonEvolved.evolution === Pkm.DEFAULT
+            (pokemonEvolved.evolution === Pkm.DEFAULT ||
+              (pokemonEvolved.evolutionRule &&
+                !(pokemonEvolved.evolutionRule instanceof CountEvolutionRule)))
           ) {
             player.items.push(Item.RARE_CANDY)
             pokemonEvolved.items.delete(Item.RARE_CANDY)
           }
+
+          // check item evolution rule after count evolution (example: Porygon-2)
+          this.checkEvolutionsAfterItemAcquired(playerId, pokemonEvolved)
         }
       }
     })


### PR DESCRIPTION
Bug reported here: https://discord.com/channels/737230355039387749/1284947470840758282

Fixed so that Porygon correctly drops Rare Candy on evolving into Porygon-2. Verified a regular pokemon still drops Candy as expected. Verified Porygon drops Rare Candy both with and without Upgrade present (i.e. both on evolving to Porygon-2 and directly to Porygon-Z).

Moved `checkEvolutionsAfterItemAcquired` to happen after dropping Rare Candy to fix an issue that duplicated the item. 
Updated the outdated reference to Clefairy in the comment..