### PR TITLE
Effect refactor extension: resetStacks, MonsterKillEffect, FireHitEffect

### DIFF
--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -50,7 +50,7 @@ import { PokemonEntity, getStrongestUnit, getUnitScore } from "./pokemon-entity"
 import { DelayedCommand } from "./simulation-command"
 import { getAvatarString } from "../utils/avatar"
 import { max } from "../utils/number"
-import { OnItemGainedEffect, GrowGroundEffect } from "./effect"
+import { OnItemGainedEffect, GrowGroundEffect, FireHitEffect, MonsterKillEffect } from "./effect"
 
 export default class Simulation extends Schema implements ISimulation {
   @type("string") weather: Weather = Weather.NEUTRAL
@@ -829,26 +829,12 @@ export default class Simulation extends Schema implements ISimulation {
         break
 
       case Effect.BLAZE:
-        if (types.has(Synergy.FIRE)) {
-          pokemon.effects.add(Effect.BLAZE)
-        }
-        break
-
       case Effect.VICTORY_STAR:
-        if (types.has(Synergy.FIRE)) {
-          pokemon.effects.add(Effect.VICTORY_STAR)
-        }
-        break
-
       case Effect.DROUGHT:
-        if (types.has(Synergy.FIRE)) {
-          pokemon.effects.add(Effect.DROUGHT)
-        }
-        break
-
       case Effect.DESOLATE_LAND:
         if (types.has(Synergy.FIRE)) {
-          pokemon.effects.add(Effect.DESOLATE_LAND)
+          pokemon.effects.add(effect)
+          pokemon.effectsSet.add(new FireHitEffect(effect))
         }
         break
 
@@ -962,6 +948,7 @@ export default class Simulation extends Schema implements ISimulation {
       case Effect.MERCILESS:
         if (types.has(Synergy.MONSTER)) {
           pokemon.effects.add(effect)
+          pokemon.effectsSet.add(new MonsterKillEffect(effect))
         }
         break
 


### PR DESCRIPTION
- Added optional resetStacks method to the base Effect class for use in resurrection
- Added resetStacks method to the GrowGroundEffect class
    - May cause Big Nugget to grant gold twice. Balance decision to be decided. I'm personally ok with this.
- Expanded OnKillEffect to be used with synergy effects
- Refactored Fire and Monster stacking effects (complete with resetStacks)