### PR TITLE
toggleReady: make arg never undefined

### DIFF
--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -293,7 +293,7 @@ export default function PreparationMenu() {
     <button
       className={cc("bubbly", "ready-button", isReady ? "green" : "orange")}
       onClick={() => {
-        dispatch(toggleReady())
+        dispatch(toggleReady(!isReady))
       }}
     >
       {t("ready")} {isReady ? "✔" : "?"}

--- a/app/public/src/stores/NetworkStore.ts
+++ b/app/public/src/stores/NetworkStore.ts
@@ -155,7 +155,7 @@ export const networkSlice = createSlice({
     removeBot: (state, action: PayloadAction<string>) => {
       state.preparation?.send(Transfer.REMOVE_BOT, action.payload)
     },
-    toggleReady: (state, action: PayloadAction<boolean | undefined>) => {
+    toggleReady: (state, action: PayloadAction<boolean>) => {
       state.preparation?.send(Transfer.TOGGLE_READY, action.payload)
     },
     toggleEloRoom: (state, action: PayloadAction<boolean>) => {

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -543,7 +543,7 @@ export class OnToggleReadyCommand extends Command<
   PreparationRoom,
   {
     client: Client
-    ready: boolean | undefined
+    ready: boolean
   }
 > {
   execute({ client, ready }) {


### PR DESCRIPTION
Ready button now sends the intended boolean instead of letting the server switch the flag. Should fix issues when spamming the button or having a client/server desync