### PR TITLE
Improve preparation room leave callbacks

### DIFF
--- a/app/public/src/stores/NetworkStore.ts
+++ b/app/public/src/stores/NetworkStore.ts
@@ -62,13 +62,13 @@ export const networkSlice = createSlice({
     logOut: (state) => {
       state.client = new Client(endpoint)
       state.uid = ""
-      state.preparation?.leave()
+      state.preparation?.connection.isOpen && state.preparation?.leave(true)
       state.preparation = undefined
-      state.lobby?.leave()
+      state.lobby?.connection.isOpen && state.lobby?.leave(true)
       state.lobby = undefined
-      state.game?.leave()
+      state.game?.connection.isOpen && state.game?.leave(true)
       state.game = undefined
-      state.after?.leave()
+      state.after?.connection.isOpen && state.after?.leave(true)
       state.after = undefined
     },
     setProfile: (state, action: PayloadAction<IUserMetadata>) => {
@@ -79,38 +79,38 @@ export const networkSlice = createSlice({
     },
     joinLobby: (state, action: PayloadAction<Room<ICustomLobbyState>>) => {
       state.lobby = action.payload
-      state.preparation?.connection.close()
+      state.preparation?.connection.isOpen && state.preparation?.leave(true)
       state.preparation = undefined
-      state.game?.connection.close()
+      state.game?.connection.isOpen && state.game?.leave(true)
       state.game = undefined
-      state.after?.connection.close()
+      state.after?.connection.isOpen && state.after?.leave(true)
       state.after = undefined
     },
     joinPreparation: (state, action: PayloadAction<Room<PreparationState>>) => {
       state.preparation = action.payload
-      state.lobby?.connection.close()
+      state.lobby?.connection.isOpen && state.lobby?.leave(true)
       state.lobby = undefined
-      state.game?.connection.close()
+      state.game?.connection.isOpen && state.game?.leave(true)
       state.game = undefined
-      state.after?.connection.close()
+      state.after?.connection.isOpen && state.after?.leave(true)
       state.after = undefined
     },
     joinGame: (state, action: PayloadAction<Room<GameState>>) => {
       Object.assign(state, { game: action.payload })
-      state.preparation?.connection.close()
+      state.preparation?.connection.isOpen && state.preparation?.leave(true)
       state.preparation = undefined
-      state.lobby?.connection.close()
+      state.lobby?.connection.isOpen && state.lobby?.leave(true)
       state.lobby = undefined
-      state.after?.connection.close()
+      state.after?.connection.isOpen && state.after?.leave(true)
       state.after = undefined
     },
     joinAfter: (state, action: PayloadAction<Room<AfterGameState>>) => {
       state.after = action.payload
-      state.game?.connection.close()
+      state.game?.connection.isOpen && state.game?.leave(true)
       state.game = undefined
-      state.lobby?.connection.close()
+      state.lobby?.connection.isOpen && state.lobby?.leave(true)
       state.lobby = undefined
-      state.preparation?.connection.close()
+      state.preparation?.connection.isOpen && state.preparation?.leave(true)
       state.preparation = undefined
     },
     sendMessage: (state, action: PayloadAction<string>) => {

--- a/app/public/src/stores/NetworkStore.ts
+++ b/app/public/src/stores/NetworkStore.ts
@@ -81,7 +81,7 @@ export const networkSlice = createSlice({
       state.lobby = action.payload
       state.preparation?.connection.isOpen && state.preparation?.leave(true)
       state.preparation = undefined
-      state.game?.connection.isOpen && state.game?.leave(true)
+      state.game?.connection.close() // still allow to reconnect if left by mistake
       state.game = undefined
       state.after?.connection.isOpen && state.after?.leave(true)
       state.after = undefined
@@ -90,7 +90,7 @@ export const networkSlice = createSlice({
       state.preparation = action.payload
       state.lobby?.connection.isOpen && state.lobby?.leave(true)
       state.lobby = undefined
-      state.game?.connection.isOpen && state.game?.leave(true)
+      state.game?.connection.close() // still allow to reconnect if left by mistake
       state.game = undefined
       state.after?.connection.isOpen && state.after?.leave(true)
       state.after = undefined
@@ -106,7 +106,7 @@ export const networkSlice = createSlice({
     },
     joinAfter: (state, action: PayloadAction<Room<AfterGameState>>) => {
       state.after = action.payload
-      state.game?.connection.isOpen && state.game?.leave(true)
+      state.game?.connection.close() // still allow to reconnect if left by mistake
       state.game = undefined
       state.lobby?.connection.isOpen && state.lobby?.leave(true)
       state.lobby = undefined


### PR DESCRIPTION
Several changes aiming to close properly the connections to the rooms, especially the preparation room:
- in Network store, replace room.connection.close() with room.leave(true) ; this enables calling the onLeave callbacks which removes the reconnection tokens properly ; this also remove immediately the client without waiting the allowed reconnection delay. 
- navigate to lobby if loading the preparation room without a valid reconnection token for a preparation room
- remove preparation room reconnection token if room is left with another close code than anormal closure / timeout
- use useCallback to memo large functions in preparation room to increase performance

I hope these would help to avoid the "lobby mislaunch" bug and the "lost elo for a game i not played" reports. I believe most of these reports is from people leaving the preparation screen without using the leave button (probably browser back button), and therefore still having the allowed reconnection time active, and the game being launched at that moment. Now they are immediately removed if they leave preparation room.