### PR TITLE
move pokemonomicon effect to handleDamage

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -294,13 +294,6 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
         specialDamage = Math.round(specialDamage * attacker.critPower)
       }
       if (
-        attacker &&
-        attacker.items.has(Item.POKEMONOMICON) &&
-        attackType === AttackType.SPECIAL
-      ) {
-        this.status.triggerBurn(3000, this, attacker)
-      }
-      if (
         this.items.has(Item.POWER_LENS) &&
         specialDamage >= 1 &&
         attacker &&

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -393,6 +393,10 @@ export default abstract class PokemonState {
         pokemon.physicalDamageReduced += min(0)(damage - reducedDamage)
       } else if (attackType === AttackType.SPECIAL) {
         pokemon.specialDamageReduced += min(0)(damage - reducedDamage)
+
+        if (attacker && attacker.items.has(Item.POKEMONOMICON)) {
+          pokemon.status.triggerBurn(3000, pokemon, attacker)
+        }
       }
 
       if (isNaN(reducedDamage)) {


### PR DESCRIPTION
Move pokemonomicon effect to handleDamage instead of handleSpecialDamage so that it applies burn for other sources of special damage than abilities, like fairy additional special damage