### PR TITLE
Fix Computing of Synergies when GOLDEN_ROD is active

### DIFF
--- a/app/models/colyseus-models/synergies.ts
+++ b/app/models/colyseus-models/synergies.ts
@@ -32,6 +32,10 @@ export default class Synergies
     })
     return count
   }
+
+  isActiveSynergy(syn: Synergy, lvl: number) {
+    return lvl >= SynergyTriggers[syn][0]
+  }
 }
 
 export function computeSynergies(board: IPokemon[]): Map<Synergy, number> {

--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -496,17 +496,17 @@ export default class Shop {
 
     if (rod === Item.GOLDEN_ROD) {
       let topSynergies: Synergy[] = Array.from(player.synergies
-      // sort synergies by count in descending order
-      ).sort(
-        (a, b) => b[1] - a[1]
       // filter only active synergies
       ).filter(
         ([s,v]) => player.synergies.isActiveSynergy(s, v)
+      // sort synergies by count in descending order
+      ).sort(
+      (a, b) => b[1] - a[1]
       // filter only synergies which have a value
       // equal to the top synergy
       ).filter((current, _, array) => {
         const highestValue = array[0][1]
-        return element[1] === highestValue
+        return current[1] === highestValue
       }
       // return only the synergy
       ).map(

--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -495,16 +495,23 @@ export default class Shop {
     }
 
     if (rod === Item.GOLDEN_ROD) {
-      let topSynergies: Synergy[] = []
-      let maxSynergyCount = 0
-      player.synergies.forEach((count, synergy) => {
-        if (count > maxSynergyCount) {
-          maxSynergyCount = count
-          topSynergies = [synergy]
-        } else if (count === maxSynergyCount) {
-          topSynergies.push(synergy)
-        }
-      })
+      let topSynergies: Synergy[] = Array.from(player.synergies
+      // sort synergies by count in descending order
+      ).sort(
+        (a, b) => b[1] - a[1]
+      // filter only active synergies
+      ).filter(
+        ([s,v]) => player.synergies.isActiveSynergy(s, v)
+      // filter only synergies which have a value
+      // equal to the top synergy
+      ).filter((current, _, array) => {
+        const highestValue = array[0][1]
+        return element[1] === highestValue
+      }
+      // return only the synergy
+      ).map(
+        ([s]) => s
+      )
       const typeWanted = pickRandomIn(topSynergies)
 
       if (rarity === Rarity.SPECIAL) {


### PR DESCRIPTION
The current state:
For example in this picture you can see Light and Electric have the same count, but only Light is the active synergy.
In the code Electric is in the pool of topSynergies and therefore also fishes for electric pokemon.
![image](https://github.com/user-attachments/assets/ab477a91-8bca-4c5d-b8e0-04e9de542e23)



Fix:
the computing of how the top synergies are calculated was changed so only ACTIVE synergies should be counted.