### PR TITLE
Fix Kleavor holding Black Augurite

### DIFF
--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -595,6 +595,10 @@ export class Kleavor extends Pokemon {
   range = 1
   skill = Ability.STONE_AXE
   attackSprite = AttackSprite.ROCK_MELEE
+  
+  onAcquired(player: Player): void {
+    this.items.delete(Item.BLACK_AUGURITE) // black augurite is not a held item, but is needed for evolution
+  }
 }
 
 export class Bounsweet extends Pokemon {

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -560,7 +560,6 @@ export class OnDragDropItemCommand extends Command<
     if (item === Item.BLACK_AUGURITE && pokemon.passive === Passive.SCYTHER) {
       pokemon.items.add(item) // add the item just in time for the evolution
       pokemon.evolutionRule.tryEvolve(pokemon, player, this.state.stageLevel)
-      pokemon.items.delete(item) // retrieve the item, black augurite is not a held item
     }
 
     if (TMs.includes(item) || HMs.includes(item)) {


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1334034810494255206

The `pokemon` pointer wasn't updated, so it still referred to Scyther when the item was attempted to be deleted.