### PR TITLE
Fix smooth rock passive behavior in sandstorm conditions

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -716,10 +716,7 @@ export default abstract class PokemonState {
       }
     }
 
-    if (
-      pokemon.simulation.weather === Weather.SANDSTORM &&
-      pokemon.types.has(Synergy.GROUND) === false
-    ) {
+    if (pokemon.simulation.weather === Weather.SANDSTORM) {
       pokemon.sandstormDamageTimer -= dt
       if (pokemon.sandstormDamageTimer <= 0 && !pokemon.simulation.finished) {
         pokemon.sandstormDamageTimer = 1000
@@ -729,13 +726,15 @@ export default abstract class PokemonState {
           sandstormDamage -= nbSmoothRocks
           pokemon.addAttackSpeed(nbSmoothRocks, pokemon, 0, false)
         }
-        pokemon.handleDamage({
-          damage: sandstormDamage,
-          board,
-          attackType: AttackType.SPECIAL,
-          attacker: null,
-          shouldTargetGainMana: false
-        })
+        if (pokemon.types.has(Synergy.GROUND) === false) {
+          pokemon.handleDamage({
+            damage: sandstormDamage,
+            board,
+            attackType: AttackType.SPECIAL,
+            attacker: null,
+            shouldTargetGainMana: false
+          })
+        }
       }
     }
 


### PR DESCRIPTION
Adjust the handling of damage during sandstorm effects to ensure smooth rocks passive work correctly for ground pokemons

fix https://discord.com/channels/737230355039387749/1302669664274350161