### PR TITLE
Fix order of simulation constructor call

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1465,17 +1465,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
         const { bluePlayer, redPlayer } = matchup
         const weather = getWeather(bluePlayer, redPlayer, redPlayer.board)
         const simulationId = nanoid()
-        const simulation = new Simulation(
-          simulationId,
-          this.room,
-          bluePlayer.board,
-          redPlayer.board,
-          bluePlayer,
-          redPlayer,
-          this.state.stageLevel,
-          weather,
-          matchup.ghost
-        )
+
         bluePlayer.simulationId = simulationId
         bluePlayer.team = Team.BLUE_TEAM
         bluePlayer.opponents.set(
@@ -1501,6 +1491,18 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
           redPlayer.opponentAvatar = bluePlayer.avatar
           redPlayer.opponentTitle = bluePlayer.title ?? ""
         }
+
+        const simulation = new Simulation(
+          simulationId,
+          this.room,
+          bluePlayer.board,
+          redPlayer.board,
+          bluePlayer,
+          redPlayer,
+          this.state.stageLevel,
+          weather,
+          matchup.ghost
+        )
 
         this.state.simulations.set(simulation.id, simulation)
       })


### PR DESCRIPTION
Rearrange the simulation constructor call to ensure proper initialization of players objects before calling the simulation logic

For example player.team was not always correctly initialized when calling afterSimulationStart hooks.

I think this is what caused the comfey bug https://discord.com/channels/737230355039387749/1301940314948505690