### PR TITLE
cache meta stats

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -11,9 +11,7 @@ import pkg from "../package.json"
 import { initTilemap } from "./core/design"
 import { GameRecord } from "./models/colyseus-models/game-record"
 import DetailledStatistic from "./models/mongo-models/detailled-statistic-v2"
-import ItemsStatistics from "./models/mongo-models/items-statistic"
 import Meta from "./models/mongo-models/meta"
-import PokemonsStatistics from "./models/mongo-models/pokemons-statistic-v2"
 import TitleStatistic from "./models/mongo-models/title-statistic"
 import { PRECOMPUTED_POKEMONS_PER_TYPE } from "./models/precomputed/precomputed-types"
 import AfterGameRoom from "./rooms/after-game-room"
@@ -23,8 +21,8 @@ import PreparationRoom from "./rooms/preparation-room"
 import { getBotData, getBotsList } from "./services/bots"
 import { discordService } from "./services/discord"
 import { getLeaderboard } from "./services/leaderboard"
+import { getMetaItems, getMetaPokemons } from "./services/meta"
 import { pastebinService } from "./services/pastebin"
-import { Title } from "./types"
 import {
   MAX_CONCURRENT_PLAYERS_ON_SERVER,
   MAX_POOL_CONNECTIONS_SIZE,
@@ -186,13 +184,15 @@ export default config({
     })
 
     app.get("/meta/items", async (req, res) => {
-      res.set("Cache-Control", "no-cache")
-      res.send(await ItemsStatistics.find())
+      // Set Cache-Control header for 24 hours (86400 seconds)
+      res.set("Cache-Control", "max-age=86400")
+      res.send(getMetaItems())
     })
 
     app.get("/meta/pokemons", async (req, res) => {
-      res.set("Cache-Control", "no-cache")
-      res.send(await PokemonsStatistics.find())
+      // Set Cache-Control header for 24 hours (86400 seconds)
+      res.set("Cache-Control", "max-age=86400")
+      res.send(getMetaPokemons())
     })
 
     app.get("/tilemap/:map", async (req, res) => {

--- a/app/index.ts
+++ b/app/index.ts
@@ -15,10 +15,13 @@ import app from "./app.config"
 import { initializeMetrics } from "./metrics"
 import { initCronJobs } from "./services/cronjobs"
 import { fetchLeaderboards } from "./services/leaderboard"
+import { fetchMetaReports } from "./services/meta"
 
 async function main() {
   fetchLeaderboards()
   setInterval(() => fetchLeaderboards(), 1000 * 60 * 10) // refresh every 10 minutes
+  fetchMetaReports()
+  setInterval(() => fetchMetaReports(), 1000 * 60 * 60 * 24) // refresh every 24 hours
 
   if (process.env.NODE_APP_INSTANCE) {
     const processNumber = Number(process.env.NODE_APP_INSTANCE || "0")
@@ -44,7 +47,7 @@ function checkLobby() {
     onTick: async () => {
       logger.debug(`Refresh lobby room`)
       const lobbies = await matchMaker.query({ name: "lobby" })
-      if(lobbies.length === 0) {
+      if (lobbies.length === 0) {
         matchMaker.createRoom("lobby", {})
       }
     },

--- a/app/services/meta.ts
+++ b/app/services/meta.ts
@@ -1,0 +1,33 @@
+import ItemsStatistics, {
+  IItemsStatistic
+} from "../models/mongo-models/items-statistic"
+import PokemonsStatistics, {
+  IPokemonsStatisticV2
+} from "../models/mongo-models/pokemons-statistic-v2"
+import { logger } from "../utils/logger"
+
+export function fetchMetaReports() {
+  logger.info("Refreshing meta reports...")
+  return Promise.all([fetchMetaItems(), fetchMetaPokemons()])
+}
+
+let metaItems = new Array<IItemsStatistic>()
+let metaPokemons = new Array<IPokemonsStatisticV2>()
+
+export async function fetchMetaItems() {
+  metaItems = await ItemsStatistics.find()
+  return metaItems
+}
+
+export async function fetchMetaPokemons() {
+  metaPokemons = await PokemonsStatistics.find()
+  return metaPokemons
+}
+
+export function getMetaPokemons() {
+  return metaPokemons
+}
+
+export function getMetaItems() {
+  return metaItems
+}


### PR DESCRIPTION
store meta stats in memory and fetch every 24 hours instead of reading the database every time

also change the cache-control header to ask browser to cache for 24 hours