### PR TITLE
Effect refactor: Water Spring

### DIFF
--- a/app/core/abilities/ability-strategy.ts
+++ b/app/core/abilities/ability-strategy.ts
@@ -43,23 +43,6 @@ export class AbilityStrategy {
       }
     })
 
-    board.forEach((x, y, pkm) => {
-      if (
-        pkm?.passive === Passive.WATER_SPRING &&
-        pkm &&
-        pkm.team !== pokemon.team &&
-        pkm.id !== pokemon.id
-      ) {
-        pkm.addPP(5, pkm, 0, false)
-        pkm.simulation.room.broadcast(Transfer.ABILITY, {
-          id: pokemon.simulation.id,
-          skill: pkm.skill,
-          positionX: pkm.positionX,
-          positionY: pkm.positionY
-        })
-      }
-    })
-
     if (pokemon.items.has(Item.AQUA_EGG)) {
       pokemon.addPP(20, pokemon, 0, false)
     }

--- a/app/core/effect.ts
+++ b/app/core/effect.ts
@@ -199,3 +199,17 @@ export class SoundCryEffect extends OnAbilityCastEffect {
     })
   }
 }
+
+export class WaterSpringEffect extends OnAbilityCastEffect {
+  apply(pokemon) {
+    pokemon.simulation.board.forEach((x, y, pkm) => {
+      if (
+        pkm?.passive === Passive.WATER_SPRING &&
+        pkm.team !== pokemon.team
+      ) {
+        pkm.addPP(5, pkm, 0, false)
+        pkm.transferAbility(pkm.skill)
+      }
+    })
+  }
+}

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -50,7 +50,7 @@ import { PokemonEntity, getStrongestUnit, getUnitScore } from "./pokemon-entity"
 import { DelayedCommand } from "./simulation-command"
 import { getAvatarString } from "../utils/avatar"
 import { max } from "../utils/number"
-import { OnItemGainedEffect, GrowGroundEffect, FireHitEffect, MonsterKillEffect, SoundCryEffect} from "./effect"
+import { OnItemGainedEffect, GrowGroundEffect, FireHitEffect, MonsterKillEffect, SoundCryEffect, WaterSpringEffect} from "./effect"
 
 export default class Simulation extends Schema implements ISimulation {
   @type("string") weather: Weather = Weather.NEUTRAL
@@ -1309,6 +1309,11 @@ export default class Simulation extends Schema implements ISimulation {
       case Effect.BAD_LUCK: {
         pokemon.effects.add(effect)
         pokemon.addLuck(-20, pokemon, 0, false)
+        break
+      }
+
+      case Effect.WATER_SPRING: {
+        pokemon.effectsSet.add(new WaterSpringEffect())
         break
       }
 

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -3637,6 +3637,10 @@ export class Mudkip extends Pokemon {
   skill = Ability.MUD_BUBBLE
   passive = Passive.WATER_SPRING
   attackSprite = AttackSprite.WATER_MELEE
+
+  beforeSimulationStart({opponentEffects}: {opponentEffects: Set<Effect> }): void {
+    opponentEffects.add(Effect.WATER_SPRING)
+  }
 }
 
 export class Marshtomp extends Pokemon {
@@ -3653,6 +3657,10 @@ export class Marshtomp extends Pokemon {
   skill = Ability.MUD_BUBBLE
   passive = Passive.WATER_SPRING
   attackSprite = AttackSprite.WATER_MELEE
+
+  beforeSimulationStart({opponentEffects}: {opponentEffects: Set<Effect> }): void {
+    opponentEffects.add(Effect.WATER_SPRING)
+  }
 }
 
 export class Swampert extends Pokemon {
@@ -3668,6 +3676,10 @@ export class Swampert extends Pokemon {
   skill = Ability.MUD_BUBBLE
   passive = Passive.WATER_SPRING
   attackSprite = AttackSprite.WATER_MELEE
+
+  beforeSimulationStart({opponentEffects}: {opponentEffects: Set<Effect> }): void {
+    opponentEffects.add(Effect.WATER_SPRING)
+  }
 }
 
 export class Torchic extends Pokemon {

--- a/app/types/enum/Effect.ts
+++ b/app/types/enum/Effect.ts
@@ -142,7 +142,8 @@ export enum Effect {
   GOOD_LUCK = "GOOD_LUCK",
   BAD_LUCK = "BAD_LUCK",
   WONDER_ROOM = "WONDER_ROOM",
-  OBSTRUCT = "OBSTRUCT"
+  OBSTRUCT = "OBSTRUCT",
+  WATER_SPRING = "WATER_SPRING"
 }
 
 export const BoardEffects = [


### PR DESCRIPTION
Prevent checking every cell of the board every time a pokemon casts.
Now only checks when a pokemon from the Mudkip line is in play on the opposing team.