### PR TITLE
Banned info in UserMetadata

### DIFF
--- a/app/models/mongo-models/user-metadata.ts
+++ b/app/models/mongo-models/user-metadata.ts
@@ -17,6 +17,7 @@ export interface IUserMetadata {
   titles: Title[]
   title: "" | Title
   role: Role
+  banned?: boolean
 }
 
 export interface IPokemonConfig {
@@ -70,6 +71,10 @@ const userMetadataSchema = new Schema({
     type: String,
     enum: Role,
     default: Role.BASIC
+  },
+  banned: {
+    type: Boolean,
+    default: false
   },
   titles: [
     {

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -3030,6 +3030,7 @@
   "anonymous_users_name_hint": "Anonymous users cannot change their name.",
   "give_boosters": "Give boosters",
   "heap_snapshot": "Write heap snapshot",
+  "banned": "Banned",
   "ban_user": "Ban User",
   "unban_user": "Unban User",
   "set_moderator": "Set Moderator",

--- a/app/public/src/pages/component/leaderboard/leaderboard-menu.css
+++ b/app/public/src/pages/component/leaderboard/leaderboard-menu.css
@@ -79,6 +79,10 @@ ul.titles > li.selected p {
   padding: 5px;
 }
 
+.search-suggestions .player.my-box.banned {
+  color: red;
+}
+
 .search-suggestions .player.my-box img {
   width: 40px;
   height: 40px;

--- a/app/public/src/pages/component/profile/player-box.tsx
+++ b/app/public/src/pages/component/profile/player-box.tsx
@@ -64,6 +64,7 @@ export default function PlayerBox(props: { user: IUserMetadata, history?: IGameR
             <p className="player-title">{t(`title.${props.user.title}`)}</p>
           )}
           <RoleBadge role={props.user.role} />
+          {props.user.banned && <div className="badge banned">{t("banned")}</div>}
           <p
             style={{
               overflow: "hidden",

--- a/app/public/src/pages/component/profile/profile.tsx
+++ b/app/public/src/pages/component/profile/profile.tsx
@@ -221,8 +221,7 @@ function OtherProfileActions({ resetSearch }) {
       {heapSnapshotButton}
       {roleButton}
       {titleButton}
-      {banButton}
-      {unbanButton}
+      {user?.banned ? unbanButton : banButton}
       <button className="bubbly blue" onClick={resetSearch}>
         {t("back_to_my_profile")}
       </button>

--- a/app/public/src/pages/component/profile/role-badge.css
+++ b/app/public/src/pages/component/profile/role-badge.css
@@ -1,27 +1,30 @@
 .badge {
-    display: inline-block;
-    padding: .25em .4em;
-    font-size: 75%;
-    font-weight: 700;
-    line-height: 1;
-    text-align: center;
-    white-space: nowrap;
-    vertical-align: baseline;
-    border-radius: .25rem;
+  display: inline-block;
+  padding: .25em .4em;
+  font-size: 75%;
+  font-weight: 700;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25rem;
 }
 
 .badge.admin {
-    background-color: #28a745;
+  background-color: #28a745;
 }
 .badge.moderator {
-    background-color: #007bff;
+  background-color: #007bff;
 }
 .badge.basic {
-    background-color: #6c757d;
+  background-color: #6c757d;
 }
 .badge.bot {
-    background-color: #6c757d;
+  background-color: #6c757d;
 }
 .badge.bot-manager {
-    background-color: #dc3545;
+  background-color: #dc3545;
+}
+.badge.banned {
+  background-color: red;
 }

--- a/app/public/src/pages/component/profile/search-results.tsx
+++ b/app/public/src/pages/component/profile/search-results.tsx
@@ -3,18 +3,20 @@ import { useTranslation } from "react-i18next"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { searchById } from "../../../stores/NetworkStore"
 import { getAvatarSrc } from "../../../../../utils/avatar"
+import { cc } from "../../utils/jsx"
 
 export default function SearchResults() {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const suggestions = useAppSelector((state) => state.lobby.suggestions)
+  console.log({ suggestions })
 
   return (
     <div>
       <ul className="search-suggestions">
         {suggestions.map((suggestion) => (
           <li
-            className="player my-box clickable"
+            className={cc("player my-box clickable", { banned: suggestion.banned === true })}
             key={suggestion.id}
             onClick={(e) => {
               dispatch(searchById(suggestion.id))

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -11,7 +11,6 @@ import { CronJob } from "cron"
 import admin from "firebase-admin"
 import Message from "../models/colyseus-models/message"
 import { TournamentSchema } from "../models/colyseus-models/tournament"
-import BannedUser from "../models/mongo-models/banned-user"
 import { IBot } from "../models/mongo-models/bot-v2"
 import ChatV2 from "../models/mongo-models/chat-v2"
 import Tournament from "../models/mongo-models/tournament"
@@ -427,10 +426,8 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
 
   async onJoin(client: Client, options: any, auth: any) {
     const user = await UserMetadata.findOne({ uid: client.auth.uid })
-    const isBanned = await BannedUser.findOne({ uid: client.auth.uid })
-
     try {
-      if (isBanned) {
+      if (user?.banned) {
         throw new Error("Account banned")
       } else if (
         (this.state.ccu > MAX_CONCURRENT_PLAYERS_ON_SERVER ||

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -8,7 +8,6 @@ import { MiniGame } from "../core/matter/mini-game"
 import { IGameUser } from "../models/colyseus-models/game-user"
 import Player from "../models/colyseus-models/player"
 import { Pokemon } from "../models/colyseus-models/pokemon"
-import BannedUser from "../models/mongo-models/banned-user"
 import { BotV2 } from "../models/mongo-models/bot-v2"
 import DetailledStatistic from "../models/mongo-models/detailled-statistic-v2"
 import History from "../models/mongo-models/history"
@@ -556,13 +555,10 @@ export default class GameRoom extends Room<GameState> {
   }
 
   async onJoin(client: Client) {
-    const isBanned = await BannedUser.findOne({ uid: client.auth.uid })
-
-    if (isBanned) {
+    const userProfile = await UserMetadata.findOne({ uid: client.auth.uid })
+    if (userProfile?.banned) {
       throw "Account banned"
     }
-
-    const userProfile = await UserMetadata.findOne({ uid: client.auth.uid })
     client.send(Transfer.USER_PROFILE, userProfile)
     this.dispatcher.dispatch(new OnJoinCommand(), { client })
   }

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -1,7 +1,6 @@
 import { Dispatcher } from "@colyseus/command"
 import { Client, ClientArray, Room, updateLobby } from "colyseus"
 import admin from "firebase-admin"
-import BannedUser from "../models/mongo-models/banned-user"
 import { IBot } from "../models/mongo-models/bot-v2"
 import UserMetadata from "../models/mongo-models/user-metadata"
 import { IPreparationMetadata, Transfer } from "../types"
@@ -349,7 +348,6 @@ export default class PreparationRoom extends Room<PreparationState> {
     try {
       const token = await admin.auth().verifyIdToken(options.idToken)
       const user = await admin.auth().getUser(token.uid)
-      const isBanned = await BannedUser.findOne({ uid: user.uid })
       const userProfile = await UserMetadata.findOne({ uid: user.uid })
       client.send(Transfer.USER_PROFILE, userProfile)
 
@@ -366,7 +364,7 @@ export default class PreparationRoom extends Room<PreparationState> {
         throw "Game already started"
       } else if (!user.displayName) {
         throw "No display name"
-      } else if (isBanned) {
+      } else if (userProfile?.banned) {
         throw "User banned"
       } else if (this.metadata.blacklist.includes(user.uid)) {
         throw "User previously kicked"

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -699,6 +699,7 @@ export interface ISuggestionUser {
   level: number
   id: string
   avatar: string
+  banned?: boolean
 }
 
 export enum Title {

--- a/db-commands/5.10/migrate-banned-flag.ts
+++ b/db-commands/5.10/migrate-banned-flag.ts
@@ -1,0 +1,37 @@
+import dotenv from "dotenv"
+import { connect } from "mongoose"
+import userMetadata from "../../app/models/mongo-models/user-metadata"
+import BannedUser from "../../app/models/mongo-models/banned-user"
+import { logger } from "../../app/utils/logger"
+
+/* Move BannedUser to a banned optional boolean in UserMetadata */
+async function main() {
+  dotenv.config()
+
+  try {
+    logger.info("connect to db ...", process.env.MONGO_URI!)
+    const db = await connect(process.env.MONGO_URI!)
+
+    const bannedList = await BannedUser.find({})
+    const bannedUids = bannedList.map((banned) => banned.uid)
+    logger.info("Banned UIDs:", bannedUids)
+
+    logger.info("migrate banned flag ...")
+    const res = await userMetadata.updateMany(
+      { uid: { $in: bannedUids } },
+      { banned: true }
+    )
+    logger.info(
+      `${res.matchedCount} users matched, ${res.modifiedCount} modified`
+    )
+    logger.info(
+      `BannedUser collection should be removed manually after checking if migration was successful`
+    )
+
+    await db.disconnect()
+  } catch (e) {
+    logger.error("Parsing error:", e)
+  }
+}
+
+main()


### PR DESCRIPTION
🔨Require a database migration script to be run

Replace BannedUser collection by a `banned` boolean in UserMetadata

Hide banned accounts in search results. They are still visible to moderators that can now immediately see the ban status

![chrome_23g2q00YS8](https://github.com/user-attachments/assets/044d4a92-577e-47f2-a9a3-7eead2df56ee)
![chrome_CVbNwbqoBc](https://github.com/user-attachments/assets/2e2adf60-09b3-4ffd-976a-f2101d8e69a0)
