### PR TITLE
Fix auto ready race condition

### DIFF
--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -80,12 +80,6 @@ export default function PreparationMenu() {
     }
   }, [nbUsersReady, users.length, allUsersReady])
 
-  useEffect(() => {
-    if (gameMode !== GameMode.CUSTOM_LOBBY && room?.connection.isOpen) {
-      dispatch(toggleReady(true)) // automatically set users ready in non-classic game mode
-    }
-  }, [gameMode, dispatch, room?.connection.isOpen])
-
   const humans = users.filter((u) => !u.isBot)
   const isElligibleForELO =
     gameMode === GameMode.QUICKPLAY || users.filter((u) => !u.isBot).length >= 2
@@ -289,7 +283,7 @@ export default function PreparationMenu() {
     </p>
   )
 
-  const readyButton = (gameMode === GameMode.CUSTOM_LOBBY || !isReady) && users.length > 0 && (
+  const readyButton = (gameMode === GameMode.CUSTOM_LOBBY) && users.length > 0 && (
     <button
       className={cc("bubbly", "ready-button", isReady ? "green" : "orange")}
       onClick={() => {

--- a/app/public/src/pages/preparation.tsx
+++ b/app/public/src/pages/preparation.tsx
@@ -16,7 +16,8 @@ import {
   joinPreparation,
   logIn,
   setErrorAlertMessage,
-  setProfile
+  setProfile,
+  toggleReady
 } from "../stores/NetworkStore"
 import {
   addUser,
@@ -237,6 +238,8 @@ export default function Preparation() {
           }
         }
       })
+      
+      r.onMessage(Transfer.TOGGLE_READY, () => dispatch(toggleReady(true)))
 
       r.onMessage(Transfer.GAME_START, async (roomId) => {
         const token = await firebase.auth().currentUser?.getIdToken()

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -106,18 +106,6 @@ export class OnJoinCommand extends Command<
             })
           }
 
-          if (this.state.gameMode !== GameMode.CUSTOM_LOBBY) {
-            this.clock.setTimeout(() => {
-              if (
-                this.state.users.has(u.uid) &&
-                !this.state.users.get(u.uid)!.ready
-              ) {
-                this.state.users.delete(u.uid)
-                client.leave(CloseCodes.USER_KICKED) // kick clients that can't auto-ready in time. Still investigating why this happens for some people
-              }
-            }, 10000)
-          }
-
           this.state.addMessage({
             authorId: "server",
             payload: `${u.displayName} joined.`,
@@ -143,6 +131,9 @@ export class OnJoinCommand extends Command<
             `There is more than 8 players in the lobby which was not supposed to happen`
           )
         }
+      }
+      if (this.room.state.gameMode !== GameMode.CUSTOM_LOBBY) {
+        this.room.dispatcher.dispatch(new OnToggleReadyCommand(), {client, ready: true})
       }
     } catch (error) {
       logger.error(error)
@@ -549,6 +540,7 @@ export class OnToggleReadyCommand extends Command<
   execute({ client, ready }) {
     try {
       // cannot toggle ready in quick play / ranked / tournament game mode
+      if (this.room.state.gameMode !== GameMode.CUSTOM_LOBBY && ready !== true && ready !== undefined)
       if (this.room.state.gameMode !== GameMode.CUSTOM_LOBBY && ready !== true)
         return
 

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -540,7 +540,6 @@ export class OnToggleReadyCommand extends Command<
   execute({ client, ready }) {
     try {
       // cannot toggle ready in quick play / ranked / tournament game mode
-      if (this.room.state.gameMode !== GameMode.CUSTOM_LOBBY && ready !== true && ready !== undefined)
       if (this.room.state.gameMode !== GameMode.CUSTOM_LOBBY && ready !== true)
         return
 

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -358,6 +358,7 @@ export default class PreparationRoom extends Room<PreparationState> {
       /*logger.info(
         `${client.auth.displayName} ${client.id} join preparation room`
       )*/
+      client.userData = {}
       this.dispatcher.dispatch(new OnJoinCommand(), { client, options, auth })
     }
   }


### PR DESCRIPTION
Due to joins being async, it can be ordered after the ready command, causing the ready command to fail.
Additionally, prior to the fix, the ready button did not work at all in non-custom lobbies since `undefined !== true` would cause an early return.