### PR TITLE
Fix ENTRAINMENT doens't effect properly

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -9698,18 +9698,19 @@ export class EntrainmentStrategy extends AbilityStrategy {
         []
       board.forEach(
         (x: number, y: number, value: PokemonEntity | undefined) => {
-          if (value && value.team === pokemon.team && value.life > 0) {
+          if (value && value.team === target.team && value.skill !== Ability.ENTRAINMENT && value.life > 0) {
             potentialTargets.push({ x, y, value })
           }
         }
       )
-      potentialTargets.sort(
-        (a, b) =>
-          distanceC(pokemon.positionX, pokemon.positionY, a.x, a.y) -
-          distanceC(pokemon.positionX, pokemon.positionY, b.x, b.y)
-      )
       if (potentialTargets.length > 0) {
-        target.skill = Ability.ENTRAINMENT
+        potentialTargets.sort(
+          (a, b) =>
+            distanceC(target.positionX, target.positionY, a.x, a.y) -
+            distanceC(target.positionX, target.positionY, b.x, b.y)
+        )
+        potentialTargets[0].value.skill = Ability.ENTRAINMENT
+        //--> target.skill = Ability.ENTRAINMENT
       }
     }
   }


### PR DESCRIPTION
discord: https://discord.com/channels/737230355039387749/1285705073367715891

• potential target check target team instead
• check if it does not have Entrainment ability
• sort and execute if list not empty
• sort range from target instead from user*

*word state pick _another enemy nearby_ i assume it nearby target instead of user