### PR TITLE
Refactor simulation.applyItemEffect

### DIFF
--- a/app/core/items.ts
+++ b/app/core/items.ts
@@ -7,6 +7,10 @@ import {
 } from "../types/enum/Item"
 import { pickRandomIn } from "../utils/random"
 import { Pokemon } from "../models/colyseus-models/pokemon"
+import { PokemonEntity } from "./pokemon-entity"
+import { ItemStats } from "../types/Config"
+import { Stat } from "../types/enum/Game"
+import { EffectClass } from "../types/enum/EffectClass"
 
 export function getWonderboxItems(existingItems: SetSchema<Item>): Item[] {
   const wonderboxItems: Item[] = []
@@ -27,4 +31,139 @@ export function onItemRemoved(item: Item, pokemon: Pokemon) {
   if (item in SynergyGivenByItem) {
     pokemon.types.delete(SynergyGivenByItem[item])
   }
+}
+
+export function triggerItem(
+  effectClass: EffectClass,
+  pokemon: PokemonEntity,
+  item: Item
+) {
+
+  if (effectClass === EffectClass.APPLY && ItemStats[item]) {
+    Object.entries(ItemStats[item]).forEach(([stat, value]) =>
+      pokemon.applyStat(stat as Stat, value)
+    )
+  }
+
+  function triggerSoulDew() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.status.triggerSoulDew(1000)
+    }
+  }
+
+  function triggerWideLens() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.range += 2
+    }
+  }
+
+  function triggerMaxRevive() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.status.resurection = true
+    }
+  }
+
+  function triggerSwiftWing() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.addDodgeChance(0.1, pokemon, 0, false)
+    }
+  }
+
+  function triggerFlameOrb() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.addAttack(pokemon.baseAtk, pokemon, 0, false)
+      pokemon.status.triggerBurn(
+        60000,
+        pokemon as PokemonEntity,
+        pokemon as PokemonEntity
+      )
+    }
+  }
+
+  function triggerToxicOrb() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.addAttack(pokemon.baseAtk, pokemon, 0, false)
+      pokemon.status.triggerPoison(
+        60000,
+        pokemon as PokemonEntity,
+        pokemon as PokemonEntity
+      )
+    }
+  }
+
+  function triggerPokerusVial() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.status.triggerPokerus()
+    }
+  }
+
+  function triggerFluffyTail() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.status.triggerRuneProtect(60000)
+    }
+  }
+
+  function triggerKingsRock() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.addShield(0.3 * pokemon.hp, pokemon, 0, false)
+    }
+  }
+
+  function triggerDynamaxBand() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.addMaxHP(2.5 * pokemon.hp, pokemon, 0, false)
+    }
+  }
+
+  function triggerTinyMushroom() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.addMaxHP(-0.5 * pokemon.hp, pokemon, 0, false)
+    }
+  }
+
+  function triggerGoldBottleCap() {
+    if (effectClass === EffectClass.APPLY && pokemon.player) {
+      pokemon.addCritChance(pokemon.player.money, pokemon, 0, false)
+      pokemon.addCritPower(pokemon.player.money / 100, pokemon, 0, false)
+    }
+  }
+
+  function triggerRepeatBall() {
+    if (effectClass === EffectClass.APPLY && pokemon.player) {
+      pokemon.addAbilityPower(
+        Math.floor(
+          (pokemon.player.rerollCount + pokemon.simulation.stageLevel) / 2
+        ),
+        pokemon,
+        0,
+        false
+      )
+    }
+  }
+
+  function triggerSacredAsh() {
+    if (effectClass === EffectClass.APPLY) {
+      pokemon.status.resurection = true
+    }
+  }
+
+  const itemMap: ReadonlyMap<Item, () => void> = new Map([
+    [Item.SOUL_DEW, triggerSoulDew],
+    [Item.WIDE_LENS, triggerWideLens],
+    [Item.MAX_REVIVE, triggerMaxRevive],
+    [Item.SWIFT_WING, triggerSwiftWing],
+    [Item.FLAME_ORB, triggerFlameOrb],
+    [Item.TOXIC_ORB, triggerToxicOrb],
+    [Item.POKERUS_VIAL, triggerPokerusVial],
+    [Item.FLUFFY_TAIL, triggerFluffyTail],
+    [Item.KINGS_ROCK, triggerKingsRock],
+    [Item.DYNAMAX_BAND, triggerDynamaxBand],
+    [Item.TINY_MUSHROOM, triggerTinyMushroom],
+    [Item.GOLD_BOTTLE_CAP, triggerGoldBottleCap],
+    [Item.REPEAT_BALL, triggerRepeatBall],
+    [Item.SACRED_ASH, triggerSacredAsh]
+  ])
+
+  const process = itemMap.get(item)
+  if (process) process()
 }

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -54,6 +54,8 @@ import MovingState from "./moving-state"
 import PokemonState from "./pokemon-state"
 import Simulation from "./simulation"
 import { DelayedCommand, SimulationCommand } from "./simulation-command"
