### PR TITLE
Fix light effects applying to spawns and resurrected pokemon

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -246,11 +246,8 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   get inLightCell(): boolean {
     if (!this.player) return false
     const { lightX, lightY } = this.player
-    if (this.team === Team.BLUE_TEAM) {
-      return this.positionX === lightX && this.positionY === lightY - 1
-    } else {
-      return this.positionX === lightX && this.positionY === 5 - (lightY - 1)
-    }
+    const {positionX, positionY} = this.refToBoardPokemon
+    return positionX === lightX && positionY === lightY
   }
 
   hasSynergyEffect(synergy: Synergy): boolean {

--- a/app/public/dist/client/changelog/patch-5.9.md
+++ b/app/public/dist/client/changelog/patch-5.9.md
@@ -90,5 +90,6 @@
 
 - Pokemon with passives that apply persistent effects now apply properly to spawns and resurrected pokemon.
 - Weather effects now apply properly to spawns and resurrected pokemon.
+- Light effects are no longer erroneously applied to spawns and resurrected pokemon.
 
 # Misc


### PR DESCRIPTION
Changed inLightCell calculation to check the location of the Pokemon object instead of the PokemonEntity object
https://discord.com/channels/737230355039387749/1319359489383731200