### PR TITLE
fix animations after transform

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -554,7 +554,7 @@ export class IllusionStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, state, board, target, crit)
-    const heal = pokemon.stars === 3 ? 70 : pokemon.stars === 2 ? 50 : 30
+    const heal = [30, 50, 70][pokemon.stars - 1] ?? 70
     pokemon.handleHeal(heal, pokemon, 0.5, crit)
     if (target) {
       pokemon.index = target.index
@@ -6147,7 +6147,7 @@ export class LavaPlumeStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit, true)
     const cells = board.getCellsInFront(pokemon, target)
-    const damage = [20,40,80][pokemon.stars - 1] ?? 80
+    const damage = [20, 40, 80][pokemon.stars - 1] ?? 80
 
     cells.forEach((cell) => {
       board.addBoardEffect(cell.x, cell.y, Effect.LAVA, pokemon.simulation)
@@ -11005,5 +11005,5 @@ export const AbilityStrategies: { [key in Ability]: AbilityStrategy } = {
   [Ability.THUNDEROUS_KICK]: new ThunderousKickStrategy(),
   [Ability.FIERY_WRATH]: new FieryWrathStrategy(),
   [Ability.VISE_GRIP]: new ViseGripStrategy(),
-  [Ability.LAVA_PLUME]: new LavaPlumeStrategy(),
+  [Ability.LAVA_PLUME]: new LavaPlumeStrategy()
 }

--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -32,7 +32,12 @@ import { Synergy } from "../types/enum/Synergy"
 import { removeInArray } from "../utils/array"
 import { logger } from "../utils/logger"
 import { clamp, min } from "../utils/number"
-import { chance, pickNRandomIn, pickRandomIn, shuffleArray } from "../utils/random"
+import {
+  chance,
+  pickNRandomIn,
+  pickRandomIn,
+  shuffleArray
+} from "../utils/random"
 import { values } from "../utils/schemas"
 import Player from "./colyseus-models/player"
 import PokemonFactory from "./pokemon-factory"
@@ -343,7 +348,10 @@ export default class Shop {
         return getPokemonData(pkm).types.includes(synergy)
       })
       shuffleArray(candidates)
-      candidates = candidates.filter((p, index) => candidates.findIndex((p2) => PkmFamily[p2] === PkmFamily[p]) === index)
+      candidates = candidates.filter(
+        (p, index) =>
+          candidates.findIndex((p2) => PkmFamily[p2] === PkmFamily[p]) === index
+      )
 
       let selectedProposition = pickRandomIn(
         candidates.length > 0 ? candidates : propositions
@@ -509,7 +517,12 @@ export default class Shop {
             )
         )
         shuffleArray(legendaryCandidates)
-        legendaryCandidates = legendaryCandidates.filter((p, index) => legendaryCandidates.findIndex((p2) => PkmFamily[p2] === PkmFamily[p]) === index)
+        legendaryCandidates = legendaryCandidates.filter(
+          (p, index) =>
+            legendaryCandidates.findIndex(
+              (p2) => PkmFamily[p2] === PkmFamily[p]
+            ) === index
+        )
         if (legendaryCandidates.length > 0)
           return pickRandomIn(legendaryCandidates)
       } else if (player.rerollCount >= 90 && player.rerollCount % 10 === 0) {
@@ -521,8 +534,12 @@ export default class Shop {
             )
         )
         shuffleArray(uniqueCandidates)
-        uniqueCandidates = uniqueCandidates.filter((p, index) => uniqueCandidates.findIndex((p2) => PkmFamily[p2] === PkmFamily[p]) === index)
-        console.log({ uniqueCandidates})
+        uniqueCandidates = uniqueCandidates.filter(
+          (p, index) =>
+            uniqueCandidates.findIndex(
+              (p2) => PkmFamily[p2] === PkmFamily[p]
+            ) === index
+        )
         if (uniqueCandidates.length > 0) return pickRandomIn(uniqueCandidates)
       }
     }

--- a/app/public/src/game/animation-manager.ts
+++ b/app/public/src/game/animation-manager.ts
@@ -7,7 +7,12 @@ import {
   SpriteType
 } from "../../../types/enum/Game"
 import { Berries } from "../../../types/enum/Item"
-import { AnimationConfig, Pkm, PkmIndex } from "../../../types/enum/Pokemon"
+import {
+  AnimationConfig,
+  Pkm,
+  PkmByIndex,
+  PkmIndex
+} from "../../../types/enum/Pokemon"
 import { logger } from "../../../utils/logger"
 import { fpsToDuration } from "../../../utils/number"
 import atlas from "../assets/atlas.json"
@@ -237,9 +242,9 @@ export default class AnimationManager {
       case PokemonActionState.WALK:
         return AnimationType.Walk
       case PokemonActionState.ATTACK:
-        return AnimationConfig[entity.name as Pkm].attack
+        return AnimationConfig[PkmByIndex[entity.index]].attack
       case PokemonActionState.EMOTE:
-        return AnimationConfig[entity.name as Pkm].emote
+        return AnimationConfig[PkmByIndex[entity.index]].emote
       case PokemonActionState.IDLE:
       default:
         return AnimationType.Idle
@@ -303,7 +308,8 @@ export default class AnimationManager {
         ? entity.index
         : "0000"
     const tint =
-      entity.shiny && !AnimationConfig[entity.name].shinyUnavailable
+      entity.shiny &&
+      !AnimationConfig[PkmByIndex[entity.index]].shinyUnavailable
         ? PokemonTint.SHINY
         : PokemonTint.NORMAL
     const animKey = `${textureIndex}/${tint}/${animation}/${SpriteType.ANIM}/${orientationCorrected}`

--- a/app/types/enum/Pokemon.ts
+++ b/app/types/enum/Pokemon.ts
@@ -2007,6 +2007,10 @@ export const PkmIndex: { [key in Pkm]: string } = {
   [Pkm.OGERPON_CORNERSTONE_MASK]: "1017-0007"
 }
 
+export const PkmByIndex: { [index: string]: Pkm } = Object.fromEntries(
+  Object.entries(PkmIndex).map(([pkm, index]) => [index, pkm as Pkm])
+)
+
 export const PkmFamily: { [key in Pkm]: Pkm } = {
   [Pkm.EGG]: Pkm.EGG,
   [Pkm.BULBASAUR]: Pkm.BULBASAUR,


### PR DESCRIPTION
Pokemons transforming (Kecleon, Zorua, Metamorph...) had animations broken after transforming, because we preserve their original name and animations are selected by name.

Changed it so animations are resolved by index instead.

https://discord.com/channels/737230355039387749/1291110602617524356