### PR TITLE
Effect refactor extension: resetStacks, MonsterKillEffect, FireHitEffect

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -1513,39 +1513,15 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     itemEffects.forEach((effect) => {
       effect.apply(this, target, board)
     })
+    this.effectsSet.forEach((effect) => {
+      if (effect instanceof OnKillEffect) {
+        effect.apply(this, target, board)
+      }
+    })
 
     if (this.passive === Passive.SOUL_HEART) {
       this.addPP(10, this, 0, false)
       this.addAbilityPower(10, this, 0, false)
-    }
-
-    if (this.hasSynergyEffect(Synergy.MONSTER)) {
-      const isPursuit = this.effects.has(Effect.PURSUIT)
-      const isBrutalSwing = this.effects.has(Effect.BRUTAL_SWING)
-      const isPowerTrip = this.effects.has(Effect.POWER_TRIP)
-      const isMerciless = this.effects.has(Effect.MERCILESS)
-
-      let lifeBoost = 0,
-        attackBoost = 0,
-        apBoost = 0
-      if (isPursuit) {
-        lifeBoost = Math.round(0.2 * target.hp)
-        attackBoost = 3
-        apBoost = 10
-      } else if (isBrutalSwing) {
-        lifeBoost = Math.round(0.4 * target.hp)
-        attackBoost = 6
-        apBoost = 20
-      } else if (isPowerTrip || isMerciless) {
-        lifeBoost = Math.round(0.6 * target.hp)
-        attackBoost = 10
-        apBoost = 30
-      }
-      if (this.life > 0) {
-        this.addMaxHP(lifeBoost, this, 0, false)
-        this.addAttack(attackBoost, this, 0, false)
-        this.addAbilityPower(apBoost, this, 0, false)
-      }
     }
 
     if (this.passive === Passive.BEAST_BOOST_ATK) {

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -56,7 +56,7 @@ import PokemonState from "./pokemon-state"
 import Simulation from "./simulation"
 import { DelayedCommand, SimulationCommand } from "./simulation-command"
 import { ItemEffects } from "./items"
-import { OnItemRemovedEffect, OnKillEffect, Effect as EffectClass } from "./effect"
+import { OnItemRemovedEffect, OnKillEffect, Effect as EffectClass, OnHitEffect } from "./effect"
 import { getPokemonData } from "../models/precomputed/precomputed-pokemon-data"
 
 export class PokemonEntity extends Schema implements IPokemonEntity {
@@ -989,6 +989,12 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
 
     // Synergy effects on hit
 
+    this.effectsSet.forEach((effect) => {
+      if (effect instanceof OnHitEffect) {
+        effect.apply(this, target, board)
+      }
+    })
+
     const nbIcyRocks =
       this.player && this.simulation.weather === Weather.SNOW
         ? count(this.player.items, Item.ICY_ROCK)
@@ -1007,20 +1013,6 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
       freezeChance += nbIcyRocks * 0.05
       if (chance(freezeChance, this)) {
         target.status.triggerFreeze(2000, target)
-      }
-    }
-
-    if (this.hasSynergyEffect(Synergy.FIRE)) {
-      const burnChance = 0.3
-      if (this.effects.has(Effect.VICTORY_STAR)) {
-        this.addAttack(1, this, 0, false)
-      } else if (this.effects.has(Effect.DROUGHT)) {
-        this.addAttack(2, this, 0, false)
-      } else if (this.effects.has(Effect.DESOLATE_LAND)) {
-        this.addAttack(3, this, 0, false)
-      }
-      if (chance(burnChance, this)) {
-        target.status.triggerBurn(2000, target, this)
       }
     }
 

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -50,7 +50,7 @@ import { PokemonEntity, getStrongestUnit, getUnitScore } from "./pokemon-entity"
 import { DelayedCommand } from "./simulation-command"
 import { getAvatarString } from "../utils/avatar"
 import { max } from "../utils/number"
-import { OnItemGainedEffect, GrowGroundEffect, MonsterKillEffect } from "./effect"
+import { OnItemGainedEffect, GrowGroundEffect, MonsterKillEffect, FireHitEffect } from "./effect"
 
 export default class Simulation extends Schema implements ISimulation {
   @type("string") weather: Weather = Weather.NEUTRAL
@@ -829,26 +829,12 @@ export default class Simulation extends Schema implements ISimulation {
         break
 
       case Effect.BLAZE:
-        if (types.has(Synergy.FIRE)) {
-          pokemon.effects.add(Effect.BLAZE)
-        }
-        break
-
       case Effect.VICTORY_STAR:
-        if (types.has(Synergy.FIRE)) {
-          pokemon.effects.add(Effect.VICTORY_STAR)
-        }
-        break
-
       case Effect.DROUGHT:
-        if (types.has(Synergy.FIRE)) {
-          pokemon.effects.add(Effect.DROUGHT)
-        }
-        break
-
       case Effect.DESOLATE_LAND:
         if (types.has(Synergy.FIRE)) {
-          pokemon.effects.add(Effect.DESOLATE_LAND)
+          pokemon.effects.add(effect)
+          pokemon.effectsSet.add(new FireHitEffect(effect))
         }
         break
 

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -50,7 +50,7 @@ import { PokemonEntity, getStrongestUnit, getUnitScore } from "./pokemon-entity"
 import { DelayedCommand } from "./simulation-command"
 import { getAvatarString } from "../utils/avatar"
 import { max } from "../utils/number"
-import { OnItemGainedEffect, GrowGroundEffect } from "./effect"
+import { OnItemGainedEffect, GrowGroundEffect, MonsterKillEffect } from "./effect"
 
 export default class Simulation extends Schema implements ISimulation {
   @type("string") weather: Weather = Weather.NEUTRAL
@@ -962,6 +962,7 @@ export default class Simulation extends Schema implements ISimulation {
       case Effect.MERCILESS:
         if (types.has(Synergy.MONSTER)) {
           pokemon.effects.add(effect)
+          pokemon.effectsSet.add(new MonsterKillEffect(effect))
         }
         break
 


### PR DESCRIPTION
- Added optional resetStacks method to the base Effect class for use in resurrection
- Added resetStacks method to the GrowGroundEffect class
    - May cause Big Nugget to grant gold twice. Balance decision to be decided. I'm personally ok with this.
- Expanded OnKillEffect to be used with synergy effects
- Refactored Fire and Monster stacking effects (complete with resetStacks)

Next I'm handling Sound, and then item stacks so the resurrect bugs can finally be fixed.