### PR TITLE
Set timer before auto-starting matches

### DIFF
--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -621,14 +621,11 @@ export class OnToggleReadyCommand extends Command<
 
 export class CheckAutoStartRoom extends Command<PreparationRoom, void> {
   async execute() {
-    await setTimeout(3000)
+    try {
+      this.state.abortOnPlayerLeave = new AbortController()
+      const signal = this.state.abortOnPlayerLeave.signal
+      await setTimeout(3000, null, { signal })
 
-    const nbExpectedPlayers =
-      this.room.metadata?.whitelist && this.room.metadata?.whitelist.length > 0
-        ? max(MAX_PLAYERS_PER_GAME)(this.room.metadata?.whitelist.length)
-        : MAX_PLAYERS_PER_GAME
-
-    if (this.state.users.size === nbExpectedPlayers) {
       this.room.state.addMessage({
         authorId: "server",
         payload: "Starting match..."
@@ -644,10 +641,9 @@ export class CheckAutoStartRoom extends Command<PreparationRoom, void> {
       }
 
       return new OnGameStartRequestCommand()
-    } else {
+    } catch (e) {
       this.room.state.addMessage({
         authorId: "server",
-        avatar: "0070/Sigh",
         payload: "Waiting for the room to fill up."
       })
     }

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -393,6 +393,7 @@ export default class PreparationRoom extends Room<PreparationState> {
       )*/
     }
     try {
+      this.state.abortOnPlayerLeave?.abort()
       if (consented) {
         throw new Error("consented leave")
       }

--- a/app/rooms/states/preparation-state.ts
+++ b/app/rooms/states/preparation-state.ts
@@ -35,6 +35,7 @@ export default class PreparationState
   @type("boolean") noElo: boolean
   @type(["string"]) whitelist: string[]
   @type(["string"]) blacklist: string[]
+  abortOnPlayerLeave?: AbortController
 
   constructor(params: {
     ownerId?: string


### PR DESCRIPTION
Needs testing.

This pull request aims to resolve an issue where a player joins an auto-start room, then immediately leaves which occasionally causes games to start with the departing player included.