### PR TITLE
remove timeout penalty for bot games

### DIFF
--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -583,7 +583,10 @@ export default class GameRoom extends Room<GameState> {
         const player = this.state.players.get(client.auth.uid)
         const hasLeftGameBeforeTheEnd =
           player && player.life > 0 && !this.state.gameFinished
-        if (hasLeftGameBeforeTheEnd) {
+        const otherHumans = values(this.state.players).filter(
+          (p) => !p.isBot && p.id !== client.auth.uid
+        )
+        if (hasLeftGameBeforeTheEnd && otherHumans.length >= 1) {
           /* if a user leaves a game before the end, 
           they cannot join another in the next 5 minutes */
           this.presence.hset(


### PR DESCRIPTION
Bot games are automatically removed when no human player remains, so it doesnt make sense to set the 5 minute cooldown in that case