### PR TITLE
Fix Unown interaction with Ditto

### DIFF
--- a/app/models/pokemon-factory.ts
+++ b/app/models/pokemon-factory.ts
@@ -54,6 +54,9 @@ export default class PokemonFactory {
       case Pkm.WORMADAM_TRASH:
         return Pkm.BURMY_TRASH
       default:
+        if (PkmFamily[name] == Pkm.UNOWN_A) {
+          return name
+        }
         return PkmFamily[name]
     }
   }


### PR DESCRIPTION
At the moment, Dittos cloning Unowns will always become a Unown A. With this change Dittos will transform into the respective Unown.