### PR TITLE
Refactor attack timings and fix Stonjourner tree status and anim

### DIFF
--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -9,7 +9,10 @@ import Board from "./board"
 import { PokemonEntity } from "./pokemon-entity"
 import PokemonState from "./pokemon-state"
 import { AttackCommand } from "./simulation-command"
-import { getAttackTimings } from "../public/src/game/animation-manager"
+import delays from "../types/delays.json"
+import { IPokemonEntity } from "../types"
+import { PROJECTILE_SPEED } from "../types/Config"
+import { max } from "../utils/number"
 
 export default class AttackingState extends PokemonState {
   name = "attacking"
@@ -123,4 +126,24 @@ export default class AttackingState extends PokemonState {
     pokemon.targetX = -1
     pokemon.targetY = -1
   }
+}
+
+export function getAttackTimings(pokemon: IPokemonEntity): {
+  delayBeforeShoot: number
+  travelTime: number
+  attackDuration: number
+} {
+  const attackDuration = 1000 / pokemon.atkSpeed
+  const d = delays[pokemon.index]?.d || 18 // number of frames before hit
+  const t = delays[pokemon.index]?.t || 36 // total number of frames in the animation
+
+  const delayBeforeShoot = max(attackDuration / 2)((attackDuration * d) / t)
+  const distance = distanceC(
+    pokemon.targetX,
+    pokemon.targetY,
+    pokemon.positionX,
+    pokemon.positionY
+  )
+  const travelTime = (distance * 1000) / PROJECTILE_SPEED
+  return { delayBeforeShoot, travelTime, attackDuration }
 }

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -483,7 +483,10 @@ export default class Simulation extends Schema implements ISimulation {
     }
   }
 
