### PR TITLE
Fix Calculation of Healing in Aquatic Synergy

### DIFF
--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -1680,7 +1680,7 @@ export default class Simulation extends Schema implements ISimulation {
             if (cell.team === Team.RED_TEAM) {
               cell.status.clearNegativeStatus()
               if (cell.types.has(Synergy.AQUATIC)) {
-                cell.handleHeal(waveLevel * 0.05 * cell.hp, cell, 0, false)
+                cell.handleHeal(waveLevel * 0.1 * cell.hp, cell, 0, false)
               }
             } else {
               cell.handleDamage({


### PR DESCRIPTION
Aquatic should heal 10% per aquatic stage not 5%.

![image](https://github.com/user-attachments/assets/9f6e0db3-854a-4672-a013-7a8ae3475049)
