### PR TITLE
fix ghost matchups player dereferencing exceptions

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -199,7 +199,7 @@ export class PaydayStrategy extends AbilityStrategy {
       crit
     )
     if (death && pokemon.player) {
-      pokemon.player.addMoney(pokemon.stars)
+      pokemon.player.addMoney(pokemon.stars, true, pokemon)
       pokemon.count.moneyCount += pokemon.stars
     }
   }
@@ -229,7 +229,7 @@ export class PickupStrategy extends AbilityStrategy {
         const moneyStolen = max(target.player.money)(pokemon.stars)
         target.player.money -= moneyStolen
         if (pokemon.player) {
-          pokemon.player.addMoney(moneyStolen)
+          pokemon.player.addMoney(moneyStolen, true, pokemon)
           pokemon.count.moneyCount += moneyStolen
         }
       }
@@ -7401,7 +7401,7 @@ export class GoldRushStrategy extends AbilityStrategy {
     const goldDamage = pokemon.player?.money ? pokemon.player?.money : 0
     const damage = 20 + goldDamage
     if (pokemon.player) {
-      pokemon.player.addMoney(2)
+      pokemon.player.addMoney(2, true, pokemon)
     }
     target.handleSpecialDamage(
       damage,

--- a/app/core/abilities/hidden-power.ts
+++ b/app/core/abilities/hidden-power.ts
@@ -181,7 +181,7 @@ export class HiddenPowerGStrategy extends HiddenPowerStrategy {
   ) {
     super.process(unown, state, board, target, crit)
     if (unown.player) {
-      unown.player.addMoney(5)
+      unown.player.addMoney(5, true, unown)
     }
   }
 }

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -69,7 +69,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   @type("uint8") attackType: AttackType
   @type("uint16") life: number
   @type("uint16") shield = 0
-  @type("uint8") team: number
+  @type("uint8") team: Team
   @type("uint8") range: number
   @type("float32") atkSpeed: number
   @type("int8") targetX = -1
@@ -1297,7 +1297,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     }
 
     if (this.items.has(Item.AMULET_COIN) && this.player) {
-      this.player.addMoney(1)
+      this.player.addMoney(1, true, this)
       this.count.moneyCount += 1
       this.count.amuletCoinCount += 1
     }
@@ -1307,7 +1307,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
         board.cells.some((p) => p && p.team !== this.team && p.life > 0) ===
         false
       const moneyGained = isLastEnemy ? 5 : 1
