### PR TITLE
remove fullscreen preference

### DIFF
--- a/app/public/dist/client/changelog/patch-5.6.md
+++ b/app/public/dist/client/changelog/patch-5.6.md
@@ -66,8 +66,7 @@
 
 # UI
 
-- Add a new "Fullscreen" button in the sidebar
-- The game now automatically enters fullscreen when starting a game if supported by the browser. You can disable this in Options > Interface
+- Add a new "Toggle Fullscreen" button in the sidebar
 - Show total money earned, total damage dealt and total reroll count in the player detail tooltip ingame
 - Units in your team planner are highlighted with a dedicated icon in the shop
 

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -2789,7 +2789,6 @@
   "music_volume": "Music Volume",
   "sfx_volume": "SFX Volume",
   "toggle_fullscreen": "Toggle fullscreen",
-  "enter_fullscreen_on_game_start": "Enter fullscreen on game start",
   "show_details_on_hover": "Show details on hover instead of right click",
   "show_damage_numbers": "Show damage numbers",
   "disable_animated_tilemap": "Disable background animations",

--- a/app/public/dist/client/locales/it/translation.json
+++ b/app/public/dist/client/locales/it/translation.json
@@ -2789,7 +2789,6 @@
   "music_volume": "Volume della musica",
   "sfx_volume": "Volume SFX",
   "toggle_fullscreen": "Attiva schermo intero",
-  "enter_fullscreen_on_game_start": "Attiva schermo intero ad inizio partita",
   "show_details_on_hover": "Mostra i dettagli al passaggio del mouse invece che con il clic destro",
   "show_damage_numbers": "Mostra valore dei danni",
   "disable_animated_tilemap": "Disabilita animazioni in background",

--- a/app/public/src/pages/component/options/game-options-modal.tsx
+++ b/app/public/src/pages/component/options/game-options-modal.tsx
@@ -132,16 +132,6 @@ export default function GameOptionsModal(props: {
           <p>
             <Checkbox
               isDark
-              checked={preferences.fullscreen}
-              onToggle={(checked) =>
-                changePreference("fullscreen", checked)
-              }
-              label={t("enter_fullscreen_on_game_start")}
-            />
-          </p>
-          <p>
-            <Checkbox
-              isDark
               checked={preferences.showDetailsOnHover}
               onToggle={(checked) =>
                 changePreference("showDetailsOnHover", checked)

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -75,7 +75,6 @@ import { MainSidebar } from "./component/main-sidebar/main-sidebar"
 import { playMusic, preloadMusic } from "./utils/audio"
 import { LocalStoreKeys, localStore } from "./utils/store"
 import { FIREBASE_CONFIG, getPortraitPath } from "./utils/utils"
-import { enterFullScreen, exitFullScreen } from "./utils/fullscreen"
 
 let gameContainer: GameContainer
 
@@ -267,7 +266,6 @@ export default function Game() {
       await r.leave(false)
     }
     dispatch(leaveGame())
-    exitFullScreen()
     navigate("/after")
     if (room?.connection.isOpen) {
       room.leave()
@@ -310,7 +308,6 @@ export default function Game() {
 
     if (!connected.current) {
       connect()
-      enterFullScreen()
     } else if (
       !initialized.current &&
       room != undefined &&

--- a/app/public/src/pages/utils/fullscreen.ts
+++ b/app/public/src/pages/utils/fullscreen.ts
@@ -1,7 +1,5 @@
-import { loadPreferences } from "../../preferences"
-
 export function enterFullScreen() {
-  if (document.fullscreenEnabled && loadPreferences().fullscreen) {
+  if (document.fullscreenEnabled) {
     try {
       document.documentElement.requestFullscreen()
     } catch (e) {

--- a/app/public/src/preferences.ts
+++ b/app/public/src/preferences.ts
@@ -14,7 +14,6 @@ export interface IPreferencesState {
   showDetailsOnHover: boolean
   showDamageNumbers: boolean
   disableAnimatedTilemap: boolean
-  fullscreen: boolean
   keybindings: Keybindings
   renderer: number
 }
@@ -26,7 +25,6 @@ const defaultPreferences: IPreferencesState = {
   showDetailsOnHover: false,
   showDamageNumbers: true,
   disableAnimatedTilemap: false,
-  fullscreen: true,
   renderer: Phaser.AUTO,
   keybindings: {
     sell: "E",


### PR DESCRIPTION
Had to remove the "auto fullscreen on enter" preference, because it only works when game is started by clicking on a button. Indeed, browser force the fullscreen to be enable through a user gesture, as a security/anti-annoyance measure. So it worked only for the player starting a custom lobby with the start game button, or joining a game with the spectate button. Because it is too deceptive for all the other players, I prefer to remove this preference completely.

The toggle fullscreen is still there though