### PR TITLE
Fix 9 out of 8 rooms

### DIFF
--- a/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../../../../types"
 import { MAX_PLAYERS_PER_GAME } from "../../../../../types/Config"
 import { GameMode } from "../../../../../types/enum/Game"
-import { throttle } from "../../../../../utils/function"
+import { block, throttle } from "../../../../../utils/function"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import RoomItem from "./room-item"
 import { RoomSelectionMenu } from "./room-selection-menu"
@@ -42,7 +42,7 @@ export default function AvailableRoomMenu() {
     }
   }, 1000)
 
-  const requestJoiningExistingRoom = throttle(async function join(
+  const requestJoiningExistingRoom = block(async function join(
     selectedRoom: RoomAvailable<IPreparationMetadata>
   ) {
     const { whitelist, blacklist, gameStartedAt, password } =
@@ -67,9 +67,9 @@ export default function AvailableRoomMenu() {
         }
       }
 
-      joinExistingPreparationRoom(selectedRoom.roomId, client, lobby, dispatch, navigate)
+      await joinExistingPreparationRoom(selectedRoom.roomId, client, lobby, dispatch, navigate)
     }
-  }, 1000)
+  })
 
   return (
     <div className="my-container room-menu custom-bg">

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -544,7 +544,6 @@ export class OnLeaveCommand extends Command<
             avatar: user.avatar
           })
           this.state.users.delete(client.auth.uid)
