### PR TITLE
Fix Duke Title given on wrong reason

### DIFF
--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -594,12 +594,16 @@ export class BuyEmotionCommand extends Command<
         }
       }
 
-      if (
-        !mongoUser.titles.includes(Title.DUKE) &&
-        mongoUser.pokemonCollection.size >= 30
-      ) {
-        mongoUser.titles.push(Title.DUKE)
+      if (!mongoUser.titles.includes(Title.DUKE)){
+        let countProfile = 0
+		    mongoUser.pokemonCollection.forEach((c) => {
+	    	  countProfile += c.emotions.length + c.shinyEmotions.length
+		    })
+        if(countProfile >= 30){
+          mongoUser.titles.push(Title.DUKE)
+        }
       }
+      
       if (
         emotion === Emotion.ANGRY &&
         index === PkmIndex[Pkm.ARBOK] &&


### PR DESCRIPTION
discord: https://discord.com/channels/737230355039387749/1285908004843290624
from check how many data in player pokemonCollection size since player getting add $index after got shard. that make it if player have 30 different types of shards instead of profiles

change to count how profile player actually has