### PR TITLE
reset preparation state before join

### DIFF
--- a/app/public/src/game/lobby-logic.ts
+++ b/app/public/src/game/lobby-logic.ts
@@ -37,7 +37,7 @@ import {
   setSearchedUser,
   setBoosterContent,
   setSuggestions,
-  leaveLobby
+  resetLobby
 } from "../stores/LobbyStore"
 import {
   logIn,
@@ -47,6 +47,7 @@ import {
   joinLobby,
   setErrorAlertMessage
 } from "../stores/NetworkStore"
+import { resetPreparation } from "../stores/PreparationStore"
 
 export async function joinLobbyRoom(
   dispatch: AppDispatch,
@@ -306,6 +307,7 @@ export async function joinExistingPreparationRoom(
   try {
     const token = await firebase.auth().currentUser?.getIdToken()
     if (token) {
+      dispatch(resetPreparation())
       const room: Room<PreparationState> = await client.joinById(roomId, {
         idToken: token
       })
@@ -321,7 +323,7 @@ export async function joinExistingPreparationRoom(
         lobby?.connection.isOpen && lobby.leave(false),
         room.connection.isOpen && room.leave(false)
       ])
-      dispatch(leaveLobby())
+      dispatch(resetLobby())
       navigate("/preparation")
     }
   } catch (error) {

--- a/app/public/src/pages/component/available-room-menu/game-rooms-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/game-rooms-menu.tsx
@@ -7,7 +7,7 @@ import GameState from "../../../../../rooms/states/game-state"
 import { ICustomLobbyState, IGameMetadata } from "../../../../../types"
 import { throttle } from "../../../../../utils/function"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
-import { leaveLobby } from "../../../stores/LobbyStore"
+import { resetLobby } from "../../../stores/LobbyStore"
 import { localStore, LocalStoreKeys } from "../../utils/store"
 import GameRoomItem from "./game-room-item"
 
@@ -42,7 +42,7 @@ export function GameRoomsMenu() {
         lobby.connection.isOpen && lobby.leave(false),
         game.connection.isOpen && game.leave(false)
       ])
-      dispatch(leaveLobby())
+      dispatch(resetLobby())
       navigate("/game")
     }
   }, 1000)

--- a/app/public/src/pages/lobby.tsx
+++ b/app/public/src/pages/lobby.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useAppDispatch, useAppSelector } from "../hooks"
-import { leaveLobby } from "../stores/LobbyStore"
+import { resetLobby } from "../stores/LobbyStore"
 import { logOut, setErrorAlertMessage } from "../stores/NetworkStore"
 import { Announcements } from "./component/announcements/announcements"
 import AvailableRoomMenu from "./component/available-room-menu/available-room-menu"
@@ -48,7 +48,7 @@ export default function Lobby() {
       await lobby.leave()
     }
     await firebase.auth().signOut()
-    dispatch(leaveLobby())
+    dispatch(resetLobby())
     dispatch(logOut())
     navigate("/")
   }, [dispatch, lobby])

--- a/app/public/src/pages/preparation.tsx
+++ b/app/public/src/pages/preparation.tsx
@@ -21,7 +21,7 @@ import {
 import {
   addUser,
   changeUser,
-  leavePreparation,
+  resetPreparation,
   pushMessage,
   removeMessage,
   removeUser,
@@ -80,7 +80,7 @@ export default function Preparation() {
                 } catch (error) {
                   logger.log(error)
                   localStore.delete(LocalStoreKeys.RECONNECTION_PREPARATION)
-                  dispatch(leavePreparation())
+                  dispatch(resetPreparation())
                   navigate("/lobby")
                   return
                 }
@@ -200,7 +200,7 @@ export default function Preparation() {
             dispatch(setErrorAlertMessage(t(`errors.${errorMessage}`)))
           }
           localStore.delete(LocalStoreKeys.RECONNECTION_PREPARATION)
-          dispatch(leavePreparation())
+          dispatch(resetPreparation())
           navigate("/lobby")
           playSound(SOUNDS.LEAVE_ROOM)
         } else if (shouldReconnect) {
@@ -212,7 +212,7 @@ export default function Preparation() {
             30
           )
           // clearing state variables to re-initialize
-          dispatch(leavePreparation())
+          dispatch(resetPreparation())
           initialized.current = false
           reconnect()
         }
@@ -235,7 +235,7 @@ export default function Preparation() {
             r.connection.isOpen && r.leave(),
             game.connection.isOpen && game.leave(false)
           ])
-          dispatch(leavePreparation())
+          dispatch(resetPreparation())
           navigate("/game")
         }
       })
@@ -260,7 +260,7 @@ export default function Preparation() {
             await room.leave(true)
           }
           localStore.delete(LocalStoreKeys.RECONNECTION_PREPARATION)
-          dispatch(leavePreparation())
+          dispatch(resetPreparation())
           navigate("/lobby")
           playSound(SOUNDS.LEAVE_ROOM)
         }}

--- a/app/public/src/stores/LobbyStore.ts
+++ b/app/public/src/stores/LobbyStore.ts
@@ -144,7 +144,7 @@ export const lobbySlice = createSlice({
     setSuggestions: (state, action: PayloadAction<ISuggestionUser[]>) => {
       state.suggestions = action.payload
     },
-    leaveLobby: () => initialState,
+    resetLobby: () => initialState,
     addTournament: (state, action: PayloadAction<TournamentSchema>) => {
       // remove previous potential duplicate
       state.tournaments = state.tournaments.filter(
@@ -255,7 +255,7 @@ export const {
   removeRoom,
   setCcu,
   setSearchedUser,
-  leaveLobby,
+  resetLobby,
   setSuggestions,
   pushBotLog,
   addTournament,

--- a/app/public/src/stores/PreparationStore.ts
+++ b/app/public/src/stores/PreparationStore.ts
@@ -89,7 +89,7 @@ export const preparationSlice = createSlice({
     setGameMode: (state, action: PayloadAction<GameMode>) => {
       state.gameMode = action.payload
     },
-    leavePreparation: () => initialState,
+    resetPreparation: () => initialState,
     setWhiteList: (state, action: PayloadAction<string[]>) => {
       state.whitelist = action.payload
     },
@@ -115,7 +115,7 @@ export const {
   setWhiteList,
   setBlackList,
   setGameMode,
-  leavePreparation
+  resetPreparation
 } = preparationSlice.actions
 
 export default preparationSlice.reducer


### PR DESCRIPTION
reset preparation store to initial state just before joining an existing preparation room

I hope this helps with the current bug of people not auto-readying when joining a quickplay lobby. I still can't reproduce the bug locally but I think it might be related to outdated 