### PR TITLE
Fix ghost battles somtimes duplicating abilities

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -226,7 +226,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   }
 
   get isGhostOpponent(): boolean {
-    return this.simulation.isGhostBattle && this.player?.team === Team.RED_TEAM
+    return this.simulation.isGhostBattle && this.team === Team.RED_TEAM
   }
 
   isTargettableBy(


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1306304253362573442/1331781013923303448

isGhostOpponent was checking the team of the player, which wasn't relevant to the ghost simulation. Only if the player happened to be on the red team in their game would it work as expected.