### PR TITLE
reset player ready when enabling/disabling elo

### DIFF
--- a/app/public/dist/client/changelog/patch-5.6.md
+++ b/app/public/dist/client/changelog/patch-5.6.md
@@ -96,3 +96,4 @@
 - Room name is no longer customizable (too many stupid people)
 - Private lobbies passwords are now automatically generated and no longer customizable
 - Custom lobbies are now private by default
+- Enabling/disabling ELO in a custom lobby now resets all players ready status

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -379,8 +379,12 @@ export class OnToggleEloCommand extends Command<
           authorId: "server",
           payload: `Room leader ${
             noElo ? "disabled" : "enabled"
-          } ELO gain for this game.`,
+          } ELO gain for this game. Players need to ready again.`,
           avatar: leader?.avatar
+        })
+
+        this.state.users.forEach((user) => {
+          user.ready = false
         })
       }
     } catch (error) {


### PR DESCRIPTION
Some room leaders enable ELO and immediately start game without consulting other players. This automatically unready players when this setting is modified.