### PR TITLE
Auto-dispose scribbles & ranked

### DIFF
--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -104,10 +104,7 @@ export default class PreparationRoom extends Room<PreparationState> {
       type: "preparation"
     })
     this.maxClients = 8
-    if (
-      options.gameMode !== GameMode.CUSTOM_LOBBY &&
-      options.gameMode !== GameMode.QUICKPLAY
-    ) {
+    if (options.gameMode === GameMode.TOURNAMENT) {
       this.autoDispose = false
     }
 


### PR DESCRIPTION
prevents scribbles & ranked to stay in lobby at 0 players