### PR TITLE
Team planner indicator in shop is now animated to be more visible

### DIFF
--- a/app/public/dist/client/changelog/patch-5.9.md
+++ b/app/public/dist/client/changelog/patch-5.9.md
@@ -155,6 +155,7 @@
 
 - Added item components recipe on craftable items tooltip
 - New stat boosts animations
+- Team planner indicator in shop is now animated to be more visible
 
 # Bugfix
 

--- a/app/public/src/pages/component/game/game-pokemon-portrait.css
+++ b/app/public/src/pages/component/game/game-pokemon-portrait.css
@@ -88,6 +88,16 @@
 .game-pokemon-portrait-planned-icon {
   width: 1.4vw;
   height: 1.4vw;
+  animation: rotateY 1s linear infinite;
+}
+
+@keyframes rotateY {
+  0% {
+    transform: rotateY(0deg);
+  }
+  100% {
+    transform: rotateY(360deg);
+  }
 }
 
 .game-pokemon-portrait-duo-part {


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1325178295360421898


https://github.com/user-attachments/assets/334655f0-fcc4-4697-987e-fc2f89d1f5f6


