### PR TITLE
Compute elo and xp directly on player leave

### DIFF
--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -112,6 +112,7 @@ export default class Player extends Schema implements IPlayer {
   canRegainLife: boolean = true
   ghost: boolean = false
   firstPartner: Pkm | undefined
+  hasLeftGame: boolean = false
 
   constructor(
     id: string,

--- a/app/public/dist/client/changelog/patch-5.9.md
+++ b/app/public/dist/client/changelog/patch-5.9.md
@@ -10,6 +10,8 @@
 
 # Gameplay
 
+- ELO, XP and titles after game are now distributed immediately after the player is eliminated and leaves the game, instead of waiting for the game to end
+
 # UI
 
 # Bugfix

--- a/app/public/src/pages/component/game/game-shop.css
+++ b/app/public/src/pages/component/game/game-shop.css
@@ -300,12 +300,12 @@
     grid-row: 1 / 1;
   }
 
-  .game-shop .game-pokemon-portrait {
+  .game-shop .game-pokemons-store > .game-pokemon-portrait {
     width: 12.5vw;
     --container-height: 10vw;
   }
 
-  .game-shop .game-pokemon-portrait .synergy-icon {
+  .game-shop .game-pokemons-store > .game-pokemon-portrait .synergy-icon {
     width: 2.5vw;
     height: 2.5vw;
   }

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -21,7 +21,7 @@ import {
   Role,
   Transfer
 } from "../../../types"
-import { RequiredStageLevelForXpElligibility } from "../../../types/Config"
+import { MinStageLevelForGameToCount } from "../../../types/Config"
 import { DungeonDetails } from "../../../types/enum/Dungeon"
 import { Team } from "../../../types/enum/Game"
 import { Pkm } from "../../../types/enum/Pokemon"
@@ -248,11 +248,11 @@ export default function Game() {
 
     const elligibleToXP =
       nbPlayers >= 2 &&
-      (room?.state.stageLevel ?? 0) >= RequiredStageLevelForXpElligibility
+      (room?.state.stageLevel ?? 0) >= MinStageLevelForGameToCount
     const elligibleToELO =
       elligibleToXP &&
       !room?.state.noElo &&
-      afterPlayers.filter((p) => p.role !== Role.BOT).length >= 4
+      afterPlayers.filter((p) => p.role !== Role.BOT).length >= 2
 
     const r: Room<AfterGameState> = await client.create("after-game", {
       players: afterPlayers,

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -112,7 +112,8 @@ export default function Game() {
   const [loaded, setLoaded] = useState<boolean>(false)
   const [connectError, setConnectError] = useState<string>("")
   const [finalRank, setFinalRank] = useState<number>(0)
-  const [finalRankVisible, setFinalRankVisible] = useState<boolean>(false)
+  enum FinalRankVisibility { HIDDEN, VISIBLE, CLOSED }
+  const [finalRankVisibility, setFinalRankVisibility] = useState<FinalRankVisibility>(FinalRankVisibility.HIDDEN)
   const container = useRef<HTMLDivElement>(null)
 
   const MAX_ATTEMPS_RECONNECT = 3
@@ -343,7 +344,7 @@ export default function Game() {
       })
       room.onMessage(Transfer.FINAL_RANK, (finalRank) => {
         setFinalRank(finalRank)
-        setFinalRankVisible(true)
+        setFinalRankVisibility(FinalRankVisibility.VISIBLE)
       })
       room.onMessage(Transfer.PRELOAD_MAPS, async (maps) => {
         logger.info("preloading maps", maps)
@@ -587,8 +588,9 @@ export default function Game() {
             value !== previousValue &&
             player.id === uid &&
             !spectate
+            && finalRankVisibility === FinalRankVisibility.HIDDEN
           ) {
-            setFinalRankVisible(true)
+            setFinalRankVisibility(FinalRankVisibility.VISIBLE)
           }
         })
         player.listen("experienceManager", (experienceManager) => {
@@ -744,9 +746,9 @@ export default function Game() {
           <MainSidebar page="game" leave={leave} leaveLabel={t("leave_game")} />
           <GameFinalRank
             rank={finalRank}
-            hide={() => setFinalRankVisible(false)}
+            hide={() => setFinalRankVisibility(FinalRankVisibility.CLOSED)}
             leave={leave}
-            visible={finalRankVisible}
+            visible={finalRankVisibility === FinalRankVisibility.VISIBLE}
           />
           {!spectate && <GameShop />}
           <GameStageInfo />

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -110,7 +110,8 @@ export const SynergyTriggers: { [key in Synergy]: number[] } = {
   [Synergy.AMORPHOUS]: [3, 5, 7]
 }
 
-export const RequiredStageLevelForXpElligibility = 10
+// games that finish before level 10 are not counted for XP and ELO to avoid potential abuse
+export const MinStageLevelForGameToCount = 10
 
 export const ExpPlace = [700, 400, 350, 300, 250, 200, 200, 200]
 


### PR DESCRIPTION
If a player leaves the game room, compute directly its ELO, XP and titles. This should be more intuitive for players that do not wait for the game to end (see Outsider bug reports for example)

A hasLeftGame boolean has been added to Player class to prevent this elo/xp to be computed twice on room dispose.

Also prevent final rank popup to continue popping up between each stage after closing it