### PR TITLE
Fix Fell Stinger duplicating in ghost matchups

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -5523,9 +5523,11 @@ export class FellStingerStrategy extends AbilityStrategy {
       pokemon.addAbilityPower(5, pokemon, 0, false)
       pokemon.addAttack(1, pokemon, 0, false)
       pokemon.addMaxHP(10, pokemon, 0, false)
-      pokemon.refToBoardPokemon.atk += 1
-      pokemon.refToBoardPokemon.ap += 5
-      pokemon.refToBoardPokemon.hp += 10
+      if(!pokemon.isGhostOpponent){
+        pokemon.refToBoardPokemon.atk += 1
+        pokemon.refToBoardPokemon.ap += 5
+        pokemon.refToBoardPokemon.hp += 10
+      }
     }
   }
 }


### PR DESCRIPTION
adjusting the instance variables of refToBoardPokemon should probably be done in methods (along with other adjustments too). I will add this later if someone doesn't get to it before me.