### PR TITLE
fix autoready bug

### DIFF
--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -80,12 +80,6 @@ export default function PreparationMenu() {
     }
   }, [nbUsersReady, users.length, allUsersReady])
 
-  useEffect(() => {
-    if (gameMode !== GameMode.CUSTOM_LOBBY && room?.connection.isOpen) {
-      dispatch(toggleReady(true)) // automatically set users ready in non-classic game mode
-    }
-  }, [gameMode, dispatch, room?.connection.isOpen])
-
   const humans = users.filter((u) => !u.isBot)
   const isElligibleForELO =
     gameMode === GameMode.QUICKPLAY || users.filter((u) => !u.isBot).length >= 2

--- a/app/public/src/pages/preparation.tsx
+++ b/app/public/src/pages/preparation.tsx
@@ -10,13 +10,15 @@ import GameState from "../../../rooms/states/game-state"
 import PreparationState from "../../../rooms/states/preparation-state"
 import { Transfer } from "../../../types"
 import { CloseCodes, CloseCodesMessages } from "../../../types/enum/CloseCodes"
+import { GameMode } from "../../../types/enum/Game"
 import { logger } from "../../../utils/logger"
 import { useAppDispatch, useAppSelector } from "../hooks"
 import {
   joinPreparation,
   logIn,
   setErrorAlertMessage,
-  setProfile
+  setProfile,
+  toggleReady
 } from "../stores/NetworkStore"
 import {
   addUser,
@@ -168,6 +170,9 @@ export default function Preparation() {
 
         if (u.uid === uid) {
           dispatch(setUser(u))
+          if (r.state.gameMode !== GameMode.CUSTOM_LOBBY) {
+            dispatch(toggleReady(true)) // automatically set users ready in non-classic game mode
+          }
         } else if (!u.isBot) {
           playSound(SOUNDS.JOIN_ROOM)
         }


### PR DESCRIPTION
The bug came from a race condition between UserMetadata.findOne db call to init player info vs client loading the prep room and sending the toggle ready command

Waiting for user to be added to state.users before sending the ready message fixes it