### PR TITLE
Fix Evolution on Mothim

### DIFF
--- a/app/core/evolution-rules.ts
+++ b/app/core/evolution-rules.ts
@@ -43,8 +43,8 @@ export abstract class EvolutionRule {
   }
 
   afterEvolve(pokemonEvolved: Pokemon, player: Player, stageLevel: number) {
-    player.updateSynergies()
     pokemonEvolved.onAcquired(player)
+    player.updateSynergies()
     player.board.forEach((pokemon) => {
       if (
         (pokemon.passive === Passive.COSMOG ||

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -13747,6 +13747,27 @@ export class WormadamPlant extends Pokemon {
     const regionSynergies = DungeonDetails[map]?.synergies
     return regionSynergies.includes(Synergy.GRASS)
   }
+
+  onEvolve({
+    pokemonEvolved: mothim,
+    pokemonsBeforeEvolution: wormadam
+  }: {
+    pokemonEvolved: Pokemon
+    pokemonsBeforeEvolution: Pokemon[]
+  }) {
+    const preEvolve = wormadam.pop() ?? Pokemon
+    switch (preEvolve?.name) {
+      case 'WORMADAM_SANDY':
+        mothim.types.add(Synergy.GROUND)
+        break
+      case 'WORMADAM_TRASH':
+        mothim.types.add(Synergy.ARTIFICIAL)
+        break
+      case 'WORMADAM_PLANT':
+        mothim.types.add(Synergy.GRASS)
+        break
+    }
+  }
 }
 
 export class WormadamSandy extends Pokemon {
@@ -13771,6 +13792,27 @@ export class WormadamSandy extends Pokemon {
       regionSynergies.includes(Synergy.GROUND) &&
       !regionSynergies.includes(Synergy.GRASS)
     )
+  }
+
+  onEvolve({
+    pokemonEvolved: mothim,
+    pokemonsBeforeEvolution: wormadam
+  }: {
+    pokemonEvolved: Pokemon
+    pokemonsBeforeEvolution: Pokemon[]
+  }) {
+    const preEvolve = wormadam.pop() ?? Pokemon
+    switch (preEvolve?.name) {
+      case 'WORMADAM_SANDY':
+        mothim.types.add(Synergy.GROUND)
+        break
+      case 'WORMADAM_TRASH':
+        mothim.types.add(Synergy.ARTIFICIAL)
+        break
+      case 'WORMADAM_PLANT':
+        mothim.types.add(Synergy.GRASS)
+        break
+    }
   }
 }
 
@@ -13798,6 +13840,27 @@ export class WormadamTrash extends Pokemon {
       !regionSynergies.includes(Synergy.GRASS)
     )
   }
+
+  onEvolve({
+    pokemonEvolved: mothim,
+    pokemonsBeforeEvolution: wormadam
+  }: {
+    pokemonEvolved: Pokemon
+    pokemonsBeforeEvolution: Pokemon[]
+  }) {
+    const preEvolve = wormadam.pop() ?? Pokemon
+    switch (preEvolve?.name) {
+      case 'WORMADAM_SANDY':
+        mothim.types.add(Synergy.GROUND)
+        break
+      case 'WORMADAM_TRASH':
+        mothim.types.add(Synergy.ARTIFICIAL)
+        break
+      case 'WORMADAM_PLANT':
+        mothim.types.add(Synergy.GRASS)
+        break
+    }
+  }
 }
 
 export class Mothim extends Pokemon {
@@ -13819,17 +13882,6 @@ export class Mothim extends Pokemon {
     // always hide mothim to avoid showing duplicated with other burmy forms
     // this does not impact the evolution of wormadam
     return false
-  }
-  onAcquired(player: Player) {
-    if (player.regionalPokemons.includes(Pkm.BURMY_PLANT)) {
-      this.types.add(Synergy.GRASS)
-    }
-    if (player.regionalPokemons.includes(Pkm.BURMY_SANDY)) {
-      this.types.add(Synergy.GROUND)
-    }
-    if (player.regionalPokemons.includes(Pkm.BURMY_TRASH)) {
-      this.types.add(Synergy.ARTIFICIAL)
-    }
   }
 }
 

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -13801,15 +13801,15 @@ export class WormadamSandy extends Pokemon {
     pokemonEvolved: Pokemon
     pokemonsBeforeEvolution: Pokemon[]
   }) {
-    const preEvolve = wormadam.pop() ?? Pokemon
-    switch (preEvolve?.name) {
-      case 'WORMADAM_SANDY':
-        mothim.types.add(Synergy.GROUND)
-        break
-      case 'WORMADAM_TRASH':
+    const preEvolve = wormadam.pop()
+    switch (true) {
+      case preEvolve instanceof WormadamTrash:
         mothim.types.add(Synergy.ARTIFICIAL)
         break
-      case 'WORMADAM_PLANT':
+      case preEvolve instanceof WormadamSandy:
+        mothim.types.add(Synergy.GROUND)
+        break
+      case preEvolve instanceof WormadamPlant:
         mothim.types.add(Synergy.GRASS)
         break
     }
@@ -13848,15 +13848,15 @@ export class WormadamTrash extends Pokemon {
     pokemonEvolved: Pokemon
     pokemonsBeforeEvolution: Pokemon[]
   }) {
-    const preEvolve = wormadam.pop() ?? Pokemon
-    switch (preEvolve?.name) {
-      case 'WORMADAM_SANDY':
-        mothim.types.add(Synergy.GROUND)
-        break
-      case 'WORMADAM_TRASH':
+    const preEvolve = wormadam.pop()
+    switch (true) {
+      case preEvolve instanceof WormadamTrash:
         mothim.types.add(Synergy.ARTIFICIAL)
         break
-      case 'WORMADAM_PLANT':
+      case preEvolve instanceof WormadamSandy:
+        mothim.types.add(Synergy.GROUND)
+        break
+      case preEvolve instanceof WormadamPlant:
         mothim.types.add(Synergy.GRASS)
         break
     }

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -13755,15 +13755,15 @@ export class WormadamPlant extends Pokemon {
     pokemonEvolved: Pokemon
     pokemonsBeforeEvolution: Pokemon[]
   }) {
-    const preEvolve = wormadam.pop() ?? Pokemon
-    switch (preEvolve?.name) {
-      case 'WORMADAM_SANDY':
-        mothim.types.add(Synergy.GROUND)
-        break
-      case 'WORMADAM_TRASH':
+    const preEvolve = wormadam.pop()
+    switch (true) {
+      case preEvolve instanceof WormadamTrash:
         mothim.types.add(Synergy.ARTIFICIAL)
         break
-      case 'WORMADAM_PLANT':
+      case preEvolve instanceof WormadamSandy:
+        mothim.types.add(Synergy.GROUND)
+        break
+      case preEvolve instanceof WormadamPlant:
         mothim.types.add(Synergy.GRASS)
         break
     }


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1290341692830121984/1290341692830121984

When evolving Wormadam, we need to check the last pokemon used for the evolution, since it's possible to have every single Wormadam in your team.

So when we have WTrash, WPlant and WGround we check the last used pokemon for the evolution and add the correct Type to Mothim.


Furthermore we also change the order of the evolution rule, so we acquire pokemon first and then calculate the synergies