### PR TITLE
Tweaks for tournament

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -63,9 +63,13 @@ if (process.env.NODE_APP_INSTANCE) {
           throw "Attempt to create one lobby"
         }
       }
-      return (await matchMaker.stats.fetchAll()).sort((p1, p2) =>
-        p1.ccu > p2.ccu ? 1 : -1
-      )[0].processId
+      const stats = await matchMaker.stats.fetchAll()
+      stats.sort((p1, p2) =>
+        p1.roomCount !== p2.roomCount
+          ? p1.roomCount - p2.roomCount
+          : p1.ccu - p2.ccu
+      )
+      return stats[0].processId
     }
   }
 }

--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -60,6 +60,7 @@ import { logger } from "../../utils/logger"
 import { cleanProfanity } from "../../utils/profanity-filter"
 import { chance, pickRandomIn } from "../../utils/random"
 import { convertSchemaToRawObject, values } from "../../utils/schemas"
+import { wait } from "../../utils/promise"
 import CustomLobbyRoom from "../custom-lobby-room"
 
 export class OnJoinCommand extends Command<
@@ -1249,6 +1250,7 @@ export class CreateTournamentLobbiesCommand extends Command<
           tournamentId,
           bracketId
         })
+        await wait(1000)
       }
 
       //save brackets to db

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -119,7 +119,6 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
     this.setState(new LobbyState())
     this.autoDispose = false
     this.listing.unlisted = true
-    this.maxClients = MAX_CONCURRENT_PLAYERS_ON_LOBBY
 
     this.clock.setInterval(async () => {
       const ccu = await matchMaker.stats.getGlobalCCU()

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -361,7 +361,7 @@ export const FishRarityProbability: {
 
 export const MAX_POOL_CONNECTIONS_SIZE = 16
 export const MAX_CONCURRENT_PLAYERS_ON_SERVER = 1000
-export const MAX_CONCURRENT_PLAYERS_ON_LOBBY = 100
+export const MAX_CONCURRENT_PLAYERS_ON_LOBBY = 500
 export const MAX_PLAYERS_PER_GAME = 8
 export const MIN_HUMAN_PLAYERS = process.env.MIN_HUMAN_PLAYERS
   ? parseInt(process.env.MIN_HUMAN_PLAYERS)

--- a/app/utils/promise.ts
+++ b/app/utils/promise.ts
@@ -1,0 +1,3 @@
+export function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
- Replace CCU with roomCount for process selection
- introduce a delay of 1 second between tournament lobbies opening
- remove maxClients on lobbyRoom, it's handled in OnJoinCommand to have a more clear error message
- increase the maximum concurrent players allowed in lobbyroom to 500