-          this.state.uids.delete(client.auth.uid)
 
           if (client.auth.uid === this.state.ownerId) {
             const newOwner = values(this.state.users).find(

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -22,13 +22,14 @@ import PreparationRoom from "../preparation-room"
 import { CloseCodes } from "../../types/enum/CloseCodes"
 import { getRank } from "../../utils/elo"
 import { SpecialGameRule } from "../../types/enum/SpecialGameRule"
+import { UserRecord } from "firebase-admin/lib/auth/user-record"
 
 export class OnJoinCommand extends Command<
   PreparationRoom,
   {
-    client: Client
+    client: Client<undefined, UserRecord>
     options: any
-    auth: any
+    auth: UserRecord
   }
 > {
   async execute({ client, options, auth }) {
@@ -543,6 +544,7 @@ export class OnLeaveCommand extends Command<
             avatar: user.avatar
           })
           this.state.users.delete(client.auth.uid)
+          this.state.uids.delete(client.auth.uid)
 
           if (client.auth.uid === this.state.ownerId) {
             const newOwner = values(this.state.users).find(

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -1,5 +1,5 @@
 import { Dispatcher } from "@colyseus/command"
-import { Client, Room, updateLobby } from "colyseus"
+import { Client, ClientArray, Room, updateLobby } from "colyseus"
 import admin from "firebase-admin"
 import BannedUser from "../models/mongo-models/banned-user"
 import { IBot } from "../models/mongo-models/bot-v2"
@@ -28,9 +28,11 @@ import {
   RemoveMessageCommand
 } from "./commands/preparation-commands"
 import PreparationState from "./states/preparation-state"
+import { UserRecord } from "firebase-admin/lib/auth/user-record"
 
 export default class PreparationRoom extends Room<PreparationState> {
   dispatcher: Dispatcher<this>
+  clients!: ClientArray<undefined, UserRecord>
 
   constructor() {
     super()
@@ -337,18 +339,23 @@ export default class PreparationRoom extends Room<PreparationState> {
 
   async onAuth(client: Client, options: any, request: any) {
     try {
-      super.onAuth(client, options, request)
       const token = await admin.auth().verifyIdToken(options.idToken)
       const user = await admin.auth().getUser(token.uid)
       const isBanned = await BannedUser.findOne({ uid: user.uid })
       const userProfile = await UserMetadata.findOne({ uid: user.uid })
       client.send(Transfer.USER_PROFILE, userProfile)
 
-      const isAlreadyInRoom = this.state.users.has(user.uid)
       const numberOfHumanPlayers = values(this.state.users).filter(
         (u) => !u.isBot
       ).length
-      if (numberOfHumanPlayers >= MAX_PLAYERS_PER_GAME && !isAlreadyInRoom) {
+
+      if (!this.state.uids.has(user.uid)) {
+        this.state.uids.add(user.uid)
+      } else {
+        throw "Already joined"
+      }
+      
+      if (numberOfHumanPlayers >= MAX_PLAYERS_PER_GAME) {
         throw "Room is full"
       } else if (this.state.gameStartedAt != null) {
         throw "Game already started"
@@ -366,17 +373,17 @@ export default class PreparationRoom extends Room<PreparationState> {
     }
   }
 
-  onJoin(client: Client, options: any, auth: any) {
-    if (client && client.auth && client.auth.displayName) {
+  async onJoin(client: Client<undefined, UserRecord>, options: any, auth: UserRecord | undefined) {
+    if (auth) {
       /*logger.info(
-        `${client.auth.displayName} ${client.id} join preparation room`
+        `${auth.displayName} ${client.id} join preparation room`
       )*/
-      this.dispatcher.dispatch(new OnJoinCommand(), { client, options, auth })
+      await this.dispatcher.dispatch(new OnJoinCommand(), { client, options, auth })
     }
   }
 
   async onLeave(client: Client, consented: boolean) {
-    if (client && client.auth && client.auth.displayName) {
+    if (client.auth && client.auth.displayName) {
       /*logger.info(
         `${client.auth.displayName} ${client.id} is leaving preparation room`
       )*/
@@ -388,7 +395,7 @@ export default class PreparationRoom extends Room<PreparationState> {
       // allow disconnected client to reconnect into this room until 10 seconds
       await this.allowReconnection(client, 10)
     } catch (e) {
-      if (client && client.auth && client.auth.displayName) {
+      if (client.auth && client.auth.displayName) {
         /*logger.info(
           `${client.auth.displayName} ${client.id} leave preparation room`
         )*/

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -345,18 +345,15 @@ export default class PreparationRoom extends Room<PreparationState> {
       const userProfile = await UserMetadata.findOne({ uid: user.uid })
       client.send(Transfer.USER_PROFILE, userProfile)
 
+      const isAlreadyInRoom = this.state.users.has(user.uid)
       const numberOfHumanPlayers = values(this.state.users).filter(
         (u) => !u.isBot
       ).length
 
-      if (!this.state.uids.has(user.uid)) {
-        this.state.uids.add(user.uid)
-      } else {
-        throw "Already joined"
-      }
-      
       if (numberOfHumanPlayers >= MAX_PLAYERS_PER_GAME) {
         throw "Room is full"
+      } else if (isAlreadyInRoom) {
+        throw "Already joined"
       } else if (this.state.gameStartedAt != null) {
         throw "Game already started"
       } else if (!user.displayName) {

--- a/app/rooms/states/preparation-state.ts
+++ b/app/rooms/states/preparation-state.ts
@@ -35,7 +35,6 @@ export default class PreparationState
   @type("boolean") noElo: boolean
   @type(["string"]) whitelist: string[]
   @type(["string"]) blacklist: string[]
-  uids: Set<string> = new Set()
 
   constructor(params: {
     ownerId?: string

--- a/app/rooms/states/preparation-state.ts
+++ b/app/rooms/states/preparation-state.ts
@@ -35,6 +35,7 @@ export default class PreparationState
   @type("boolean") noElo: boolean
   @type(["string"]) whitelist: string[]
   @type(["string"]) blacklist: string[]
+  uids: Set<string> = new Set()
 
   constructor(params: {
     ownerId?: string

--- a/app/utils/function.ts
+++ b/app/utils/function.ts
@@ -57,9 +57,8 @@ export function block<T extends (...args: any) => any>(
       executing = true
       const maybePromise: ReturnType<T> = fn.apply(context, args)
       lastResult = await maybePromise
+      executing = false
     }
-
-    executing = false
 
     return lastResult
   }

--- a/app/utils/function.ts
+++ b/app/utils/function.ts
@@ -44,6 +44,27 @@ export function throttle<T extends (...args: any) => any>(
   }
 }
 
+export function block<T extends (...args: any) => any>(
+  fn: T
+): ThrottledFunction<T> {
+  let executing: boolean
+  let lastResult: ReturnType<T>
+  
+  return async function (this: any, ...args: any[]): Promise<ReturnType<T>> {
+    const context = this
+    
+    if (!executing) {
+      executing = true
+      const maybePromise: ReturnType<T> = fn.apply(context, args)
+      lastResult = await maybePromise
+    }
+
+    executing = false
+
+    return lastResult
+  }
+}
+
 // repeat fn several times
 export const repeat = (n: number) => (cb: (i: number) => void) => {
   for (let i = 0; i < n; i++) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -389,16 +389,16 @@
       }
     },
     "node_modules/@colyseus/auth": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/@colyseus/auth/-/auth-0.15.10.tgz",
-      "integrity": "sha512-2RsbqtS2WTsjDlY5BDxpjC4OGm0HvvaNlZYMPGLD5vN8gJoQGnU9SEl1OWmcvlrxqFY0tEk1d4Wux10G4U8ifw==",
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@colyseus/auth/-/auth-0.15.12.tgz",
+      "integrity": "sha512-veq2A+J7JA6EJVIyd2TBuO3SMEnaEhj9f6UdAL8qicPLjJ6JQH+An5C85zob7KuNXrmAMKfHUjUGpLH+ET6oWA==",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^9.0.5",
         "connect-redis": "^7.1.0",
         "express-jwt": "^8.4.1",
         "express-session": "^1.17.3",
-        "grant": "^5.4.22",
+        "grant": "^5.4.23",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -408,7 +408,7 @@
         "url": "https://github.com/sponsors/endel"
       },
       "peerDependencies": {
-        "@colyseus/core": "^0.15.23",
+        "@colyseus/core": "0.15.x",
         "express": "^4.17.1"
       }
     },
@@ -425,13 +425,12 @@
       }
     },
     "node_modules/@colyseus/core": {
-      "version": "0.15.53",
-      "resolved": "https://registry.npmjs.org/@colyseus/core/-/core-0.15.53.tgz",
-      "integrity": "sha512-09tcOCZTCDL/o0uo7ysz3HjW7EYiAFIDNstCSMGX0ua/Ul+gQj9YO8J43rRZIe3vKExHtrWm0zOU2uquhRjY1A==",
+      "version": "0.15.57",
+      "resolved": "https://registry.npmjs.org/@colyseus/core/-/core-0.15.57.tgz",
+      "integrity": "sha512-tAKNaFSFOpRH2ayLva9hQBVPQu0eKxDxaZJYugZMQ5i6yQ2RTvcbk/5Up7OZn/bfdk9THvBYnh6WfdZAOctK+g==",
       "license": "MIT",
       "dependencies": {
         "@colyseus/greeting-banner": "^2.0.0",
-        "@colyseus/schema": "^2.0.4",
         "@gamestdio/timer": "^1.3.0",
         "debug": "^4.3.4",
         "msgpackr": "^1.9.1",
@@ -443,6 +442,9 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/endel"
+      },
+      "peerDependencies": {
+        "@colyseus/schema": "^2.0.4"
       }
     },
     "node_modules/@colyseus/core/node_modules/nanoid": {
@@ -526,17 +528,38 @@
       }
     },
     "node_modules/@colyseus/ws-transport": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@colyseus/ws-transport/-/ws-transport-0.15.2.tgz",
-      "integrity": "sha512-v83omTcAmU+vm3uqaaPFDXHxs4tYXUgJwR4IviZF0UMCm3OIQ85end+vsHaKGQf+wSfincCKGkA1etwxqlWTLQ==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@colyseus/ws-transport/-/ws-transport-0.15.3.tgz",
+      "integrity": "sha512-wm1AT1d6esUnZt1sUvrPcq9hkDBhZKZiB+fHCZEaPw3QDtG9slbOaZZ9Evr2DlxUUAaHU0H2qV3kchBYyL68UQ==",
       "license": "MIT",
       "dependencies": {
-        "@colyseus/core": "^0.15.38",
         "@types/ws": "^7.4.4",
-        "ws": "^7.4.5"
+        "ws": "^8.18.0"
       },
       "peerDependencies": {
+        "@colyseus/core": "0.15.x",
         "@colyseus/schema": ">=1.0.0"
+      }
+    },
+    "node_modules/@colyseus/ws-transport/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -4419,9 +4442,9 @@
       "license": "MIT"
     },
     "node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "license": "MIT",
       "optional": true
     },
@@ -4860,19 +4883,22 @@
       "license": "MIT"
     },
     "node_modules/colyseus": {
-      "version": "0.15.17",
-      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.15.17.tgz",
-      "integrity": "sha512-9RDi8fbikCQ8tb9ptNQ0MBsP3dOR9ltxQGhkg6f0RGnQ+tkzcXEfwtIuO6nbGJm75bmSFPmRH40uoG6qlvBlIw==",
+      "version": "0.15.57",
+      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.15.57.tgz",
+      "integrity": "sha512-h9hkmXOvcreRhJxdu73BJctGEPYW36ImHByjiMhEOIuSQLcNSlkcwaqCll/7Oc/cTELHStTa5eyOnI640mOe8A==",
       "license": "MIT",
       "dependencies": {
-        "@colyseus/auth": "^0.15.10",
-        "@colyseus/core": "^0.15.36",
+        "@colyseus/auth": "^0.15.11",
+        "@colyseus/core": "^0.15.57",
         "@colyseus/redis-driver": "^0.15.6",
         "@colyseus/redis-presence": "^0.15.5",
-        "@colyseus/ws-transport": "^0.15.1"
+        "@colyseus/ws-transport": "^0.15.3"
       },
       "engines": {
         "node": ">= 14.x"
+      },
+      "peerDependencies": {
+        "@colyseus/schema": "^2.0.0"
       }
     },
     "node_modules/colyseus.js": {
@@ -5902,9 +5928,9 @@
       "license": "MIT"
     },
     "node_modules/elliptic": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
-      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7246,9 +7272,9 @@
       }
     },
     "node_modules/grant/node_modules/cookie-signature": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.1.tgz",
-      "integrity": "sha512-78KWk9T26NhzXtuL26cIJ8/qNHANyJ/ZYrmEXFzUmhZdjpBv+DlWlOANRTGBt48YcyslsLrj0bMLFTmXvLRCOw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8368,14 +8394,14 @@
       }
     },
     "node_modules/jwk-to-pem": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.6.tgz",
-      "integrity": "sha512-zPC/5vjyR08TpknpTGW6Z3V3lDf9dU92oHbf0jJlG8tGOzslF9xk2UiO/seSx2llCUrNAe+AvmuGTICSXiYU7A==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.7.tgz",
+      "integrity": "sha512-cSVphrmWr6reVchuKQZdfSs4U9c5Y4hwZggPoz6cbVnTpAVgGRpEuQng86IyqLeGZlhTh+c4MAreB6KbdQDKHQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "asn1.js": "^5.3.0",
-        "elliptic": "^6.5.7",
+        "elliptic": "^6.6.1",
         "safe-buffer": "^5.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@reduxjs/toolkit": "^2.2.7",
     "@types/bootstrap": "^5.2.10",
     "body-parser": "^1.20.3",
-    "colyseus": "^0.15.15",
+    "colyseus": "^0.15.57",
     "colyseus.js": "^0.15.25",
     "cors": "^2.8.5",
     "cron": "^3.1.6",


### PR DESCRIPTION
Rejecting in `onJoin` will cause the same result as double joins, where the user becomes a ghost of the room.
This fix will trigger warnings and errors for onAuth failing on the client's console upon rejection.
As well, Colyseus is updated to include a fix for `onAuth` rejections not decrementing client count.