### PR TITLE
Prevent selecting/dragging button text

### DIFF
--- a/app/public/src/pages/component/available-room-menu/room-selection-menu.css
+++ b/app/public/src/pages/component/available-room-menu/room-selection-menu.css
@@ -12,6 +12,10 @@
   padding: 1em 0.5em;
 }
 
+.room-selection-menu li > * {
+  user-select: none;
+}
+
 .room-selection-menu li:hover {
   background-color: var(--color-bg-accent);
   cursor: var(--cursor-hover);

--- a/app/public/src/pages/component/available-room-menu/room-selection-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/room-selection-menu.tsx
@@ -13,22 +13,22 @@ export function RoomSelectionMenu(props: { show: boolean, onClose: () => void, o
         header={t("new_game")}
         body={<ul>
             <li className="my-box" onClick={() => props.onSelectMode(GameMode.QUICKPLAY)}>
-                <img src="assets/ui/game_modes/quickplay.png" alt="Quick Play" />
+                <img src="assets/ui/game_modes/quickplay.png" alt="Quick Play" draggable="false" />
                 <h2>{t("quick_play")}</h2>
                 <p>{t("quick_play_description")}</p>
             </li>
             <li className="my-box" onClick={() => props.onSelectMode(GameMode.RANKED)}>
-                <img src="assets/ui/game_modes/ranked.png" alt="Ranked match" />
+                <img src="assets/ui/game_modes/ranked.png" alt="Ranked match" draggable="false" />
                 <h2>{t("ranked_match")}</h2>
                 <p>{t("ranked_match_description")}</p>
             </li>
             <li className="my-box" onClick={() => props.onSelectMode(GameMode.SCRIBBLE)}>
-                <img src="assets/ui/game_modes/scribble.png" alt="Smeargle's Scribble" />
+                <img src="assets/ui/game_modes/scribble.png" alt="Smeargle's Scribble" draggable="false" />
                 <h2>{t("smeargle_scribble")}</h2>
                 <p>{t("smeargle_scribble_description")}</p>
             </li>
             <li className="my-box" onClick={() => props.onSelectMode(GameMode.CUSTOM_LOBBY)}>
-                <img src="assets/ui/game_modes/custom.png" alt="Custom lobby" />
+                <img src="assets/ui/game_modes/custom.png" alt="Custom lobby" draggable="false" />
                 <h2>{t("custom_room")}</h2>
                 <p>{t("custom_room_description")}</p>
             </li>


### PR DESCRIPTION
Currently one can select or drag content within the modal for creating/joining games. This disables being able to select content within the buttons for the modal.