### PR TITLE
Show total money earned, total damage dealt and total reroll count in the player detail tooltip ingame

### DIFF
--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -176,9 +176,9 @@ export default class Player extends Schema implements IPlayer {
     }
   }
 
-  addMoney(value: number) {
+  addMoney(value: number, countTotalEarned = true) {
     this.money += value
-    this.totalMoneyEarned += value
+    if (countTotalEarned && value > 0) this.totalMoneyEarned += value
   }
 
   addBattleResult(

--- a/app/public/dist/client/changelog/patch-5.6.md
+++ b/app/public/dist/client/changelog/patch-5.6.md
@@ -50,9 +50,11 @@
 
 - Add a new "Fullscreen" button in the sidebar
 - The game now automatically enters fullscreen when starting a game if supported by the browser. You can disable this in Options > Interface
+- Show total money earned, total damage dealt and total reroll count in the player detail tooltip ingame
 
 # Bugfix
 
 - Fix regional variants of additional pokemons not being immediately available after the additional pokemon being picked
+- Fix total money earned not being correctly updated sometimes
 
 # Misc

--- a/app/public/src/pages/component/game/game-player-detail.tsx
+++ b/app/public/src/pages/component/game/game-player-detail.tsx
@@ -1,29 +1,20 @@
-import { ArraySchema } from "@colyseus/schema"
 import React, { useMemo } from "react"
 import { useTranslation } from "react-i18next"
-import HistoryItem from "../../../../../models/colyseus-models/history-item"
-import Synergies from "../../../../../models/colyseus-models/synergies"
+import { IPlayer } from "../../../../../types"
 import { SynergyTriggers } from "../../../../../types/Config"
 import { BattleResult } from "../../../../../types/enum/Game"
 import { getAvatarSrc } from "../../../utils"
 import { Life } from "../icons/life"
 import { Money } from "../icons/money"
 
-export default function GamePlayerDetail(props: {
-  name: string
-  life: number
-  money: number
-  level: number
-  history: ArraySchema<HistoryItem>
-  synergies: Synergies
-}) {
+export default function GamePlayerDetail(props: { player: IPlayer }) {
   const { t } = useTranslation()
   const synergyList = useMemo(
     () =>
-      Object.entries(props.synergies)
+      Object.entries(props.player.synergies)
         .filter(([syn, val]) => val >= SynergyTriggers[syn][0])
         .map(([syn]) => syn),
-    [props.synergies]
+    [props.player.synergies]
   )
 
   return (
@@ -35,19 +26,19 @@ export default function GamePlayerDetail(props: {
           alignItems: "center"
         }}
       >
-        <span className="player-name">{props.name}</span>
+        <span className="player-name">{props.player.name}</span>
         <span>
-          {t("lvl")} {props.level}
+          {t("lvl")} {props.player.experienceManager.level}
         </span>
         <span>
-          <Life value={props.life} />
+          <Life value={props.player.life} />
         </span>
         <span>
-          <Money value={props.money} />
+          <Money value={props.player.money} />
         </span>
       </div>
       <div style={{ display: "flex", justifyContent: "start" }}>
-        {props.history.slice(-5).map((record, i) => {
+        {props.player.history.slice(-5).map((record, i) => {
           return (
             <div
               key={`${record.name}${i}_game-player-detail`}
@@ -64,8 +55,8 @@ export default function GamePlayerDetail(props: {
                     record.result === BattleResult.WIN
                       ? "4px solid #4aa52e"
                       : record.result === BattleResult.DRAW
-                      ? "4px solid #cc6a28"
-                      : "4px solid #8c2022",
+                        ? "4px solid #cc6a28"
+                        : "4px solid #8c2022",
                   marginLeft: "6px",
                   borderRadius: "12px"
                 }}
@@ -85,7 +76,7 @@ export default function GamePlayerDetail(props: {
         {synergyList.map((synergy, i) => {
           return (
             <div
-              key={`${props.name}_${synergy}${i}_game-player-detail`}
+              key={`${props.player.name}_${synergy}${i}_game-player-detail`}
               style={{
                 display: "flex",
                 justifyContent: "space-around",
@@ -102,6 +93,12 @@ export default function GamePlayerDetail(props: {
             </div>
           )
         })}
+      </div>
+      <div style={{ display: "flex", justifyContent: "space-evenly" }}>
+        <span>{t("total")}</span>
+        <span title={t("total_money_earned")}><img src="assets/icons/money.svg" alt="$" style={{ width: "24px", height: "24px" }} /> {props.player.totalMoneyEarned}</span>
+        <span title={t("total_player_damage_dealt")}><img src="assets/icons/ATK.png" alt="✊" style={{ width: "24px", height: "24px" }} />{props.player.totalPlayerDamageDealt}</span>
+        <span title={t("total_reroll_count")}><img src="assets/ui/refresh.svg" alt="↻" style={{ width: "24px", height: "24px" }} /> {props.player.rerollCount}</span>
       </div>
     </div>
   )

--- a/app/public/src/pages/component/game/game-player.tsx
+++ b/app/public/src/pages/component/game/game-player.tsx
@@ -47,14 +47,7 @@ export default function GamePlayer(props: {
         place="left"
         data-tooltip-offset={{ left: 30, bottom: props.index === 0 ? 50 : 0 }}
       >
-        <GamePlayerDetail
-          name={props.player.name}
-          life={props.player.life}
-          money={props.player.money}
-          level={props.player.experienceManager.level}
-          history={props.player.history}
-          synergies={props.player.synergies}
-        />
+        <GamePlayerDetail player={props.player} />
       </Tooltip>
     </div>
   )

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -661,7 +661,10 @@ export default function Game() {
           "rank",
           "regionalPokemons",
           "streak",
-          "title"
+          "title",
+          "rerollCount",
+          "totalMoneyEarned",
+          "totalPlayerDamageDealt"
         ]
 
         fields.forEach((field) => {

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -650,7 +650,7 @@ export class OnSellDropCommand extends Command<
           pokemon.shiny,
           this.state.specialGameRule
         )
-        player.addMoney(sellPrice)
+        player.addMoney(sellPrice, false)
         pokemon.items.forEach((it) => {
           player.items.push(it)
         })

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -354,7 +354,6 @@ export interface IPlayer {
   role: Role
   itemsProposition: ArraySchema<Item>
   pokemonsProposition: ArraySchema<PkmProposition>
-  rerollCount: number
   loadingProgress: number
   effects: Effects
   isBot: boolean
@@ -367,6 +366,9 @@ export interface IPlayer {
   ultraRegionalPool: Pkm[]
   opponents: Map<string, number>
   ghost: boolean
+  rerollCount: number
+  totalMoneyEarned: number
+  totalPlayerDamageDealt: number
 }
 
 export interface IPokemon {


### PR DESCRIPTION
Show total money earned, total damage dealt and total reroll count in the player detail tooltip ingame

![chrome_mODKG48Y99](https://github.com/user-attachments/assets/f7aa8f5f-8adf-4768-9a36-8b7a24988156)

Fix their value not being updated correctly client-side