### PR TITLE
remove additional income from PvE rounds and streaks

### DIFF
--- a/app/public/dist/client/changelog/patch-5.9.md
+++ b/app/public/dist/client/changelog/patch-5.9.md
@@ -79,6 +79,7 @@
   - Master ball: 1500 ELO
   - Beast ball: 1700 ELO
 - ELO, XP and titles after game are now distributed immediately after the player is eliminated and leaves the game, instead of waiting for the game to end
+- PvE rounds no longer give additional income based on victory/defeat streaks
 - Due to an increase of cases of intentional leaves at the start of a game, we have to increase the penalties for early disconnections. Intentional disconnections before stage 6 are no longer protected against Elo loss. Unintentional disconnections without reconnection within the next 3 minutes before stage 6 remain protected against Elo loss, but players won't be able to join a new game within the next 5 minutes.
 
 # UI

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1080,13 +1080,15 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
     })
   }
 
-  computeIncome() {
+  computeIncome(isPVE: boolean) {
     this.state.players.forEach((player) => {
       let income = 0
       if (player.alive && !player.isBot) {
         player.interest = Math.min(Math.floor(player.money / 10), 5)
         income += player.interest
-        income += max(5)(player.streak)
+        if (!isPVE) {
+          income += max(5)(player.streak)
+        }
         income += 5
         player.addMoney(income, true, null)
         if (income > 0) {
@@ -1293,7 +1295,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
 
     if (!isGameFinished) {
       this.state.stageLevel += 1
-      this.computeIncome()
+      this.computeIncome(isPVE)
       this.state.players.forEach((player: Player) => {
         if (player.alive) {
           // Fake bots XP bar


### PR DESCRIPTION
PvE rounds no longer give additional income based on victory/defeat streaks

This was giving an unfair money advantage to players that manage to have a good streak before PvE rounds, as PvE is not impacting the streak