### PR TITLE
remove pp gain on damage on shield

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -491,7 +491,7 @@ export default abstract class PokemonState {
       // logger.debug(`${pokemon.name} took ${damage} and has now ${pokemon.life} life shield ${pokemon.shield}`);
 
       if (shouldTargetGainMana) {
-        pokemon.addPP(Math.ceil(damage / 10), pokemon, 0, false)
+        pokemon.addPP(Math.ceil(residualDamage / 10), pokemon, 0, false)
       }
 
       if (takenDamage > 0) {

--- a/app/public/dist/client/changelog/patch-5.8.md
+++ b/app/public/dist/client/changelog/patch-5.8.md
@@ -10,7 +10,7 @@ Gen 1 is now complete !
 
 # Gameplay
 
-- 
+- Remove additional PP gain from damage taken in shield
 
 # Changes to Pokemon & Abilities
 


### PR DESCRIPTION
AP scaling on shield abilities (Stakataka, Registeel, Slowking...) lead to a point where the damage required to break the shield provides enough additional PP with PP on damage to regain even more shield, making the unit unkillable.

I propose to make additional PP on residual damage instead of incoming damage. That solves the issue, but is a nerf to all frontline units using shield, so will probably require a few adjustments as compensation.