### PR TITLE
Fix AP scaling on some abilities

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -10394,13 +10394,13 @@ export class TrickOrTreatStrategy extends AbilityStrategy {
       target.hp = Math.floor(target.hp * lifeReduction)
       target.status.triggerFlinch(3000, target, pokemon)
     } else if (pokemon.ap <= 100) {
-      // 51-100 AP: transforms the unit in magikarp during X seconds, replacing its ability with splash
+      // 51-100 AP: transforms the unit into magikarp for X seconds, replacing its ability with splash
       const originalAbility = target.skill
       const originalAttack = target.atk
       const originalDefense = target.def
       const originalSpecialDefense = target.speDef
       const originalIndex = target.index
-      const duration = Math.round(3000 * (1 - pokemon.ap / 100))
+      const duration = Math.round(3000 * (1 + pokemon.ap / 100))
       target.index = PkmIndex[Pkm.MAGIKARP]
       target.skill = Ability.SPLASH
       target.atk = 1

--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -761,7 +761,8 @@ export class DiamondStormStrategy extends AbilityStrategy {
           board,
           AttackType.SPECIAL,
           pokemon,
-          crit
+          crit,
+          false
         )
       }
     })
@@ -6850,7 +6851,7 @@ export class NightShadeStrategy extends AbilityStrategy {
         target.hp *
         (1 + (0.5 * pokemon.ap) / 100)
     )
-    target.handleSpecialDamage(damage, board, AttackType.TRUE, pokemon, crit)
+    target.handleSpecialDamage(damage, board, AttackType.TRUE, pokemon, crit, false)
   }
 }
 
@@ -10388,7 +10389,7 @@ export class TrickOrTreatStrategy extends AbilityStrategy {
       }
     } else if (pokemon.ap <= 50) {
       // 0-50 AP: shrink unit size and HP
-      const lifeReduction = 0.4 * (1 + pokemon.ap / 100)
+      const lifeReduction = 0.4 * (1 - pokemon.ap / 100)
       target.life = Math.floor(target.life * lifeReduction)
       target.hp = Math.floor(target.hp * lifeReduction)
       target.status.triggerFlinch(3000, target, pokemon)
@@ -10399,7 +10400,7 @@ export class TrickOrTreatStrategy extends AbilityStrategy {
       const originalDefense = target.def
       const originalSpecialDefense = target.speDef
       const originalIndex = target.index
-      const duration = Math.round(3000 * (1 + pokemon.ap / 100))
+      const duration = Math.round(3000 * (1 - pokemon.ap / 100))
       target.index = PkmIndex[Pkm.MAGIKARP]
       target.skill = Ability.SPLASH
       target.atk = 1

--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -752,7 +752,7 @@ export class DiamondStormStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, state, board, target, crit)
-    const damage = Math.round(2 * pokemon.def * (1 + pokemon.ap / 100))
+    const damage = 2 * pokemon.def
     const cells = board.getAdjacentCells(pokemon.positionX, pokemon.positionY)
     cells.forEach((cell) => {
       if (cell.value && cell.value.team !== pokemon.team) {
@@ -761,8 +761,7 @@ export class DiamondStormStrategy extends AbilityStrategy {
           board,
           AttackType.SPECIAL,
           pokemon,
-          crit,
-          false
+          crit
         )
       }
     })

--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -10389,7 +10389,7 @@ export class TrickOrTreatStrategy extends AbilityStrategy {
       }
     } else if (pokemon.ap <= 50) {
       // 0-50 AP: shrink unit size and HP
-      const lifeReduction = 0.4 * (1 - pokemon.ap / 100)
+      const lifeReduction = 0.4 / (1 + pokemon.ap / 100)
       target.life = Math.floor(target.life * lifeReduction)
       target.hp = Math.floor(target.hp * lifeReduction)
       target.status.triggerFlinch(3000, target, pokemon)


### PR DESCRIPTION
Diamond Storm and Night Shade both apply AP before-hand.

Their respective AP scaling as of now is `AP^2 + 2AP + 1` and `AP^2/2 + 1.5AP + 1`. At 100AP this means 4x and 3x respectively.

Trick Or Treat incorrectly applies AP on one of its curses.