### PR TITLE
GrowGround refactor memory improvement

### DIFF
--- a/app/core/effect.ts
+++ b/app/core/effect.ts
@@ -8,9 +8,11 @@ type EffectOrigin = EffectEnum | Item
 
 export abstract class Effect {
   origin?: EffectOrigin
-  apply: (entity: PokemonEntity, ...others: any[]) => void
-  constructor(effect: (entity: PokemonEntity, ...others: any[]) => void, origin?: EffectOrigin) {
-    this.apply = effect
+  apply(entity: PokemonEntity, ...others: any[]) {}
+  constructor(effect?: (entity: PokemonEntity, ...others: any[]) => void, origin?: EffectOrigin) {
+    if (effect) {
+      this.apply = effect
+    }
     this.origin = origin
   }
 }
@@ -31,15 +33,7 @@ export class OnKillEffect extends Effect {
   }
 }
 
-export abstract class DynamicEffect {
-  origin?: EffectOrigin
-  apply(pokemon: PokemonEntity) {}
-    constructor(origin?: EffectOrigin) {
-      this.origin = origin
-    }
-}
-
-export abstract class PeriodicEffect extends DynamicEffect {
+export abstract class PeriodicEffect extends Effect {
   intervalMs: number
   timer: number
   count: number
@@ -48,7 +42,7 @@ export abstract class PeriodicEffect extends DynamicEffect {
     intervalMs: number,
     origin?: EffectOrigin
   ) {
-    super(origin)
+    super(undefined, origin)
     this.intervalMs = intervalMs
     this.timer = intervalMs
     this.count = 0

--- a/app/core/effect.ts
+++ b/app/core/effect.ts
@@ -20,17 +20,35 @@ export class OnItemGainedEffect extends Effect {}
 
 export class OnItemRemovedEffect extends Effect {}
 
-export class PeriodicEffect extends Effect {
+// applied after knocking out an enemy
+export class OnKillEffect extends Effect {
+  apply: (entity: PokemonEntity, target: PokemonEntity, board: Board) => void
+  constructor(
+    effect: (entity: PokemonEntity, target: PokemonEntity, board: Board) => void
+  ) {
+    super(effect)
+    this.apply = effect
+  }
+}
+
+export abstract class DynamicEffect {
+  origin?: EffectEnum
+  apply(pokemon: PokemonEntity) {}
+    constructor(origin?: EffectEnum) {
+      this.origin = origin
+    }
+}
+
+export abstract class PeriodicEffect extends DynamicEffect {
   intervalMs: number
   timer: number
   count: number
 
   constructor(
-    effect: (entity: PokemonEntity) => void,
     intervalMs: number,
-    origin?: EffectOrigin
+    origin?: EffectEnum
   ) {
-    super(effect, origin)
+    super(origin)
     this.intervalMs = intervalMs
     this.timer = intervalMs
     this.count = 0
@@ -47,36 +65,27 @@ export class PeriodicEffect extends Effect {
 }
 
 export class GrowGroundEffect extends PeriodicEffect {
+  synergyLevel: number
   constructor(effect: EffectEnum) {
-    const synergyLevel = SynergyEffects[Synergy.GROUND].indexOf(effect) + 1
-    super(
-      (pokemon) => {
-        pokemon.addDefense(synergyLevel, pokemon, 0, false)
-        pokemon.addSpecialDefense(synergyLevel, pokemon, 0, false)
-        pokemon.addAttack(synergyLevel, pokemon, 0, false)
-        pokemon.transferAbility("GROUND_GROW")
-        if (
-          pokemon.items.has(Item.BIG_NUGGET) &&
-          this.count === 5 &&
-          pokemon.player
-        ) {
-          pokemon.player.addMoney(3, true, pokemon)
-          pokemon.count.moneyCount += 3
-        }
-      },
-      3000,
-      effect
-    )
+    super(3000, effect)
+    this.synergyLevel = SynergyEffects[Synergy.GROUND].indexOf(effect) + 1
   }
-}
 
-// applied after knocking out an enemy
-export class OnKillEffect extends Effect {
-  apply: (entity: PokemonEntity, target: PokemonEntity, board: Board) => void
-  constructor(
-    effect: (entity: PokemonEntity, target: PokemonEntity, board: Board) => void
-  ) {
-    super(effect)
-    this.apply = effect
+  apply(pokemon) {
+    if (this.count > 5) {
+      return
+    }
+    pokemon.addDefense(this.synergyLevel, pokemon, 0, false)
+    pokemon.addSpecialDefense(this.synergyLevel, pokemon, 0, false)
+    pokemon.addAttack(this.synergyLevel, pokemon, 0, false)
+    pokemon.transferAbility("GROUND_GROW")
+    if (
+      pokemon.items.has(Item.BIG_NUGGET) &&
+      this.count === 5 &&
+      pokemon.player
+    ) {
+      pokemon.player.addMoney(3, true, pokemon)
+      pokemon.count.moneyCount += 3
+    }
   }
 }

--- a/app/core/effect.ts
+++ b/app/core/effect.ts
@@ -32,9 +32,9 @@ export class OnKillEffect extends Effect {
 }
 
 export abstract class DynamicEffect {
-  origin?: EffectEnum
+  origin?: EffectOrigin
   apply(pokemon: PokemonEntity) {}
-    constructor(origin?: EffectEnum) {
+    constructor(origin?: EffectOrigin) {
       this.origin = origin
     }
 }
@@ -46,7 +46,7 @@ export abstract class PeriodicEffect extends DynamicEffect {
 
   constructor(
     intervalMs: number,
-    origin?: EffectEnum
+    origin?: EffectOrigin
   ) {
     super(origin)
     this.intervalMs = intervalMs

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -56,7 +56,7 @@ import PokemonState from "./pokemon-state"
 import Simulation from "./simulation"
 import { DelayedCommand, SimulationCommand } from "./simulation-command"
 import { ItemEffects } from "./items"
-import { OnItemRemovedEffect, OnKillEffect, Effect as EffectClass, DynamicEffect } from "./effect"
+import { OnItemRemovedEffect, OnKillEffect, DynamicEffect } from "./effect"
 import { getPokemonData } from "../models/precomputed/precomputed-pokemon-data"
 
 export class PokemonEntity extends Schema implements IPokemonEntity {

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -56,7 +56,7 @@ import PokemonState from "./pokemon-state"
 import Simulation from "./simulation"
 import { DelayedCommand, SimulationCommand } from "./simulation-command"
 import { ItemEffects } from "./items"
-import { OnItemRemovedEffect, OnKillEffect, DynamicEffect } from "./effect"
+import { OnItemRemovedEffect, OnKillEffect, Effect as EffectClass } from "./effect"
 import { getPokemonData } from "../models/precomputed/precomputed-pokemon-data"
 
 export class PokemonEntity extends Schema implements IPokemonEntity {
@@ -122,7 +122,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   isClone = false
   refToBoardPokemon: IPokemon
   commands = new Array<SimulationCommand>()
-  effectsSet = new Set<DynamicEffect>()
+  effectsSet = new Set<EffectClass>()
 
   constructor(
     pokemon: IPokemon,

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -56,7 +56,7 @@ import PokemonState from "./pokemon-state"
 import Simulation from "./simulation"
 import { DelayedCommand, SimulationCommand } from "./simulation-command"
 import { ItemEffects } from "./items"
-import { OnItemRemovedEffect, OnKillEffect, Effect as EffectClass } from "./effect"
+import { OnItemRemovedEffect, OnKillEffect, Effect as EffectClass, DynamicEffect } from "./effect"
 import { getPokemonData } from "../models/precomputed/precomputed-pokemon-data"
 
 export class PokemonEntity extends Schema implements IPokemonEntity {
@@ -122,7 +122,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   isClone = false
   refToBoardPokemon: IPokemon
   commands = new Array<SimulationCommand>()
-  effectsSet = new Set<EffectClass>()
+  effectsSet = new Set<DynamicEffect>()
 
   constructor(
     pokemon: IPokemon,


### PR DESCRIPTION
apply method is defined in the class itself instead of the constructor, so that multiple instances of the class share the reference to the function in memory
https://discord.com/channels/737230355039387749/1317095176333824041/1328133247389007932