### PR TITLE
disable join button with loading animation

### DIFF
--- a/app/public/src/pages/component/available-room-menu/room-item.tsx
+++ b/app/public/src/pages/component/available-room-menu/room-item.tsx
@@ -1,5 +1,5 @@
 import { RoomAvailable } from "colyseus.js"
-import React from "react"
+import React, { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { IPreparationMetadata } from "../../../../../types"
 import {
@@ -64,6 +64,7 @@ export default function RoomItem(props: {
   }
 
   const title = `${props.room.metadata?.ownerName ? "Owner: " + props.room.metadata?.ownerName : ""}\n${props.room.metadata?.playersInfo?.join("\n")}`
+  const [joining, setJoining] = useState<boolean>(false)
 
   return (
     <div className="room-item my-box">
@@ -121,17 +122,21 @@ export default function RoomItem(props: {
       </span>
       <button
         title={disabledReason ?? t("join")}
-        disabled={!canJoin}
+        disabled={!canJoin || joining}
         className={cc(
           "bubbly",
+          joining ? "loading" : "",
           props.room.metadata?.password ? "orange" : "green"
         )}
         onClick={() => {
           if (
             props.room.clients < nbPlayersExpected &&
-            props.room.metadata?.gameStartedAt === null
+            props.room.metadata?.gameStartedAt === null &&
+            !joining
           ) {
             props.click(props.room)
+            setJoining(true)
+            setTimeout(() => setJoining(false), 5000)
           }
         }}
       >

--- a/app/public/src/style/buttons.css
+++ b/app/public/src/style/buttons.css
@@ -3,6 +3,7 @@ button {
 }
 
 .bubbly {
+  position: relative;
   padding: 0.25em 0.5em;
   background: #e7e7e7;
   display: inline-block;
@@ -142,4 +143,30 @@ button {
   display: inline-block;
   vertical-align: text-top;
   margin-right: 0.25em;
+}
+
+.bubbly.loading::after {
+  content: "";
+  position: absolute;
+  width: 1.5em;
+  height: 1.5em;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: auto;
+  border: 4px solid transparent;
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: button-loading-spinner 1s ease infinite;
+}
+
+@keyframes button-loading-spinner {
+  from {
+    transform: rotate(0turn);
+  }
+
+  to {
+    transform: rotate(1turn);
+  }
 }

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -24,7 +24,6 @@ import { getRank } from "../../utils/elo"
 import { SpecialGameRule } from "../../types/enum/SpecialGameRule"
 import { UserRecord } from "firebase-admin/lib/auth/user-record"
 import { setTimeout } from "node:timers/promises"
-import { AbortError } from "node-fetch"
 
 export class OnJoinCommand extends Command<
   PreparationRoom,
@@ -48,10 +47,10 @@ export class OnJoinCommand extends Command<
         }
       }
 
-      const numberOfHumanPlayers = values(this.state.users).filter(
+      let nbHumanPlayers = values(this.state.users).filter(
         (u) => !u.isBot
       ).length
-      if (numberOfHumanPlayers >= MAX_PLAYERS_PER_GAME) {
+      if (nbHumanPlayers >= MAX_PLAYERS_PER_GAME) {
         client.leave(CloseCodes.ROOM_FULL)
         return
       }
@@ -61,6 +60,7 @@ export class OnJoinCommand extends Command<
       ) {
         this.state.ownerId = auth.uid
       }
+
       if (this.state.users.has(auth.uid)) {
         const user = this.state.users.get(auth.uid)!
         this.state.addMessage({
@@ -70,10 +70,8 @@ export class OnJoinCommand extends Command<
         })
       } else {
         const u = await UserMetadata.findOne({ uid: auth.uid })
-        const numberOfHumanPlayers = values(this.state.users).filter(
-          (u) => !u.isBot
-        ).length
-        if (numberOfHumanPlayers >= MAX_PLAYERS_PER_GAME) {
+        nbHumanPlayers = values(this.state.users).filter((u) => !u.isBot).length // update again the value after the database request
+        if (nbHumanPlayers >= MAX_PLAYERS_PER_GAME) {
           // lobby has been filled with someone else while waiting for the database
           client.leave(CloseCodes.ROOM_FULL)
           return

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -576,7 +576,7 @@ export default class GameRoom extends Room<GameState> {
         throw new Error("consented leave")
       }
 
-      // allow disconnected client to reconnect into this room until 3 minutes
+      // allow disconnected client to reconnect into this room until 5 minutes
       await this.allowReconnection(client, 300)
       const userProfile = await UserMetadata.findOne({ uid: client.auth.uid })
       client.send(Transfer.USER_PROFILE, userProfile)


### PR DESCRIPTION
A player can join twice the same room, in that case we can have several clients but one user, causing lobbies 9/8 players like what happened for semifinals today.

I didnt find how to block several clients joining the same prep room yet, but heres a client side fix in the meantime.

I disable the room join button and add a loading spinner to prevent a player from joining twice by spamming click.

