### PR TITLE
Debug roomcaches size for memory leak investigation

### DIFF
--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -622,6 +622,10 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
               this.removeRoom(roomIndex, room.roomId)
             }
           })
+
+          this.presence.hlen("roomcaches").then((n) => {
+            logger.debug(`roomcaches size: ${n}`)
+          })
         },
         start: true
       })


### PR DESCRIPTION
Added a log every minute with roomcaches hash size in Redis presence.

If this number goes up over time, we will have definite confirmation that Redis presence is leaking