### PR TITLE
fix flamethrower damage

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -2729,6 +2729,7 @@ export class FlameThrowerStrategy extends AbilityStrategy {
           pokemon,
           crit
         )
+        cell.value.status.triggerBurn(4000, cell.value, pokemon)
       }
     })
   }

--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -2714,7 +2714,7 @@ export class FlameThrowerStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, state, board, target, crit)
-    const damage = [20, 40, 80][pokemon.stars - 1] ?? 80
+    const damage = [30, 60, 120][pokemon.stars - 1] ?? 120
 
     effectInLine(board, pokemon, target, (cell) => {
       if (

--- a/app/public/dist/client/changelog/patch-5.9.md
+++ b/app/public/dist/client/changelog/patch-5.9.md
@@ -105,6 +105,6 @@
 - Pokemon with passives that apply persistent effects now apply properly to spawns and resurrected pokemon.
 - Weather effects now apply properly to spawns and resurrected pokemon.
 - Light effects are no longer erroneously applied to spawns and resurrected pokemon.+
-- Fix Flamethrower damage, the values were 20/40/80 instead of 30/60/120
+- Fix Flamethrower damage & burn effect not working properly
 
 # Misc

--- a/app/public/dist/client/changelog/patch-5.9.md
+++ b/app/public/dist/client/changelog/patch-5.9.md
@@ -104,6 +104,7 @@
 
 - Pokemon with passives that apply persistent effects now apply properly to spawns and resurrected pokemon.
 - Weather effects now apply properly to spawns and resurrected pokemon.
-- Light effects are no longer erroneously applied to spawns and resurrected pokemon.
+- Light effects are no longer erroneously applied to spawns and resurrected pokemon.+
+- Fix Flamethrower damage, the values were 20/40/80 instead of 30/60/120
 
 # Misc


### PR DESCRIPTION
Fix Flamethrower damage, the values were 20/40/80 instead of 30/60/120
Also it was not triggering burn status contrary to what description says