### PR TITLE
Refactor resurrect

### DIFF
--- a/app/core/effect.ts
+++ b/app/core/effect.ts
@@ -57,15 +57,6 @@ export class MonsterKillEffect extends OnKillEffect {
     this.count += 1
   }
 
-  resetStacks(pokemon) {
-    const attackBoost = [3, 6, 10, 10][this.synergyLevel] ?? 10
-    const apBoost = [10, 20, 30, 30][this.synergyLevel] ?? 30
-    pokemon.addAttack(-this.count * attackBoost, pokemon, 0, false)
-    pokemon.addAbilityPower(-this.count * apBoost, pokemon, 0, false)
-    pokemon.addMaxHP(-this.hpBoosted, pokemon, 0, false)
-    this.hpBoosted = 0
-    this.count = 0
-  }
 }
 
 export abstract class PeriodicEffect extends Effect {
@@ -148,11 +139,6 @@ export class FireHitEffect extends OnHitEffect {
     this.count += 1
   }
 
-  resetStacks(pokemon) {
-    const removalAmount = -this.count * this.synergyLevel
-    pokemon.addAttack(removalAmount, pokemon, 0, false)
-    this.count = 0
-  }
 }
 
 export class OnAbilityCastEffect extends Effect {

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -1754,6 +1754,10 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   }
 
   resurrect() {
+    this.life = this.hp
+    this.pp = 0
+    this.status.clearNegativeStatus()
+
     if (this.items.has(Item.SACRED_ASH) && this.player) {
       const team = this.simulation.getTeam(this.player.id)
       if (team) {
@@ -1866,9 +1870,6 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
       resetSoundStacks(soundEffect)
     }
 
-    this.life = this.hp
-    this.pp = 0
-    this.status.clearNegativeStatus()
     this.status.resurection = false // prevent resurrecting again
     this.shield = 0 // remove existing shield
     this.flyingProtection = 0 // prevent flying effects twice

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -58,7 +58,11 @@ import AttackingState from "./attacking-state"
 import Board, { Cell } from "./board"
 import {
   Effect as EffectClass,
+  FireHitEffect,
+  GrowGroundEffect,
+  MonsterKillEffect,
   OnHitEffect,
+  OnItemGainedEffect,
   OnItemRemovedEffect,
   OnKillEffect
 } from "./effect"
@@ -1750,20 +1754,6 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   }
 
   resurrect() {
-    this.life = this.refToBoardPokemon.hp
-    this.shield = 0
-    this.pp = 0
-    this.ap = 0
-    this.atk = this.refToBoardPokemon.atk
-    this.def = this.refToBoardPokemon.def
-    this.speDef = this.refToBoardPokemon.speDef
-    this.atkSpeed = this.refToBoardPokemon.atkSpeed
-    this.critChance = DEFAULT_CRIT_CHANCE
-    this.critPower = DEFAULT_CRIT_POWER
-    this.count = new Count()
-    this.status.clearNegativeStatus()
-    this.effects.clear()
-
     if (this.items.has(Item.SACRED_ASH) && this.player) {
       const team = this.simulation.getTeam(this.player.id)
       if (team) {
@@ -1793,20 +1783,95 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
       }
     }
 
-    this.items.delete(Item.DYNAMAX_BAND)
-    this.items.delete(Item.SACRED_ASH)
-    this.items.delete(Item.MAX_REVIVE)
+    const stackingItems = [
+      Item.DEFENSIVE_RIBBON,
+      Item.SOUL_DEW,
+      Item.UPGRADE
+    ]
 
-    this.simulation.applySynergyEffects(this)
-    this.simulation.applyItemsEffects(this)
-    this.status.resurection = false // prevent reapplying max revive again
-    this.shield = 0 // prevent reapplying shield again
+    const removedItems = [
+      Item.DYNAMAX_BAND,
+      Item.SACRED_ASH,
+      Item.MAX_REVIVE
+    ]
+
+    stackingItems.forEach((item) => {
+      if (this.items.has(item)) {
+        ItemEffects[item]
+          ?.filter((effect) => effect instanceof OnItemRemovedEffect)
+          ?.forEach((effect) => effect.apply(this))
+        ItemEffects[item]
+          ?.filter((effect) => effect instanceof OnItemGainedEffect)
+          ?.forEach((effect) => effect.apply(this))
+      }
+    })
+
+    removedItems.forEach((item) => {
+      if (this.items.has(item)) {
+        this.removeItem(item)
+      }
+    })
+
+    const resetGroundStacks = (effect: GrowGroundEffect) => {
+      const removalAmount = effect.synergyLevel * effect.count
+      this.addDefense(removalAmount, this, 0, false)
+      this.addSpecialDefense(removalAmount, this, 0, false)
+      this.addAttack(removalAmount, this, 0, false)
+      effect.count = 0
+    }
+
+    const resetMonsterStacks = (effect: MonsterKillEffect) => {
+      const attackBoost = [3, 6, 10, 10][effect.synergyLevel] ?? 10
+      const apBoost = [10, 20, 30, 30][effect.synergyLevel] ?? 30
+      this.addAttack(-effect.count * attackBoost, this, 0, false)
+      this.addAbilityPower(-effect.count * apBoost, this, 0, false)
+      this.addMaxHP(-effect.hpBoosted, this, 0, false)
+      effect.hpBoosted = 0
+      effect.count = 0
+    }
+
+    const resetFireStacks = (effect: FireHitEffect) => {
+      const removalAmount = -effect.count * effect.synergyLevel
+      this.addAttack(removalAmount, this, 0, false)
+      effect.count = 0
+    }
+
+    const resetSoundStacks = (effect: Effect) => {
+      const synergyLevel = SynergyEffects[Synergy.SOUND].indexOf(effect)
+      const attackBoost = ([2, 1, 1][synergyLevel] ?? 0) *
+        -this.count.soundCryCount
+      const attackSpeedBoost = ([0, 5, 5][synergyLevel] ?? 0) *
+        -this.count.soundCryCount
+      const manaBoost = ([0, 0, 3][synergyLevel] ?? 0) *
+        -this.count.soundCryCount
+      this.addAttack(attackBoost, this, 0, false)
+      this.addAttackSpeed(attackSpeedBoost, this, 0, false)
+      this.addPP(manaBoost, this, 0, false)
+      this.count.soundCryCount = 0
+    }
+
+    this.effectsSet.forEach((effect) => {
+      if (effect instanceof GrowGroundEffect) {
+        resetGroundStacks(effect)
+      } else if (effect instanceof MonsterKillEffect) {
+        resetMonsterStacks(effect)
+      } else if (effect instanceof FireHitEffect) {
+        resetFireStacks(effect)
+      }
+    })
+    const soundEffect = SynergyEffects[Synergy.SOUND].find((effect) => {
+      this.player?.effects.has(effect)
+    })
+    if (soundEffect) {
+      resetSoundStacks(soundEffect)
+    }
+
+    this.life = this.hp
+    this.pp = 0
+    this.status.clearNegativeStatus()
+    this.status.resurection = false // prevent resurrecting again
+    this.shield = 0 // remove existing shield
     this.flyingProtection = 0 // prevent flying effects twice
-    SynergyEffects[Synergy.FOSSIL].forEach((fossilResurectEffect) =>
-      this.effects.delete(fossilResurectEffect)
-    ) // prevent resurecting fossils twice
-
-    // does not trigger postEffects (iron defense, normal shield, rune protect, focus band, delta orb, flame orb...)
   }
 
   eatBerry(berry: Item, stealedFrom?: PokemonEntity) {


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1317095176333824041/1320421361063034954
> Resurrection remove statuses with some exceptions, i think of enraged, tapu fields, and all the things implemented as statuses but not actual statuses in the game.
Resurrection also reset item and synergy stacks, and their associated stat buffs. This has been decided as a balance measure
the rest shall remain unaffected