-      this.player.addMoney(moneyGained)
+      this.player.addMoney(moneyGained, true, this)
       this.count.moneyCount += moneyGained
     }
 

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -635,7 +635,7 @@ export default abstract class PokemonState {
           pokemon.count.growGroundCount === 5 &&
           player
         ) {
-          player.addMoney(3)
+          player.addMoney(3, true, pokemon)
           pokemon.count.moneyCount += 3
         }
       }

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -60,6 +60,7 @@ export default class Simulation extends Schema implements ISimulation {
   redPlayer: Player | undefined
   stormLightningTimer = 0
   tidalwaveTimer = 0
+  isGhostBattle: boolean
 
   constructor(
     id: string,
@@ -69,7 +70,8 @@ export default class Simulation extends Schema implements ISimulation {
     bluePlayer: Player,
     redPlayer: Player | undefined,
     stageLevel: number,
-    weather: Weather
+    weather: Weather,
+    isGhostBattle = false
   ) {
     super()
     this.id = id
@@ -80,6 +82,7 @@ export default class Simulation extends Schema implements ISimulation {
     this.redPlayerId = redPlayer?.id ?? "pve"
     this.stageLevel = stageLevel
     this.weather = weather
+    this.isGhostBattle = isGhostBattle
 
     this.board = new Board(BOARD_HEIGHT, BOARD_WIDTH)
 
@@ -154,7 +157,6 @@ export default class Simulation extends Schema implements ISimulation {
               Effect.HEART_OF_THE_SWARM
             ].some((e) => effects.has(e))
           ) {
-            const teamIndex = team === blueTeam ? 0 : 1
             const bugTeam = new Array<IPokemon>()
             team.forEach((pkm) => {
               if (pkm.types.has(Synergy.BUG) && pkm.positionY != 0) {
@@ -184,9 +186,9 @@ export default class Simulation extends Schema implements ISimulation {
               )
               const coord = this.getClosestAvailablePlaceOnBoardToPokemon(
                 bugTeam[i],
-                teamIndex
+                player.team
               )
-              this.addPokemon(bug, coord.x, coord.y, teamIndex, true)
+              this.addPokemon(bug, coord.x, coord.y, player.team, true)
             }
           }
 
@@ -204,16 +206,15 @@ export default class Simulation extends Schema implements ISimulation {
             }
 
             if (pokemon.items.has(Item.ROTOM_PHONE)) {
-              const teamIndex = team === blueTeam ? 0 : 1
               const rotomDrone = PokemonFactory.createPokemonFromName(
                 Pkm.ROTOM_DRONE,
                 player
               )
               const coord = this.getClosestAvailablePlaceOnBoardToPokemon(
                 pokemon,
-                teamIndex
+                player.team
               )
-              this.addPokemon(rotomDrone, coord.x, coord.y, teamIndex, true)
+              this.addPokemon(rotomDrone, coord.x, coord.y, player.team, true)
             }
           })
         }
@@ -272,7 +273,7 @@ export default class Simulation extends Schema implements ISimulation {
     pokemon: IPokemon,
     x: number,
     y: number,
-    team: number,
+    team: Team,
     isClone = false
   ) {
     const pokemonEntity = new PokemonEntity(pokemon, x, y, team, this)
@@ -299,10 +300,10 @@ export default class Simulation extends Schema implements ISimulation {
     return pokemonEntity
   }
 
-  getFirstAvailablePlaceOnBoard(teamIndex: number): { x: number; y: number } {
+  getFirstAvailablePlaceOnBoard(team: Team): { x: number; y: number } {
     let candidateX = 0,
       candidateY = 0
-    if (teamIndex === 0) {
+    if (team === Team.BLUE_TEAM) {
       outerloop: for (let y = 0; y < this.board.rows; y++) {
         for (let x = 0; x < this.board.columns; x++) {
           if (this.board.getValue(x, y) === undefined) {
@@ -329,7 +330,7 @@ export default class Simulation extends Schema implements ISimulation {
   getClosestAvailablePlaceOnBoardTo(
     positionX: number,
     positionY: number,
-    teamIndex: number
+    team: Team
   ): { x: number; y: number } {
     const placesToConsiderByOrderOfPriority = [
       [0, 0],
@@ -370,7 +371,8 @@ export default class Simulation extends Schema implements ISimulation {
     ]
     for (const [dx, dy] of placesToConsiderByOrderOfPriority) {
       const x = positionX + dx
-      const y = teamIndex === 0 ? positionY - 1 + dy : 5 - (positionY - 1) - dy
+      const y =
+        team === Team.BLUE_TEAM ? positionY - 1 + dy : 5 - (positionY - 1) - dy
 
       if (
         x >= 0 &&
@@ -382,17 +384,17 @@ export default class Simulation extends Schema implements ISimulation {
         return { x, y }
       }
     }
-    return this.getFirstAvailablePlaceOnBoard(teamIndex)
+    return this.getFirstAvailablePlaceOnBoard(team)
   }
 
   getClosestAvailablePlaceOnBoardToPokemon(
     pokemon: IPokemon | IPokemonEntity,
-    teamIndex: number
+    team: Team
   ): { x: number; y: number } {
     return this.getClosestAvailablePlaceOnBoardTo(
       pokemon.positionX,
       pokemon.positionY,
-      teamIndex
+      team
     )
   }
 
@@ -1517,8 +1519,8 @@ export default class Simulation extends Schema implements ISimulation {
       )
 
       if (this.winnerId === this.redPlayerId) {
-        if (this.bluePlayerId !== "pve") {
-          this.redPlayer.addMoney(1)
+        if (this.bluePlayerId !== "pve" && !this.isGhostBattle) {
+          this.redPlayer.addMoney(1, true, null)
           client?.send(Transfer.PLAYER_INCOME, 1)
         }
       } else {
@@ -1555,7 +1557,7 @@ export default class Simulation extends Schema implements ISimulation {
 
       if (this.winnerId === this.bluePlayerId) {
         if (this.redPlayerId !== "pve") {
-          this.bluePlayer.addMoney(1)
+          this.bluePlayer.addMoney(1, true, null)
           client?.send(Transfer.PLAYER_INCOME, 1)
         }
       } else {

--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -1,9 +1,10 @@
 import { ArraySchema, MapSchema, Schema, type } from "@colyseus/schema"
+import { PokemonEntity } from "../../core/pokemon-entity"
 import type GameState from "../../rooms/states/game-state"
 import type { IPlayer, Role, Title } from "../../types"
 import { SynergyTriggers, UniqueShop } from "../../types/Config"
 import { DungeonPMDO } from "../../types/enum/Dungeon"
-import { BattleResult, Rarity } from "../../types/enum/Game"
+import { BattleResult, Rarity, Team } from "../../types/enum/Game"
 import {
   ArtificialItems,
   Berries,
@@ -42,7 +43,7 @@ import Synergies, { computeSynergies } from "./synergies"
 export default class Player extends Schema implements IPlayer {
   @type("string") id: string
   @type("string") simulationId = ""
-  @type("number") simulationTeamIndex: number = 0
+  @type("number") team: Team = Team.BLUE_TEAM
   @type("string") name: string
   @type("string") avatar: string
   @type({ map: Pokemon }) board = new MapSchema<Pokemon>()
@@ -176,7 +177,18 @@ export default class Player extends Schema implements IPlayer {
     }
   }
 
-  addMoney(value: number, countTotalEarned = true) {
+  addMoney(
+    value: number,
+    countTotalEarned: boolean,
+    origin: PokemonEntity | null
+  ) {
+    if (
+      origin &&
+      origin.simulation.isGhostBattle &&
+      origin.player?.team === Team.RED_TEAM
+    ) {
+      return // do not count money earned by pokemons from a ghost player
+    }
     this.money += value
     if (countTotalEarned && value > 0) this.totalMoneyEarned += value
   }

--- a/app/public/dist/client/changelog/patch-5.6.md
+++ b/app/public/dist/client/changelog/patch-5.6.md
@@ -60,5 +60,6 @@
 
 - Fix regional variants of additional pokemons not being immediately available after the additional pokemon being picked
 - Fix total money earned not being correctly updated sometimes
+- Fix some pokemons passives not working properly when played in ghost matchups (ghost = copy of a player to ensure every player has an opponent)
 
 # Misc

--- a/app/public/src/pages/component/game/game-dps-meter.tsx
+++ b/app/public/src/pages/component/game/game-dps-meter.tsx
@@ -7,18 +7,19 @@ import { getAvatarSrc } from "../../../utils"
 import GamePlayerDpsMeter from "./game-player-dps-meter"
 import GamePlayerDpsTakenMeter from "./game-player-dps-taken-meter"
 import GamePlayerHpsMeter from "./game-player-hps-meter"
+import { Team } from "../../../../../types/enum/Game"
 import "./game-dps-meter.css"
 
 export default function GameDpsMeter() {
   const { t } = useTranslation()
   const currentPlayer = useAppSelector(selectCurrentPlayer)
-  const teamIndex = useAppSelector(
-    (state) => state.game.currentSimulationTeamIndex
+  const team = useAppSelector(
+    (state) => state.game.currentTeam
   )
   const blueDpsMeter = useAppSelector((state) => state.game.blueDpsMeter)
   const redDpsMeter = useAppSelector((state) => state.game.redDpsMeter)
-  const myDpsMeter = teamIndex === 0 ? blueDpsMeter : redDpsMeter
-  const opponentDpsMeter = teamIndex === 0 ? redDpsMeter : blueDpsMeter
+  const myDpsMeter = team === Team.BLUE_TEAM ? blueDpsMeter : redDpsMeter
+  const opponentDpsMeter = team === Team.BLUE_TEAM ? redDpsMeter : blueDpsMeter
 
   const [isOpen, setOpen] = useState(preferences.showDpsMeter)
 

--- a/app/public/src/stores/GameStore.ts
+++ b/app/public/src/stores/GameStore.ts
@@ -25,7 +25,7 @@ export interface GameStateStore {
   noElo: boolean
   currentPlayerId: string
   currentSimulationId: string
-  currentSimulationTeamIndex: number
+  currentTeam: Team
   money: number
   interest: number
   streak: number
@@ -54,7 +54,7 @@ const initialState: GameStateStore = {
   noElo: false,
   currentPlayerId: "",
   currentSimulationId: "",
-  currentSimulationTeamIndex: 0,
+  currentTeam: Team.BLUE_TEAM,
   money: 5,
   interest: 0,
   streak: 0,
@@ -184,8 +184,10 @@ export const gameSlice = createSlice({
         state.currentPlayerId === action.payload.redPlayerId
       ) {
         state.currentSimulationId = action.payload.id
-        state.currentSimulationTeamIndex =
-          state.currentPlayerId === action.payload.bluePlayerId ? 0 : 1
+        state.currentTeam =
+          state.currentPlayerId === action.payload.bluePlayerId
+            ? Team.BLUE_TEAM
+            : Team.RED_TEAM
         state.weather = action.payload.weather
         state.blueDpsMeter = new Array<IDps>()
         state.redDpsMeter = new Array<IDps>()
@@ -200,7 +202,7 @@ export const gameSlice = createSlice({
     setPlayer: (state, action: PayloadAction<IPlayer>) => {
       state.currentPlayerId = action.payload.id
       state.currentSimulationId = action.payload.simulationId
-      state.currentSimulationTeamIndex = action.payload.simulationTeamIndex
+      state.currentTeam = action.payload.team
       state.currentPlayerSynergies = Array.from(action.payload.synergies)
     },
     addDpsMeter: (

--- a/app/types/enum/Game.ts
+++ b/app/types/enum/Game.ts
@@ -114,8 +114,8 @@ export enum Damage {
 }
 
 export enum Team {
-  BLUE_TEAM,
-  RED_TEAM
+  BLUE_TEAM = 0,
+  RED_TEAM = 1
 }
 
 export enum BoardEvent {

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -27,7 +27,8 @@ import {
   Orientation,
   PokemonActionState,
   Rarity,
-  Stat
+  Stat,
+  Team
 } from "./enum/Game"
 import { Item } from "./enum/Item"
 import { Passive } from "./enum/Passive"
@@ -331,7 +332,7 @@ export interface IPlayer {
   board: MapSchema<Pokemon>
   shop: ArraySchema<Pkm>
   simulationId: string
-  simulationTeamIndex: number
+  team: Team
   experienceManager: ExperienceManager
   synergies: Synergies
   money: number


### PR DESCRIPTION
Many runtime exceptions are caused by playerB in ghost matchups not being an instance of Player class, but a IPlayer POJO

This happens because we dereferenced ghost players and replace it with a POJO with a new id and a new name "Ghost of X", initially to avoid a ghost player to earn money in a ghost battle ; possibly other reasons that i don't remember

The way i fixed it is to no longer dereference player object but instead pass a new flag "isGhostBattle" to simulation, then test when necessary if this is a red ghost player case, for example in player.addMoney method

I'm confident this fixes the runtime exceptions, but i think I may forget some implications of having the original Player instance in a ghost matchup (besides the money earning). So feedback and testing is welcome.