-  applyPostEffects(blueTeam: MapSchema<Pokemon>, redTeam: MapSchema<Pokemon>) {
+  applyPostEffects(
+    blueBoard: MapSchema<Pokemon>,
+    redBoard: MapSchema<Pokemon>
+  ) {
     /*
     in order:
     - spawns (bug, rotom, white flute, etc)
@@ -494,10 +497,10 @@ export default class Simulation extends Schema implements ISimulation {
     */
 
     // SPAWNS (bug, rotom, white flute, etc)
-    for (const team of [blueTeam, redTeam]) {
-      const teamIndex = team === blueTeam ? Team.BLUE_TEAM : Team.RED_TEAM
-      const player = team === blueTeam ? this.bluePlayer : this.redPlayer
-      const effects = team === blueTeam ? this.blueEffects : this.redEffects
+    for (const board of [blueBoard, redBoard]) {
+      const teamIndex = board === blueBoard ? Team.BLUE_TEAM : Team.RED_TEAM
+      const player = board === blueBoard ? this.bluePlayer : this.redPlayer
+      const effects = board === blueBoard ? this.blueEffects : this.redEffects
 
       if (
         [
@@ -508,7 +511,7 @@ export default class Simulation extends Schema implements ISimulation {
         ].some((e) => effects.has(e))
       ) {
         const bugTeam = new Array<IPokemon>()
-        team.forEach((pkm) => {
+        board.forEach((pkm) => {
           if (pkm.types.has(Synergy.BUG) && pkm.positionY != 0) {
             bugTeam.push(pkm)
           }
@@ -553,9 +556,9 @@ export default class Simulation extends Schema implements ISimulation {
         }
       }
 
-      team.forEach((pokemon) => {
+      board.forEach((pokemon) => {
         if (pokemon.items.has(Item.ROTOM_PHONE) && !pokemon.isOnBench) {
-          const player = team === blueTeam ? this.bluePlayer : this.redPlayer
+          const player = board === blueBoard ? this.bluePlayer : this.redPlayer
           const rotomDrone = PokemonFactory.createPokemonFromName(
             Pkm.ROTOM_DRONE,
             player

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -14232,6 +14232,10 @@ export class Stonjourner extends Pokemon {
   skill = Ability.GRAVITY
   passive = Passive.STONJOURNER
   attackSprite = AttackSprite.ROCK_MELEE
+  onSpawn({ entity }: { entity: IPokemonEntity }) {
+    entity.status.tree = true
+    entity.toIdleState()
+  }
   afterSimulationStart({
     entity,
     simulation
@@ -14243,8 +14247,6 @@ export class Stonjourner extends Pokemon {
           cell.value.addAbilityPower(50, cell.value, 0, false)
         }
       })
-    entity.status.tree = true
-    entity.toIdleState()
   }
 }
 

--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -45,6 +45,7 @@ export default class Status extends Schema implements IStatus {
   @type("boolean") curseFate = false
   @type("boolean") enraged = false
   @type("boolean") skydiving = false
+  @type("boolean") tree = false
   magmaStorm = false
   soulDew = false
   clearWing = false
@@ -79,7 +80,6 @@ export default class Status extends Schema implements IStatus {
   synchroCooldown = 3000
   magmaStormCooldown = 0
   synchro = false
-  tree = false
   resurectingCooldown = 0
   doubleDamage = false
   drySkin = false

--- a/app/public/src/game/animation-manager.ts
+++ b/app/public/src/game/animation-manager.ts
@@ -1,7 +1,4 @@
-import { IPokemonEntity } from "../../../types"
 import { AnimationComplete, AnimationType } from "../../../types/Animation"
-import { PROJECTILE_SPEED } from "../../../types/Config"
-import delays from "../../../types/delays.json"
 import {
   Orientation,
   OrientationFlip,
@@ -11,10 +8,10 @@ import {
 } from "../../../types/enum/Game"
 import { Berries } from "../../../types/enum/Item"
 import { AnimationConfig, Pkm, PkmIndex } from "../../../types/enum/Pokemon"
-import { distanceC } from "../../../utils/distance"
 import { logger } from "../../../utils/logger"
-import { fpsToDuration, max } from "../../../utils/number"
+import { fpsToDuration } from "../../../utils/number"
 import atlas from "../assets/atlas.json"
+import delays from "../../../types/delays.json"
 import durations from "../assets/pokemons/durations.json"
 import indexList from "../assets/pokemons/indexList.json"
 import PokemonSprite from "./components/pokemon"
@@ -332,26 +329,6 @@ export default class AnimationManager {
       entity.animationLocked = true
     }
   }
-}
-
-export function getAttackTimings(pokemon: IPokemonEntity): {
-  delayBeforeShoot: number
-  travelTime: number
-  attackDuration: number
-} {
-  const attackDuration = 1000 / pokemon.atkSpeed
-  const d = delays[pokemon.index]?.d || 18 // number of frames before hit
-  const t = delays[pokemon.index]?.t || 36 // total number of frames in the animation
-
-  const delayBeforeShoot = max(attackDuration / 2)((attackDuration * d) / t)
-  const distance = distanceC(
-    pokemon.targetX,
-    pokemon.targetY,
-    pokemon.positionX,
-    pokemon.positionY
-  )
-  const travelTime = (distance * 1000) / PROJECTILE_SPEED
-  return { delayBeforeShoot, travelTime, attackDuration }
 }
 
 export function getAttackAnimTimeScale(pokemonIndex: string, atkSpeed: number) {

--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -1,5 +1,6 @@
 import { type NonFunctionPropNames } from "@colyseus/schema/lib/types/HelperTypes"
 import { GameObjects } from "phaser"
+import { getAttackTimings } from "../../../../core/attacking-state"
 import { getMoveSpeed } from "../../../../core/pokemon-entity"
 import Simulation from "../../../../core/simulation"
 import Count from "../../../../models/colyseus-models/count"
@@ -22,7 +23,7 @@ import { Passive } from "../../../../types/enum/Passive"
 import { AnimationConfig, Pkm } from "../../../../types/enum/Pokemon"
 import { max } from "../../../../utils/number"
 import { transformAttackCoordinate } from "../../pages/utils/utils"
-import AnimationManager, { getAttackTimings } from "../animation-manager"
+import AnimationManager from "../animation-manager"
 import GameScene from "../scenes/game-scene"
 import { displayAbility } from "./abilities-animations"
 import PokemonSprite from "./pokemon"
@@ -90,7 +91,7 @@ export default class BattleManager {
       )
       this.animationManager.animatePokemon(
         pokemonUI,
-        PokemonActionState.WALK,
+        pokemon.status.tree ? PokemonActionState.IDLE : PokemonActionState.WALK,
         this.flip
       )
       this.group.add(pokemonUI)

--- a/app/public/src/game/game-container.ts
+++ b/app/public/src/game/game-container.ts
@@ -130,7 +130,8 @@ class GameContainer {
       "wound",
       "enraged",
       "locked",
-      "magicBounce"
+      "magicBounce",
+      "tree"
     ]
 
     fields.forEach((field) => {

--- a/app/utils/board.ts
+++ b/app/utils/board.ts
@@ -1,8 +1,13 @@
 import { MapSchema } from "@colyseus/schema"
-import Player from "../models/colyseus-models/player"
+import { PokemonEntity } from "../core/pokemon-entity"
 import { Pokemon } from "../models/colyseus-models/pokemon"
+import PokemonSprite from "../public/src/game/components/pokemon"
 import { SpecialGameRule } from "../types/enum/SpecialGameRule"
 import { values } from "./schemas"
+
+export function isOnBench(pokemon: Pokemon | PokemonEntity | PokemonSprite) {
+  return pokemon.positionY === 0
+}
 
 export function isPositionEmpty(
   x: number,


### PR DESCRIPTION
Move `getAttackTimings` to the core module to streamline imports and enhance performance at startup and hot reload. 

Fix the animation state incorrectly set to Walk for pokemons with tree status like Stonjourner

Small refactor with renaming, more comments and constants to Simulation constructor