### PR TITLE
Fix immobile and untargetable pokemon caused by healing after death

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -621,10 +621,12 @@ export default abstract class PokemonState {
           effectsRemovedList.forEach((x) =>
             pokemon.simulation.blueEffects.delete(x)
           )
+          pokemon.simulation.blueTeam.delete(pokemon.id)
         } else {
           effectsRemovedList.forEach((x) =>
             pokemon.simulation.redEffects.delete(x)
           )
+          pokemon.simulation.redTeam.delete(pokemon.id)
         }
       }
     }

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -1377,15 +1377,7 @@ export default class Simulation extends Schema implements ISimulation {
           pkm.shieldDone
         )
 
-      if (
-        (!pkm.life || pkm.life <= 0) &&
-        !pkm.status.resurecting &&
-        !pkm.status.resurection
-      ) {
-        this.blueTeam.delete(key)
-      } else {
-        pkm.update(dt, this.board, this.weather, this.bluePlayer)
-      }
+      pkm.update(dt, this.board, this.weather, this.bluePlayer)
     })
 
     this.redTeam.forEach((pkm, key) => {
@@ -1402,15 +1394,7 @@ export default class Simulation extends Schema implements ISimulation {
           pkm.shieldDone
         )
 
-      if (
-        (!pkm.life || pkm.life <= 0) &&
-        !pkm.status.resurecting &&
-        !pkm.status.resurection
-      ) {
-        this.redTeam.delete(key)
-      } else {
-        pkm.update(dt, this.board, this.weather, this.redPlayer)
-      }
+      pkm.update(dt, this.board, this.weather, this.redPlayer)
     })
 
     if (this.weather === Weather.STORM) {


### PR DESCRIPTION
Changes pokemon to be deleted from the team map at the same time as they are deleted from the board.
https://discord.com/channels/737230355039387749/1330545617109516298