### PR TITLE
Reserve space for wiki scrollbar

### DIFF
--- a/app/public/src/pages/component/wiki/wiki.css
+++ b/app/public/src/pages/component/wiki/wiki.css
@@ -38,6 +38,7 @@
   height: 75vh;
   padding: 0.5em 0 40px 0;
   overflow-y: auto;
+  scrollbar-gutter: stable;
 }
 
 #wiki-page .pokemon-name {


### PR DESCRIPTION
On the Pokemons tab and Weather tab, hovering or selecting a pokemon sometimes result in vertical overflow, introducing a scrollbar that causes shifting. This is particularly annoying on the Pokemons tab as it shifts the icons around.

This change reserves space for the scrollbar always, except on Safari which does not support the CSS property.