### PR TITLE
keep reconnection token when clicking no on reconnection prompt

### DIFF
--- a/app/public/src/pages/lobby.tsx
+++ b/app/public/src/pages/lobby.tsx
@@ -76,7 +76,6 @@ export default function Lobby() {
               className="bubbly red"
               onClick={() => {
                 setGameToReconnect(null)
-                localStore.delete(LocalStoreKeys.RECONNECTION_GAME)
               }}
             >
               {t("no")}


### PR DESCRIPTION
This was causing confusion when players open another browser tab and click "No" on the reconnection prompt while continuing to play on their other tab. If they reload the game tab, having no reconnection token means they are unable to join back the game.

I changed it so the reconnection token is not removed. This means players will always get the reconnection modal every time they load a PAC webpage following the next 60 minutes after game start.

https://discord.com/channels/737230355039387749/1334228861415854160