### PR TITLE
Fix primeape to require 31 ATK/10 KOs

### DIFF
--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -6653,7 +6653,7 @@ export class Primeape extends Pokemon {
   stars = 2
   evolution = Pkm.ANNIHILAPE
   evolutionRule = new ConditionBasedEvolutionRule(
-    (pokemon) => pokemon.atk >= 30
+    (pokemon) => pokemon.atk > 30
   )
   hp = 240
   atk = 21


### PR DESCRIPTION
With a base ATK of 21, only 9KOs are actually required before this change.