### PR TITLE
new method simulation.removeItemEffect

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -601,6 +601,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     permanent = false
   ) {
     this.items.delete(item)
+    this.simulation.removeItemEffect(this, item)
     if (permanent && !this.isGhostOpponent){
       this.refToBoardPokemon.items.delete(item)
     }

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -439,6 +439,14 @@ export default class Simulation extends Schema implements ISimulation {
     }
   }
 
+  removeItemEffect(pokemon: PokemonEntity, item: Item){
+    if (ItemStats[item]) {
+      Object.entries(ItemStats[item]).forEach(([stat, value]) =>
+        pokemon.applyStat(stat as Stat, -value)
+      )
+    }
+  }
+
   applySynergyEffects(pokemon: PokemonEntity) {
     if (pokemon.team === Team.BLUE_TEAM) {
       this.applyEffects(


### PR DESCRIPTION
I'm not entirely sure it makes sense to have this be a method for simulation when it's applied only by a PokemonEntity object, but keeping it in the same place as applyItemEffect probably makes it easier to organize mentally.