### PR TITLE
Refresh shop ui with onChangePosition for position based evolutions

### DIFF
--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -539,6 +539,10 @@ export default class Player extends Schema implements IPlayer {
       }
     })
   }
+
+  refreshShopUI() {
+    this.shop = new ArraySchema<Pkm>(...this.shop)
+  }
 }
 
 function pickRandomTMs() {

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -1942,6 +1942,10 @@ export class Poliwhirl extends Pokemon {
       }
     }
   )
+
+  onChangePosition(x: number, y: number, player: Player): void {
+    player.refreshShopUI()
+  }
 }
 
 export class Politoed extends Pokemon {
@@ -7258,6 +7262,10 @@ export class Clamperl extends Pokemon {
       }
     }
   )
+
+  onChangePosition(x: number, y: number, player: Player): void {
+    player.refreshShopUI()
+  }
 }
 
 export class Gorebyss extends Pokemon {


### PR DESCRIPTION
We can force Redux to update the shop (`GameStore`) by reassigning the data to a new reference. Performance impact should be minimal since the ArraySchema is very small, but I'm open to alternative suggestions.
https://discord.com/channels/737230355039387749/737244224688226346/1337557775181676544