### PR TITLE
adding cache-control headers to api endpoints

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -161,6 +161,7 @@ export default config({
     })
 
     app.get("/meta", async (req, res) => {
+      res.set("Cache-Control", "no-cache")
       res.send(
         await Meta.find({}, [
           "cluster_id",
@@ -181,10 +182,12 @@ export default config({
     })
 
     app.get("/meta/items", async (req, res) => {
+      res.set("Cache-Control", "no-cache")
       res.send(await ItemsStatistics.find())
     })
 
     app.get("/meta/pokemons", async (req, res) => {
+      res.set("Cache-Control", "no-cache")
       res.send(await PokemonsStatistics.find())
     })
 
@@ -194,10 +197,12 @@ export default config({
     })
 
     app.get("/leaderboards", async (req, res) => {
+      res.set("Cache-Control", "no-cache")
       res.send(getLeaderboard())
     })
 
     app.get("/game-history/:playerUid", async (req, res) => {
+      res.set("Cache-Control", "no-cache")
       const { playerUid } = req.params
       const { page = 1 } = req.query
       const limit = 10


### PR DESCRIPTION
We still have cache issues for leaderboard apparently. Adding Cache-control: no-cache headers to express API responses in order for default cloudflare cache behavior to not cache it neither.

https://discord.com/channels/737230355039387749/1314736864506286232