### PR TITLE
Fix duplicate hatch

### DIFF
--- a/app/core/evolution-rules.ts
+++ b/app/core/evolution-rules.ts
@@ -276,6 +276,7 @@ export class HatchEvolutionRule extends EvolutionRule {
   }
 
   evolve(pokemon: Pokemon, player: Player, stageLevel: number): Pokemon {
+    this.evolutionTimer = EvolutionTime.EVOLVE_HATCH // prevent trying to evolve twice in a row
     const pokemonEvolutionName = this.getEvolution(pokemon, player, stageLevel)
     const pokemonEvolved = player.transformPokemon(
       pokemon,


### PR DESCRIPTION
fix https://discord.com/channels/737230355039387749/1301866274426716171

explaination:
https://github.com/sylvainpolletvillard/pokemonAutoChess/blob/f2cc11cab18d99034c4c7168b3f5dace07549ca0/app/core/evolution-rules.ts#L68

this change could proc hatch evolution twice in a row (condition unclear), so by reassigning immediately the evolutionTimer before evolving, we prevent that from happening