### PR TITLE
throttle refresh key to min 300ms between two calls

### DIFF
--- a/app/public/dist/client/changelog/patch-5.10.md
+++ b/app/public/dist/client/changelog/patch-5.10.md
@@ -79,4 +79,5 @@
 # Misc
 
 - Increased allowed game reconnection time from 3 minutes to 5 minutes
+- Refresh key shortcut is now throttled to minimum 300ms before the next refresh, to prevent accidental double refresh
 - New title: Annihilator: get an Annihilape

--- a/app/public/src/game/scenes/game-scene.ts
+++ b/app/public/src/game/scenes/game-scene.ts
@@ -21,6 +21,7 @@ import {
 import { GamePhaseState } from "../../../../types/enum/Game"
 import { Item, ItemRecipe } from "../../../../types/enum/Item"
 import { Pkm } from "../../../../types/enum/Pokemon"
+import { throttle } from "../../../../utils/function"
 import { logger } from "../../../../utils/logger"
 import { values } from "../../../../utils/schemas"
 import { clearTitleNotificationIcon } from "../../../../utils/window"
@@ -176,10 +177,10 @@ export default class GameScene extends Scene {
     this.input.keyboard!.removeAllListeners()
     this.input.keyboard!.on(
       "keydown-" + preferences.keybindings.refresh,
-      () => {
+      throttle(() => {
         playSound(SOUNDS.REFRESH, 0.5)
         this.refreshShop()
-      }
+      }, 300)
     )
 
     this.input.keyboard!.on("keydown-" + preferences.keybindings.lock, () => {


### PR DESCRIPTION
Refresh key shortcut is now throttled to minimum 300ms before the next refresh, to prevent accidental double refresh