### PR TITLE
Prevent out of bounds drag drop exploit

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1,4 +1,4 @@
- import { Command } from "@colyseus/command"
+import { Command } from "@colyseus/command"
 import { Client, updateLobby } from "colyseus"
 import { nanoid } from "nanoid"
 
@@ -35,7 +35,9 @@ import {
   PORTAL_CAROUSEL_BASE_DURATION,
   PortalCarouselStages,
   StageDuration,
-  SynergyTriggers
+  SynergyTriggers,
+  BOARD_WIDTH,
+  BOARD_SIDE_HEIGHT
 } from "../../types/Config"
 import { Effect } from "../../types/enum/Effect"
 import { BattleResult, GamePhaseState, Team } from "../../types/enum/Game"
@@ -233,11 +235,15 @@ export class OnDragDropCommand extends Command<
       message.updateItems = false
       const pokemon = player.board.get(detail.id)
       const { x, y } = detail
-      
+
       if (
         pokemon &&
-        x != null && x >= 0 && x <= 7 &&
-        y != null && y >= 0 && y <= 4
+        x != null &&
+        x >= 0 &&
+        x < BOARD_WIDTH &&
+        y != null &&
+        y >= 0 &&
+        y < BOARD_SIDE_HEIGHT
       ) {
         const dropOnBench = y == 0
         const dropFromBench = isOnBench(pokemon)

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1,4 +1,4 @@
-import { Command } from "@colyseus/command"
+ import { Command } from "@colyseus/command"
 import { Client, updateLobby } from "colyseus"
 import { nanoid } from "nanoid"
 
@@ -236,7 +236,7 @@ export class OnDragDropCommand extends Command<
       
       if (
         pokemon &&
-        x != null && x >= 0 && x <= 7
+        x != null && x >= 0 && x <= 7 &&
         y != null && y >= 0 && y <= 4
       ) {
         const dropOnBench = y == 0

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -232,8 +232,13 @@ export class OnDragDropCommand extends Command<
     if (player) {
       message.updateItems = false
       const pokemon = player.board.get(detail.id)
-      if (pokemon) {
-        const { x, y } = detail
+      const { x, y } = detail
+      
+      if (
+        pokemon &&
+        x != null && x >= 0 && x <= 7
+        y != null && y >= 0 && y <= 4
+      ) {
         const dropOnBench = y == 0
         const dropFromBench = isOnBench(pokemon)
 

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -12,6 +12,7 @@ export const SCOPE_LENS_MANA = 15
 export const ARMOR_FACTOR = 0.1
 export const BOARD_WIDTH = 8
 export const BOARD_HEIGHT = 6
+export const BOARD_SIDE_HEIGHT = 4 // 0 = bench
 
 export const RarityHpCost: { [key in Rarity]: number } = Object.freeze({
   [Rarity.COMMON]: 1,


### PR DESCRIPTION
Add checks to make sure drag drop target is within the board. Prevents abuses where a pokemon can start on the opponent's side of the board, or a pokemon can be placed out of bounds (making them untargetable, but still able to attack opponents)

https://discord.com/channels/737230355039387749/1337590750451470438