### PR TITLE
Additional check for autostart and autoremove lobbies

### DIFF
--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -120,7 +120,14 @@ export default class PreparationRoom extends Room<PreparationState> {
 
     if (options.autoStartDelayInSeconds) {
       this.clock.setTimeout(() => {
-        if (this.state.users.size < 2) {
+        if (this.state.gameStartedAt != null) {
+          // game has started but the prep room is still open
+          logger.debug(
+            "game has started but the prep room is still open, forcing close"
+          )
+          this.disconnect(CloseCodes.NORMAL_CLOSURE)
+          return
+        } else if (this.state.users.size < 2) {
           // automatically remove lobbies with zero or one players
           if (this.metadata?.tournamentId) {
             // automatically give rank 1 if solo in a tournament lobby


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1316173116417769582

The only visible bug in logs happened on Quarter finals lobby, with 3 lobbies out of 4 automatically ended after the 10 min timeout, but apparently played because we haved the true ending messages 20 to 25 minutes later 

Declaring the end of a tournament match is done in 2 ways: after the game is finished, or after the 10 minute timeout when only one player is connected to a tournament lobby. The fact we have 2 messages for these 3 brackets let me suppose that both these conditions have been triggered.

I'm adding additional check to prevent closing the prep room and triggering tournament-match-end if the lobby is started (if gameStartedAt !=null)

I'm also adding a log in that case to investigate if that happens often, and if we need to do something about it by clearing the clock on game start for example.