### PR TITLE
euclidian distance for Comfey election

### DIFF
--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -551,7 +551,6 @@ export default class Simulation extends Schema implements ISimulation {
 
       team.forEach((pokemon) => {
         if (pokemon.items.has(Item.ROTOM_PHONE) && !pokemon.isOnBench) {
-          const player = team === blueTeam ? this.bluePlayer : this.redPlayer
           const rotomDrone = PokemonFactory.createPokemonFromName(
             Pkm.ROTOM_DRONE,
             player
@@ -670,11 +669,10 @@ export default class Simulation extends Schema implements ISimulation {
     // WEATHER EFFECTS
     if (this.weather !== Weather.NEUTRAL) {
       for (const team of [this.blueTeam, this.redTeam]) {
+        const player = team === this.blueTeam ? this.bluePlayer : this.redPlayer
+        const opponentPlayer =
+          team === this.blueTeam ? this.redPlayer : this.bluePlayer
         team.forEach((pokemon) => {
-          const player =
-            team === this.blueTeam ? this.bluePlayer : this.redPlayer
-          const opponentPlayer =
-            team === this.blueTeam ? this.redPlayer : this.bluePlayer
           this.applyWeatherEffects(pokemon, player, opponentPlayer)
         })
       }

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -7,10 +7,8 @@ import {
   HatchEvolutionRule,
   ItemEvolutionRule
 } from "../../core/evolution-rules"
-import { PokemonEntity } from "../../core/pokemon-entity"
 import Simulation from "../../core/simulation"
 import { DelayedCommand } from "../../core/simulation-command"
-import { OnUpdatePhaseCommand } from "../../rooms/commands/game-commands"
 import GameState from "../../rooms/states/game-state"
 import {
   AttackSprite,
@@ -59,7 +57,7 @@ import { Synergy, SynergyEffects } from "../../types/enum/Synergy"
 import { Weather } from "../../types/enum/Weather"
 import { removeInArray, sum } from "../../utils/array"
 import { getFirstAvailablePositionInBench } from "../../utils/board"
-import { distanceC, distanceM } from "../../utils/distance"
+import { distanceC, distanceE } from "../../utils/distance"
 import { chance, pickRandomIn } from "../../utils/random"
 import { values } from "../../utils/schemas"
 import PokemonFactory from "../pokemon-factory"
@@ -12451,13 +12449,13 @@ export class Comfey extends Pokemon {
     if (alliesWithFreeSlots.length > 0) {
       alliesWithFreeSlots.sort(
         (a, b) =>
-          distanceM(
+          distanceE(
             a.positionX,
             a.positionY,
             entity.positionX,
             entity.positionY
           ) -
-          distanceM(
+          distanceE(
             b.positionX,
             b.positionY,
             entity.positionX,


### PR DESCRIPTION
Use euclidian distance to choose on which ally Comfey go

doesn't fix the bug reported about it not attaching, but should make it more intuitive for diagonal vs direct adjacent