### PR TITLE
fix sudowoodo line gaining atk bug

### DIFF
--- a/app/core/idle-state.ts
+++ b/app/core/idle-state.ts
@@ -37,7 +37,7 @@ export class IdleState extends PokemonState {
 
   onEnter(pokemon: PokemonEntity) {
     super.onEnter(pokemon)
-    if (pokemon.status.tree) {
+    if (pokemon.status.tree && pokemon.action !== PokemonActionState.IDLE) {
       pokemon.action = PokemonActionState.IDLE
     } else if (pokemon.status.resurecting) {
       pokemon.action = PokemonActionState.HURT


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1281924087295512606

after last fix player report and I already tested that can be happening if pokemon get status freeze/sleep

since status.tree pokemon will set to Idle state and if pokemon got **freeze** also send to idle state in **update** it getting loop gaining damage than it should be


the thing is I'm not completely sure will affect  another situation so i not PR this. but after test awhile i think it should be ok