### PR TITLE
fix champion and elite four member titles not given

### DIFF
--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -1413,10 +1413,10 @@ export class EndTournamentCommand extends Command<
       }
 
       for (const player of finalists) {
-        const mongoUser = await UserMetadata.findOne({ uid: player.id })
-        const user = this.room.users.get(player.id)
         const rank = player.ranks.at(-1) ?? 1
+        const user = this.room.users.get(player.id)
 
+        const mongoUser = await UserMetadata.findOne({ uid: player.id })
         if (mongoUser == null || user == null) continue
 
         mongoUser.booster += 3 // 3 boosters for top 8


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1330311801060987013

i think its due to the async call order