### PR TITLE
Hotfix getNearestAvailablePlaceCoordinates

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -1023,7 +1023,7 @@ export default abstract class PokemonState {
       const distance = distanceM(pokemon.positionX, pokemon.positionY, x, y)
       if (
         value === undefined &&
-        (maxRange === undefined || distance >= maxRange)
+        (maxRange === undefined || distance <= maxRange)
       ) {
         if (distance < minDistance) {
           candidateCells = [{ x, y, value }]


### PR DESCRIPTION
maxRange was implemented as a minimum instead of a maximum

Hotfix because there are pending hotfixes merged. Will change to master if requested.