### PR TITLE
group ranked by groups

### DIFF
--- a/app/public/dist/client/changelog/patch-5.9.md
+++ b/app/public/dist/client/changelog/patch-5.9.md
@@ -82,7 +82,7 @@
 # Gameplay
 
 - New status: Blinded: reduce accuracy of basic attacks by 50%. Replace the existing Smoke effect that was not considered a status.
-- New rank system: 12 different ranks, each with a different icon (by @joinity). Beast ball and Master ball players will create ranked games with Ultra ball.
+- New rank system: 12 different ranks, each with a different icon (by @joinity).
   - Level ball: 0 ELO
   - Net ball: 1050 ELO
   - Safari ball: 1100 ELO
@@ -94,6 +94,11 @@
   - Ultra ball: 1400 ELO
   - Master ball: 1500 ELO
   - Beast ball: 1700 ELO
+- Ranked matches are created for these groups:
+  - Level ball - Net ball: < 1100 ELO
+  - Safari ball - Premier ball: 1100 - 1249 ELO
+  - Quick ball - Superball: 1250 - 1399 ELO
+  - Ultraball - Beast ball:  >1400 ELO
 - ELO, XP and titles after game are now distributed immediately after the player is eliminated and leaves the game, instead of waiting for the game to end
 - PvE rounds no longer give additional income based on victory/defeat streaks
 - Due to an increase of cases of intentional leaves at the start of a game, we have to increase the penalties for early disconnections. Intentional disconnections before stage 6 are no longer protected against Elo loss. Unintentional disconnections without reconnection within the next 3 minutes before stage 6 remain protected against Elo loss, but players won't be able to join a new game within the next 5 minutes.


### PR DESCRIPTION
Ranked matches are created for these groups:
  - Level ball - Net ball: < 1100 ELO
  - Safari ball - Premier ball: 1100 - 1249 ELO
  - Quick ball - Superball: 1250 - 1399 ELO
  - Ultraball - Beast ball:  >1400 ELO

in order to reduce the time required to get a full ranked lobby