+import { EffectClass } from "../types/enum/EffectClass"
+import { triggerItem } from "./items"
 
 export class PokemonEntity extends Schema implements IPokemonEntity {
   @type("boolean") shiny: boolean
@@ -587,7 +589,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
 
   addItem(item: Item, permanent = false) {
     this.items.add(item)
-    this.simulation.applyItemEffect(this, item)
+    triggerItem(EffectClass.APPLY, this, item)
     if (permanent && !this.isGhostOpponent) {
       this.refToBoardPokemon.items.add(item)
     }

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -1,7 +1,7 @@
 import { MapSchema, Schema, SetSchema, type } from "@colyseus/schema"
 import Player from "../models/colyseus-models/player"
 import { Pokemon } from "../models/colyseus-models/pokemon"
-import { getWonderboxItems, triggerItems } from "./items"
+import { getWonderboxItems, triggerItem } from "./items"
 import PokemonFactory from "../models/pokemon-factory"
 import { getPokemonData } from "../models/precomputed/precomputed-pokemon-data"
 import { PRECOMPUTED_POKEMONS_PER_TYPE } from "../models/precomputed/precomputed-types"

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -1,7 +1,7 @@
 import { MapSchema, Schema, SetSchema, type } from "@colyseus/schema"
 import Player from "../models/colyseus-models/player"
 import { Pokemon } from "../models/colyseus-models/pokemon"
-import { getWonderboxItems } from "./items"
+import { getWonderboxItems, triggerItems } from "./items"
 import PokemonFactory from "../models/pokemon-factory"
 import { getPokemonData } from "../models/precomputed/precomputed-pokemon-data"
 import { PRECOMPUTED_POKEMONS_PER_TYPE } from "../models/precomputed/precomputed-types"
@@ -50,6 +50,7 @@ import { PokemonEntity, getStrongestUnit, getUnitScore } from "./pokemon-entity"
 import { DelayedCommand } from "./simulation-command"
 import { getAvatarString } from "../utils/avatar"
 import { max } from "../utils/number"
+import { EffectClass } from "../types/enum/EffectClass"
 
 export default class Simulation extends Schema implements ISimulation {
   @type("string") weather: Weather = Weather.NEUTRAL
@@ -349,93 +350,11 @@ export default class Simulation extends Schema implements ISimulation {
     }
 
     pokemon.items.forEach((item) => {
-      this.applyItemEffect(pokemon, item)
+      triggerItem(EffectClass.APPLY, pokemon, item)
     })
 
     if (pokemon.passive === Passive.SYNCHRO) {
       pokemon.status.triggerSynchro()
-    }
-  }
-
-  applyItemEffect(pokemon: PokemonEntity, item: Item) {
-    if (ItemStats[item]) {
-      Object.entries(ItemStats[item]).forEach(([stat, value]) =>
-        pokemon.applyStat(stat as Stat, value)
-      )
-    }
-
-    if (item === Item.SOUL_DEW) {
-      pokemon.status.triggerSoulDew(1000)
-    }
-
-    if (item === Item.WIDE_LENS) {
-      pokemon.range += 2
-    }
-
-    if (item === Item.MAX_REVIVE) {
-      pokemon.status.resurection = true
-    }
-
-    if (item === Item.SWIFT_WING) {
-      pokemon.addDodgeChance(0.1, pokemon, 0, false)
-    }
-
-    if (item === Item.FLAME_ORB) {
-      pokemon.addAttack(pokemon.baseAtk, pokemon, 0, false)
-      pokemon.status.triggerBurn(
-        60000,
-        pokemon as PokemonEntity,
-        pokemon as PokemonEntity
-      )
-    }
-
-    if (item === Item.TOXIC_ORB) {
-      pokemon.addAttack(pokemon.baseAtk, pokemon, 0, false)
-      pokemon.status.triggerPoison(
-        60000,
-        pokemon as PokemonEntity,
-        pokemon as PokemonEntity
-      )
-    }
-
-    if (item === Item.POKERUS_VIAL) {
-      pokemon.status.triggerPokerus()
-    }
-
-    if (item === Item.FLUFFY_TAIL) {
-      pokemon.status.triggerRuneProtect(60000)
-    }
-
-    if (item === Item.KINGS_ROCK) {
-      pokemon.addShield(0.3 * pokemon.hp, pokemon, 0, false)
-    }
-
-    if (item === Item.DYNAMAX_BAND) {
-      pokemon.addMaxHP(2.5 * pokemon.hp, pokemon, 0, false)
-    }
-
-    if (item === Item.TINY_MUSHROOM) {
-      pokemon.addMaxHP(-0.5 * pokemon.hp, pokemon, 0, false)
-    }
-
-    if (item === Item.GOLD_BOTTLE_CAP && pokemon.player) {
-      pokemon.addCritChance(pokemon.player.money, pokemon, 0, false)
-      pokemon.addCritPower(pokemon.player.money / 100, pokemon, 0, false)
-    }
-
-    if (item === Item.REPEAT_BALL && pokemon.player) {
-      pokemon.addAbilityPower(
-        Math.floor(
-          (pokemon.player.rerollCount + pokemon.simulation.stageLevel) / 2
-        ),
-        pokemon,
-        0,
-        false
-      )
-    }
-
-    if (item === Item.SACRED_ASH) {
-      pokemon.status.resurection = true
     }
   }
 

--- a/app/types/enum/EffectClass.ts
+++ b/app/types/enum/EffectClass.ts
@@ -1,0 +1,3 @@
+export const enum EffectClass{
+  APPLY = "APPLY"
+}


### PR DESCRIPTION
moved item application logic to core/items.ts
- allows for item logic to share the same hash table
    - item removal logic coming next
- isn't simulation specific (not needed to be a simulation method)

added EffectClass type for function hooks

updated simulation.applyItemEffect calls