### PR TITLE
allow holding artif items giving one of their existing synergies

### DIFF
--- a/app/public/dist/client/changelog/patch-5.9.md
+++ b/app/public/dist/client/changelog/patch-5.9.md
@@ -29,6 +29,8 @@
 
 # Changes to Items
 
+- Pokemons can now hold artificial items and Shiny Stone even if they give one of their existing synergies
+
 # Gameplay
 
 - ELO, XP and titles after game are now distributed immediately after the player is eliminated and leaves the game, instead of waiting for the game to end

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -50,7 +50,7 @@ import {
   OgerponMasks,
   ShinyItems,
   SynergyGivenByItem,
-  SynergyItems
+  SynergyStones
 } from "../../types/enum/Item"
 import { Passive } from "../../types/enum/Passive"
 import {
@@ -287,7 +287,7 @@ export class OnDragDropCommand extends Command<
               })
             }
             pokemon.onChangePosition(x, y, player)
-            success = true            
+            success = true
           } else if (
             pokemon.canBePlaced &&
             !(dropFromBench && dropToEmptyPlace && isBoardFull)
@@ -574,9 +574,8 @@ export class OnDragDropItemCommand extends Command<
     }
 
     if (
-      SynergyItems.includes(item) &&
-      pokemon.types.has(SynergyGivenByItem[item]) &&
-      pokemon.passive !== Passive.RECYCLE
+      SynergyStones.includes(item) &&
+      pokemon.types.has(SynergyGivenByItem[item])
     ) {
       // prevent adding a synergy stone on a pokemon that already has this synergy
       client.send(Transfer.DRAG_DROP_FAILED, message)
@@ -617,7 +616,7 @@ export class OnDragDropItemCommand extends Command<
       const itemCombined = recipe[0] as Item
 
       if (
-        itemCombined in SynergyGivenByItem &&
+        SynergyStones.includes(itemCombined) &&
         pokemon.types.has(SynergyGivenByItem[itemCombined])
       ) {
         // prevent combining into a synergy stone on a pokemon that already has this synergy


### PR DESCRIPTION
Pokemons can now hold artificial items and Shiny Stone even if they give one of their existing synergies

![image](https://github.com/user-attachments/assets/bbe4a8d1-b933-4574-97cc-9f5c97f0f838)

