### PR TITLE
Cancel cosmog and cosmoem hp buffs after evolve

### DIFF
--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -13290,6 +13290,9 @@ export class Cosmoem extends Pokemon {
       else return Pkm.LUNALA
     }
   )
+  onAcquired(player: Player) {
+    this.hp = 200 // cancel hp buffs of cosmog
+  }
   hp = 200
   atk = 5
   def = 8
@@ -13318,6 +13321,7 @@ export class Solgaleo extends Pokemon {
   skill = Ability.SUNSTEEL_STRIKE
   attackSprite = AttackSprite.STEEL_MELEE
   onAcquired(player: Player) {
+    this.hp = 300 // cancel hp buffs of cosmoem
     player.titles.add(Title.STARGAZER)
   }
 }
@@ -13339,6 +13343,7 @@ export class Lunala extends Pokemon {
   skill = Ability.MOONGEIST_BEAM
   attackSprite = AttackSprite.STEEL_MELEE
   onAcquired(player: Player) {
+    this.hp = 300 // cancel hp buffs of cosmoem
     player.titles.add(Title.STARGAZER)
   }
 }


### PR DESCRIPTION
> Fix permanent stat buffs not carrying over for hatch, item-based and condition-based evolution rules

This change caused a problem for Cosmog and Cosmoem which evolves by progressively gaining permanent max HP. We need to revert this buff when evolving.

This gives a huge advantage to Cosmog right now so probably needs hotfix