### PR TITLE
Move the fire synergy effect from onHit to onAttack

### DIFF
--- a/app/core/effect.ts
+++ b/app/core/effect.ts
@@ -121,7 +121,17 @@ export class OnHitEffect extends Effect {
   }
 }
 
-export class FireHitEffect extends OnHitEffect {
+export class OnAttackEffect extends Effect {
+  apply(entity: PokemonEntity, target: PokemonEntity, board: Board) {}
+  constructor(
+    effect?: (entity: PokemonEntity, target: PokemonEntity, board: Board) => void,
+    origin?: EffectOrigin
+  ) {
+    super(effect, origin)
+  }
+}
+
+export class FireHitEffect extends OnAttackEffect {
   count: number = 0
   synergyLevel: number
   constructor(
@@ -132,11 +142,7 @@ export class FireHitEffect extends OnHitEffect {
   }
 
   apply(pokemon, target, board) {
-    const burnChance = 0.3
     pokemon.addAttack(this.synergyLevel, pokemon, 0, false)
-    if (chance(burnChance, pokemon)) {
-      target.status.triggerBurn(2000, target, pokemon)
-    }
     this.count += 1
   }
 

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -61,6 +61,7 @@ import {
   FireHitEffect,
   GrowGroundEffect,
   MonsterKillEffect,
+  OnAttackEffect,
   OnHitEffect,
   OnItemGainedEffect,
   OnItemRemovedEffect,
@@ -724,6 +725,12 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   }) {
     this.addPP(ON_ATTACK_MANA, this, 0, false)
 
+    this.effectsSet.forEach((effect) => {
+      if (effect instanceof OnAttackEffect) {
+        effect.apply(this, target, board)
+      }
+    })
+
     if (this.items.has(Item.BLUE_ORB)) {
       this.count.staticHolderCount++
       if (this.count.staticHolderCount > 2) {
@@ -1056,6 +1063,13 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
       freezeChance += nbIcyRocks * 0.05
       if (chance(freezeChance, this)) {
         target.status.triggerFreeze(2000, target)
+      }
+    }
+
+    if (this.hasSynergyEffect(Synergy.FIRE)) {
+      const burnChance = 0.3
+      if (chance(burnChance, this)) {
+        target.status.triggerBurn(2000, target, this)
       }
     }
 

--- a/app/public/dist/client/changelog/patch-5.10.md
+++ b/app/public/dist/client/changelog/patch-5.10.md
@@ -63,6 +63,7 @@
 
 - Nerf Field speed boost: ~~20/25/30%~~ → 15/20/25%
 - Nerf Grass 3 healing: ~~7~~ → 5 HP every 2 seconds
+- Fire attack bonus is now on-attack and no longer on-hit. That means it will trigger even if the attack is dodged or blocked.
 
 # Changes to Items
 


### PR DESCRIPTION
Prevents Choice Scarf from granting double stacks

https://discord.com/channels/737230355039387749/737244224688226346/1336253952798232656