### PR TITLE
fix stone edge ability

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -619,19 +619,6 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
       }
     }
 
-    if (this.status.stoneEdge) {
-      const tg = board.getValue(target.positionX, target.positionY)
-      if (tg) {
-        tg.handleDamage({
-          damage: Math.round(this.def * (1 + this.ap / 100)),
-          board,
-          attackType: AttackType.SPECIAL,
-          attacker: this,
-          shouldTargetGainMana: true
-        })
-      }
-    }
-
     if (this.passive === Passive.DURANT) {
       const bugAllies =
         board.cells.filter(

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -62,6 +62,10 @@ export default abstract class PokemonState {
         damage = Math.ceil(damage * (1 + pokemon.ap / 100))
       }
 
+      if (pokemon.status.stoneEdge) {
+        damage += Math.round(pokemon.def * (1 + pokemon.ap / 100))
+      }
+
       let trueDamagePart = 0
       if (pokemon.effects.has(Effect.STEEL_SURGE)) {
         trueDamagePart += 0.33

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -14941,7 +14941,7 @@ export class Binacle extends Pokemon {
   range = 1
   skill = Ability.STONE_EDGE
   additional = true
-  attackSprite = AttackSprite.ROCK_MELEE
+  attackSprite = AttackSprite.ROCK_RANGE
 }
 
 export class Barbaracle extends Pokemon {
@@ -14956,7 +14956,7 @@ export class Barbaracle extends Pokemon {
   range = 1
   skill = Ability.STONE_EDGE
   additional = true
-  attackSprite = AttackSprite.ROCK_MELEE
+  attackSprite = AttackSprite.ROCK_RANGE
 }
 
 export class Skarmory extends Pokemon {

--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -9,7 +9,7 @@ import { Item } from "../../types/enum/Item"
 import { Passive } from "../../types/enum/Passive"
 import { Weather } from "../../types/enum/Weather"
 import { count } from "../../utils/array"
-import { max } from "../../utils/number"
+import { max, min } from "../../utils/number"
 import { chance } from "../../utils/random"
 
 export default class Status extends Schema implements IStatus {
@@ -350,7 +350,7 @@ export default class Status extends Schema implements IStatus {
       this.stoneEdge = true
       this.stoneEdgeCooldown = timer
       pkm.addCritChance(20, pkm, 1, false)
-      pkm.range = 3
+      pkm.range += 2
     }
   }
 
@@ -358,7 +358,7 @@ export default class Status extends Schema implements IStatus {
     if (this.stoneEdgeCooldown - dt <= 0) {
       this.stoneEdge = false
       pkm.addCritChance(-20, pkm, 1, false)
-      pkm.range = pkm.baseRange
+      pkm.range = min(pkm.baseRange)(pkm.range - 2)
     } else {
       this.stoneEdgeCooldown -= dt
     }

--- a/app/public/dist/client/changelog/patch-5.7.md
+++ b/app/public/dist/client/changelog/patch-5.7.md
@@ -30,6 +30,7 @@
 - Locked status now correctly triggers retargetting, and reapply wide lens effect after restoring range
 - Fixed a bug where the player was not able to refresh the shop if they have free shop rerolls but zero gold
 - Items giving a synergy are now also taken into account for weather election
+- Fix many bugs related to Stone Edge ability
 
 # Misc
 

--- a/app/public/dist/client/locales/de/translation.json
+++ b/app/public/dist/client/locales/de/translation.json
@@ -1612,7 +1612,7 @@
     "GLAIVE_RUSH": "Der Angreifer stürmt mit seinem gesamten Körper rücksichtslos los. Springt hinter das Ziel und fügt ihm 6 Sekunden lang [40,80,150,SP] PHYSICAL und ARMOR_REDUCTION zu.",
     "FOUL_PLAY": "Fügt [2,4,6,SP,ND=1] x ATK des Ziels als SPEZIAL zu",
     "DOUBLE_IRON_BASH": "Der Benutzer dreht sich, zentriert die Sechskantmutter in seiner Brust und schlägt dann zweimal hintereinander mit den Armen zu, wobei er [150,SP] % seines ATK einsetzt. Dadurch FLINCH das Ziel 3 Sekunden lang zusammen.",
-    "STONE_EDGE": "Für [5,8] Sekunden SILENCE selbst, erhält 2 RANGE, [10,20,SP] CRIT_CHANCE und wendet 100% seiner DEF als PHYSICAL auf Angriffe an",
+    "STONE_EDGE": "Für [5,8] Sekunden SILENCE selbst, erhält 2 RANGE, [20,SP] CRIT_CHANCE und wendet [100,SP]% seiner DEF als PHYSICAL auf Angriffe an",
     "ROAR": "Puste das Ziel weg. Wenn es gegen eine Wand prallt, erleidet es [10,20,40,SP] SPEZIAL. Wenn es ein anderes Pokémon trifft, erleiden beide Pokémon SPEZIAL.",
     "INFESTATION": "Fügt dem Ziel [10,SP] SPECIAL für jeden verbündeten BUG an Bord zu und platziert deinen stärksten BUG im Kampf auf deiner Bank",
     "IVY_CUDGEL": "Fügt dem Ziel [100,SP] SPECIAL zu",

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -1616,7 +1616,7 @@
     "GLAIVE_RUSH": "The caster throws its entire body into a reckless charge. Dash behind the target, dealing it [40,80,150,SP] PHYSICAL and ARMOR_REDUCTION itself for 6 seconds",
     "FOUL_PLAY": "Deals [2,4,6,SP,ND=1] x target's ATK as SPECIAL",
     "DOUBLE_IRON_BASH": "The user rotates, centering the hex nut in its chest, and then strikes with its arms twice in a row with [150,SP] % of its ATK. This make the target FLINCH for 3 seconds.",
-    "STONE_EDGE": "For [5,8] seconds, the caster SILENCE itself, gains 2 RANGE, [10,20,SP] CRIT_CHANCE and apply 100% of its DEF as PHYSICAL on attacks",
+    "STONE_EDGE": "For [5,8] seconds, the caster SILENCE itself, gains 2 RANGE, [20,SP] CRIT_CHANCE and apply [100,SP]% of its DEF as PHYSICAL on attacks",
     "ROAR": "Blow away the target. If it hits a wall, it suffers [10,20,40,SP] SPECIAL. If it hits another pokémon, both pokémons suffer SPECIAL.",
     "INFESTATION": "Deals [10,SP] SPECIAL to the target for each allied BUG on board and places your most powerful BUG on your bench in the fight",
     "IVY_CUDGEL": "Deals [100,SP] SPECIAL to the target",

--- a/app/public/dist/client/locales/fr/translation.json
+++ b/app/public/dist/client/locales/fr/translation.json
@@ -1612,7 +1612,7 @@
     "GLAIVE_RUSH": "Le lanceur jette tout son corps dans une charge imprudente. Fonce derrière la cible, lui infligeant [40,80,150,SP] PHYSICAL et ARMOR_REDUCTION pendant 6 secondes",
     "FOUL_PLAY": "Inflige [2,4,6,SP,ND=1] x l'ATK de la cible en SPECIAL",
     "DOUBLE_IRON_BASH": "Le lanceur pivote, centre l'écrou hexagonal sur sa poitrine, puis frappe avec ses bras deux fois de suite avec [150,SP] % de son ATK. Cela inflige FLINCH à la cible pendant 3 secondes.",
-    "STONE_EDGE": "Pendant [5,8] secondes, le lanceur s'auto-inflige SILENCE, gagne 2 RANGE, [10,20,SP] CRIT_CHANCE et inflige 100% de sa DEF en PHYSICAL avec ses attaques.",
+    "STONE_EDGE": "Pendant [5,8] secondes, le lanceur s'auto-inflige SILENCE, gagne 2 RANGE, [20,SP] CRIT_CHANCE et inflige [100,SP]% de sa DEF en PHYSICAL avec ses attaques.",
     "ROAR": "Souffle sur la cible, ce qui la projette en arrière. Si elle heurte un mur, elle subit [10,20,40,SP] SPECIAL. Si elle heurte un autre Pokémon, les deux Pokémon subissent les dégâts.",
     "INFESTATION": "Inflige [10,SP] SPECIAL à la cible pour chaque allié BUG sur le plateau, et amène au combat votre Pokémon BUG le plus puissant sur votre banc",
     "IVY_CUDGEL": "Inflige [100,SP] SPECIAL à la cible",

--- a/app/public/dist/client/locales/it/translation.json
+++ b/app/public/dist/client/locales/it/translation.json
@@ -1612,7 +1612,7 @@
     "GLAIVE_RUSH": "L'utilizzatore si butta di corpo in una carica molto rischiosa. Scatta verso il bersaglio, infliggendo [40,80,150,SP] PHYSICAL e causa a se stesso ARMOR_REDUCTION per 6 secondi.",
     "FOUL_PLAY": "Infliggi [2,4,6,SP] SPECIAL moltiplicati per l' ATK del bersaglio",
     "DOUBLE_IRON_BASH": "L'utilizzatore rotea su sè stesso, poi colpisce con le sue braccia due volte infliggendo il [150,SP] % del suo ATK entrambe le volte. Causa al bersaglio FLINCH per 3 secondi.",
-    "STONE_EDGE": "Per [5,8] secondi, l'utilizzatore si autoinfligge SILENCE, ottiene 2 di RANGE, [10,20,SP] di CRIT_CHANCE e applica il 100% della sua DEF come PHYSICAL agli attacchi.",
+    "STONE_EDGE": "Per [5,8] secondi, l'utilizzatore si autoinfligge SILENCE, ottiene 2 di RANGE, [20,SP] di CRIT_CHANCE e applica il [100,SP]% della sua DEF come PHYSICAL agli attacchi.",
     "ROAR": "Spazza via il bersaglio. Se il bersaglio colpisce un muro, gli vengono inflitti [10,20,40,SP] SPECIAL. Se colpisce un altro Pokèmon, entrambi subiscono SPECIAL.",
     "INFESTATION": "Infliggi [10,SP] SPECIAL al bersaglio per ogni Pokèmon BUG alleato e piazza il BUG più forte nella panchina durante il combattimento.",
     "IVY_CUDGEL": "Infliggi [100,SP] SPECIAL al bersaglio.",

--- a/app/public/dist/client/locales/ko/translation.json
+++ b/app/public/dist/client/locales/ko/translation.json
@@ -1612,7 +1612,7 @@
     "GLAIVE_RUSH": "시전자가 무모하게 돌진한다. 대상의 후방으로 이동하여 [40,80,150,SP]의 PHYSICAL 를 입히고 6초 동안 자신에게 ARMOR_REDUCTION을 부여한다.",
     "FOUL_PLAY": "대상 ATK 의 [2,4,6,SP] 배만큼 SPECIAL 를 가한다.",
     "DOUBLE_IRON_BASH": "시전자가 회전하여 ATK 의 [150,SP]% 를 두 번 가격한다. 대상은 3초 동안 FLINCH 이 된다.",
-    "STONE_EDGE": "[5,8] 초 동안 시전자가 SILENCE 상태가 되고, 2 RANGE 와 [10,20,SP] CRIT_CHANCE 를 획득하고 기본공격 시 DEF 의 100%를 PHYSICAL 로 입힌다.",
+    "STONE_EDGE": "[5,8] 초 동안 시전자가 SILENCE 상태가 되고, 2 RANGE 와 [20,SP] CRIT_CHANCE 를 획득하고 기본공격 시 DEF 의 [100,SP]%를 PHYSICAL 로 입힌다.",
     "ROAR": "대상을 날려버린다. 벽에 부딪히면 [10,20,40,SP] SPECIAL 을 입는다. 다른 포켓몬에게 부딪히면 둘 다 SPECIAL 을 입는다.",
     "INFESTATION": "필드에 있는 아군 BUG 수만큼 [10,SP] SPECIAL 을 대상에게 가하고, 대기석의 가장 강한 BUG 를 전투에 참여시킨다.",
     "IVY_CUDGEL": "대상에게 [100,SP]의 SPECIAL 를 입힌다.",


### PR DESCRIPTION
Stone edge had many issues:
- Stone edge additional damage was handled separately, triggering 2 attacks instead of one (double block with fighting)
- Stone edge additional damage was dealing special damage (supposed to be physical)
- Stone edge was forcing range to 3 and resetting to 1, not taking into account wide lens
- Stone edge description was not showing that additional damage scale with AP
- Stone edge is increasing crit chance to 20% at all tiers (10/20 in description)
- Change Barbaracle line attack sprite to use Rock_range instead of Rock_melee