### PR TITLE
Add antialiasing support, refactor preferences a little bit

### DIFF
--- a/app/public/dist/client/locales/de/translation.json
+++ b/app/public/dist/client/locales/de/translation.json
@@ -2919,6 +2919,7 @@
   "show_details_on_hover": "Die Details werden angezeigt, wenn du mit der Maus darüber fährst, anstatt mit der rechten Maustaste zu klicken",
   "show_damage_numbers": "Zeige Schadens Nummern an",
   "disable_animated_tilemap": "Deaktiviere Hintergrund Animationen",
+  "antialiasing": "Aktiviere anti-aliasing",
   "save": "Speichern",
   "passive": "Passiv",
   "pick_additional_pokemon_hint": "Wähle ein zusätzliches Pokémon. Es wird für alle verfügbar sein.",

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -2996,6 +2996,7 @@
   "show_details_on_hover": "Show details on hover instead of right click",
   "show_damage_numbers": "Show damage numbers",
   "disable_animated_tilemap": "Disable background animations",
+  "antialiasing": "Enable anti-aliasing",
   "save": "Save",
   "reset": "Reset",
   "snapshot": "Snapshot",

--- a/app/public/dist/client/locales/es/translation.json
+++ b/app/public/dist/client/locales/es/translation.json
@@ -2950,6 +2950,7 @@
   "show_details_on_hover": "Mostrar detalles al pasar el mouse en lugar de hacer clic con el botón derecho",
   "show_damage_numbers": "Mostrar números de daños",
   "disable_animated_tilemap": "Deshabilitar la animación para el mapa de mosaicos (fondo)",
+  "antialiasing": "Activar anti-aliasing",
   "save": "Ahorrar",
   "reset": "Reiniciar",
   "snapshot": "Snapshot",

--- a/app/public/dist/client/locales/fr/translation.json
+++ b/app/public/dist/client/locales/fr/translation.json
@@ -2989,6 +2989,7 @@
   "show_details_on_hover": "Afficher les détails au survol au lieu du clic droit",
   "show_damage_numbers": "Afficher les nombres de dégâts des coups",
   "disable_animated_tilemap": "Désactiver les animations en arrière-plan",
+  "antialiasing": "Afficher l'anticrénelage",
   "save": "Sauvegarder",
   "reset": "Réinitialiser",
   "snapshot": "Copier l'équipe actuelle",

--- a/app/public/dist/client/locales/it/translation.json
+++ b/app/public/dist/client/locales/it/translation.json
@@ -2857,6 +2857,7 @@
   "show_details_on_hover": "Mostra i dettagli al passaggio del mouse invece che con il clic destro",
   "show_damage_numbers": "Mostra valore dei danni",
   "disable_animated_tilemap": "Disabilita animazioni in background",
+  "antialiasing": "Attiva l'antialiasing",
   "save": "Salva",
   "reset": "Reset",
   "snapshot": "Snapshot",

--- a/app/public/src/game/components/emote-menu.css
+++ b/app/public/src/game/components/emote-menu.css
@@ -15,7 +15,6 @@
 .emote-menu li img {
   width: 80px;
   height: 80px;
-  image-rendering: pixelated;
   border: 1px solid #000000;
   border-radius: 4px;
   box-shadow: 2px 2px #00000060;

--- a/app/public/src/game/components/emote-menu.tsx
+++ b/app/public/src/game/components/emote-menu.tsx
@@ -11,6 +11,7 @@ import store from "../../stores"
 import { getPortraitSrc } from "../../../../utils/avatar"
 import GameScene from "../scenes/game-scene"
 import "./emote-menu.css"
+import { usePreference } from "../../preferences"
 
 export function EmoteMenuComponent(props: {
   player: IPlayer
@@ -18,6 +19,7 @@ export function EmoteMenuComponent(props: {
   shiny: boolean
   sendEmote: (emotion: Emotion) => void
 }) {
+  const [antialiasing] = usePreference('antialiasing')
   const { t } = useTranslation()
   const emotions: Emotion[] = AvatarEmotions.filter((emotion) => {
     const indexEmotion = Object.values(Emotion).indexOf(emotion)
@@ -44,7 +46,10 @@ export function EmoteMenuComponent(props: {
             <img
               src={getPortraitSrc(props.index, props.shiny, emotion)}
               title={emotion + (!unlocked ? " (locked)" : "")}
-              className={cc({ locked: !unlocked })}
+              className={cc({
+                locked: !unlocked,
+                pixelated: !antialiasing
+              })}
               onClick={() => unlocked && props.sendEmote(emotion)}
             />
             <span className="counter">{i + 1}</span>

--- a/app/public/src/game/components/item-container.ts
+++ b/app/public/src/game/components/item-container.ts
@@ -10,7 +10,7 @@ import {
   WeatherRocks
 } from "../../../../types/enum/Item"
 import { getGameScene } from "../../pages/game"
-import { preferences } from "../../preferences"
+import { preference } from "../../preferences"
 import DraggableObject from "./draggable-object"
 import ItemDetail from "./item-detail"
 import ItemsContainer from "./items-container"
@@ -90,7 +90,7 @@ export default class ItemContainer extends DraggableObject {
 
   onPointerOver(pointer) {
     super.onPointerOver(pointer)
-    if (preferences.showDetailsOnHover && !this.detail?.visible) {
+    if (preference("showDetailsOnHover") && !this.detail?.visible) {
       this.mouseoutTimeout && clearTimeout(this.mouseoutTimeout)
       this.openDetail()
     }
@@ -108,7 +108,7 @@ export default class ItemContainer extends DraggableObject {
     if (this.draggable) {
       this.circle?.setFrame(this.cellIndex * 3)
     }
-    if (preferences.showDetailsOnHover) {
+    if (preference("showDetailsOnHover")) {
       this.mouseoutTimeout = setTimeout(
         () => {
           if (this.detail?.visible) {
@@ -123,7 +123,7 @@ export default class ItemContainer extends DraggableObject {
   onPointerDown(pointer: Phaser.Input.Pointer) {
     super.onPointerDown(pointer)
     this.parentContainer.bringToTop(this)
-    if (pointer.rightButtonDown() && !preferences.showDetailsOnHover) {
+    if (pointer.rightButtonDown() && !preference("showDetailsOnHover")) {
       if (!this.detail?.visible) {
         this.openDetail()
         this.updateDropZone(false)
@@ -155,7 +155,7 @@ export default class ItemContainer extends DraggableObject {
           this.mouseoutTimeout && clearTimeout(this.mouseoutTimeout)
         })
         this.detail.dom.addEventListener("mouseleave", () => {
-          if (preferences.showDetailsOnHover) {
+          if (preference("showDetailsOnHover")) {
             this.mouseoutTimeout = setTimeout(
               () => {
                 if (this.detail?.visible) {

--- a/app/public/src/game/components/item-detail.css
+++ b/app/public/src/game/components/item-detail.css
@@ -20,7 +20,6 @@
   width: 45px;
   height: 45px;
   align-self: center;
-  image-rendering: pixelated;
   object-fit: contain;
   grid-area: icon;
 }
@@ -39,7 +38,6 @@
 .game-item-recipe img {
   width: 22.5px;
   height: 22.5px;
-  image-rendering: pixelated;
   object-fit: contain;
 }
 

--- a/app/public/src/game/components/item-detail.tsx
+++ b/app/public/src/game/components/item-detail.tsx
@@ -8,6 +8,8 @@ import { Stat } from "../../../../types/enum/Game"
 import { HMs, Item, ItemRecipe, TMs } from "../../../../types/enum/Item"
 import { addIconsToDescription } from "../../pages/utils/descriptions"
 import "./item-detail.css"
+import { cc } from "../../pages/utils/jsx"
+import { usePreferences } from "../../preferences"
 
 export function ItemDetailTooltip({
   item,
@@ -16,6 +18,7 @@ export function ItemDetailTooltip({
   item: Item
   depth?: number
 }) {
+  const [preferences] = usePreferences()
   const { t } = useTranslation()
   const recipes = useMemo(
     () =>
@@ -42,11 +45,29 @@ export function ItemDetailTooltip({
 
   return (
     <div className="game-item-detail">
-      <img className="game-item-detail-icon" src={`assets/item/${getImageFilename()}.png`} />
+      <img
+        className={cc("game-item-detail-icon", {
+          pixelated: !preferences.antialiasing
+        })}
+        src={`assets/item/${getImageFilename()}.png`}
+      />
       <div className="game-item-detail-name">
-        {ItemRecipe[item] && (<div className="game-item-recipe">
-          {ItemRecipe[item]?.map((item, i) => <React.Fragment key={`component_${i}_${item}`}><img className="game-item-detail-icon" src={`assets/item/${item}.png`} key={item} />{i === 0 && ' + '}</React.Fragment>)}
-        </div>)}
+        {ItemRecipe[item] && (
+          <div className="game-item-recipe">
+            {ItemRecipe[item]?.map((item, i) => (
+              <React.Fragment key={`component_${i}_${item}`}>
+                <img
+                  className={cc("game-item-detail-icon", {
+                    pixelated: !preferences.antialiasing
+                  })}
+                  src={`assets/item/${item}.png`}
+                  key={item}
+                />
+                {i === 0 && " + "}
+              </React.Fragment>
+            ))}
+          </div>
+        )}
         {t(`item.${item}`)}
       </div>
       <div className="game-item-detail-stats">

--- a/app/public/src/game/components/pokemon-avatar.ts
+++ b/app/public/src/game/components/pokemon-avatar.ts
@@ -11,6 +11,8 @@ import GameScene from "../scenes/game-scene"
 import EmoteMenu from "./emote-menu"
 import LifeBar from "./life-bar"
 import PokemonSprite from "./pokemon"
+import { preference } from "../../preferences"
+import { cc } from "../../pages/utils/jsx"
 
 export default class PokemonAvatar extends PokemonSprite {
   scene: GameScene
@@ -278,6 +280,7 @@ export class EmoteBubble extends GameObjects.DOMElement {
 
     const emoteImg = document.createElement("img")
     emoteImg.src = getAvatarSrc(emoteAvatar)
+    emoteImg.className = cc({ pixelated: !preference('antialiasing') })
 
     this.dom.appendChild(emoteImg)
     this.setElement(this.dom)

--- a/app/public/src/game/components/pokemon-detail.tsx
+++ b/app/public/src/game/components/pokemon-detail.tsx
@@ -12,6 +12,8 @@ import { Synergy } from "../../../../types/enum/Synergy"
 import { AbilityTooltip } from "../../pages/component/ability/ability-tooltip"
 import { addIconsToDescription } from "../../pages/utils/descriptions"
 import { getPortraitSrc } from "../../../../utils/avatar"
+import { cc } from "../../pages/utils/jsx"
+import { preference } from "../../preferences"
 
 export default class PokemonDetail extends GameObjects.DOMElement {
   dom: HTMLDivElement
@@ -102,7 +104,9 @@ export default class PokemonDetail extends GameObjects.DOMElement {
 
     if (index === PkmIndex[Pkm.EGG]) {
       const eggHint = document.createElement("img")
-      eggHint.className = "game-pokemon-detail-portrait-hint"
+      eggHint.className = cc("game-pokemon-detail-portrait-hint", {
+        pixelated: !preference("antialiasing")
+      })
       eggHint.src = getPortraitSrc(PkmIndex[evolution])
       wrap.appendChild(eggHint)
     }

--- a/app/public/src/game/components/pokemon-special.tsx
+++ b/app/public/src/game/components/pokemon-special.tsx
@@ -3,7 +3,7 @@ import PokemonFactory from "../../../../models/pokemon-factory"
 import { PokemonActionState } from "../../../../types/enum/Game"
 import { Pkm } from "../../../../types/enum/Pokemon"
 import { clamp, min } from "../../../../utils/number"
-import { preferences } from "../../preferences"
+import { preference } from "../../preferences"
 import AnimationManager from "../animation-manager"
 import GameScene from "../scenes/game-scene"
 import PokemonSprite from "./pokemon"
@@ -72,7 +72,7 @@ export default class PokemonSpecial extends PokemonSprite {
 
   updateTooltipPosition() {
     if (this.detail) {
-      if (this.input && preferences.showDetailsOnHover) {
+      if (this.input && preference("showDetailsOnHover")) {
         this.detail.setPosition(this.input.localX, this.input.localY)
         return
       }

--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -33,7 +33,7 @@ import { clamp, min } from "../../../../utils/number"
 import { chance } from "../../../../utils/random"
 import { values } from "../../../../utils/schemas"
 import { transformAttackCoordinate } from "../../pages/utils/utils"
-import { preferences } from "../../preferences"
+import { preference } from "../../preferences"
 import type { DebugScene } from "../scenes/debug-scene"
 import type GameScene from "../scenes/game-scene"
 import { displayAbility } from "./abilities-animations"
@@ -274,7 +274,7 @@ export default class PokemonSprite extends DraggableObject {
 
   updateTooltipPosition() {
     if (this.detail) {
-      if (this.input && preferences.showDetailsOnHover) {
+      if (this.input && preference("showDetailsOnHover")) {
         this.detail.setPosition(
           this.input.localX + 200,
           min(0)(this.input.localY - 175)
@@ -356,7 +356,7 @@ export default class PokemonSprite extends DraggableObject {
     super.onPointerDown(pointer)
     if (
       this.shouldShowTooltip &&
-      !preferences.showDetailsOnHover &&
+      !preference("showDetailsOnHover") &&
       pointer.rightButtonDown() &&
       this.scene &&
       !this.detail
@@ -371,7 +371,7 @@ export default class PokemonSprite extends DraggableObject {
     super.onPointerUp()
     if (
       this.shouldShowTooltip &&
-      preferences.showDetailsOnHover &&
+      preference("showDetailsOnHover") &&
       !this.detail
     ) {
       this.openDetail()
@@ -380,7 +380,7 @@ export default class PokemonSprite extends DraggableObject {
 
   onPointerOut(): void {
     super.onPointerOut()
-    if (this.shouldShowTooltip && preferences.showDetailsOnHover) {
+    if (this.shouldShowTooltip && preference("showDetailsOnHover")) {
       this.closeDetail()
     }
   }
@@ -389,7 +389,7 @@ export default class PokemonSprite extends DraggableObject {
     super.onPointerOver(pointer)
 
     if (
-      preferences.showDetailsOnHover &&
+      preference("showDetailsOnHover") &&
       this.shouldShowTooltip &&
       this.detail == null &&
       !pointer.leftButtonDown() // we're dragging another pokemon

--- a/app/public/src/game/scenes/game-scene.ts
+++ b/app/public/src/game/scenes/game-scene.ts
@@ -28,7 +28,7 @@ import { clearTitleNotificationIcon } from "../../../../utils/window"
 import { getGameContainer } from "../../pages/game"
 import { SOUNDS, playMusic, playSound } from "../../pages/utils/audio"
 import { transformCoordinate } from "../../pages/utils/utils"
-import { loadPreferences, preferences } from "../../preferences"
+import { preference } from "../../preferences"
 import AnimationManager from "../animation-manager"
 import BattleManager from "../components/battle-manager"
 import BoardManager from "../components/board-manager"
@@ -173,25 +173,25 @@ export default class GameScene extends Scene {
   }
 
   registerKeys() {
-    const preferences = loadPreferences()
+    const keybindings = preference("keybindings")
     this.input.keyboard!.removeAllListeners()
     this.input.keyboard!.on(
-      "keydown-" + preferences.keybindings.refresh,
+      "keydown-" + keybindings.refresh,
       throttle(() => {
         playSound(SOUNDS.REFRESH, 0.5)
         this.refreshShop()
       }, 300)
     )
 
-    this.input.keyboard!.on("keydown-" + preferences.keybindings.lock, () => {
+    this.input.keyboard!.on("keydown-" + keybindings.lock, () => {
       this.room?.send(Transfer.LOCK)
     })
 
-    this.input.keyboard!.on("keydown-" + preferences.keybindings.buy_xp, () => {
+    this.input.keyboard!.on("keydown-" + keybindings.buy_xp, () => {
       this.buyExperience()
     })
 
-    this.input.keyboard!.on("keydown-" + preferences.keybindings.sell, (e) => {
+    this.input.keyboard!.on("keydown-" + keybindings.sell, (e) => {
       if (this.pokemonDragged != null) return
       if (this.shopIndexHovered !== null) {
         this.removeFromShop(this.shopIndexHovered)
@@ -210,7 +210,7 @@ export default class GameScene extends Scene {
       }
     })
 
-    this.input.keyboard!.on("keydown-" + preferences.keybindings.switch, () => {
+    this.input.keyboard!.on("keydown-" + keybindings.switch, () => {
       if (this.pokemonHovered) {
         this.switchBetweenBenchAndBoard(this.pokemonHovered)
       }
@@ -301,7 +301,7 @@ export default class GameScene extends Scene {
     const sys = this.sys as any
     if (sys.animatedTiles) {
       sys.animatedTiles.init(map)
-      if (preferences.disableAnimatedTilemap) {
+      if (preference("disableAnimatedTilemap")) {
         sys.animatedTiles.pause()
       }
     }

--- a/app/public/src/index.tsx
+++ b/app/public/src/index.tsx
@@ -12,13 +12,11 @@ import Lobby from "./pages/lobby"
 import Preparation from "./pages/preparation"
 import { SpriteDebug } from "./pages/sprite-viewer"
 import { Gameboy } from "./pages/gameboy"
-import { loadPreferences } from "./preferences"
 import store from "./stores/index"
 
 import "./i18n"
 import "./style/index.css"
 
-loadPreferences()
 const container = document.getElementById("root")
 const root = createRoot(container!)
 

--- a/app/public/src/pages/after-game.tsx
+++ b/app/public/src/pages/after-game.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState } from "react"
 import { Navigate } from "react-router-dom"
 import AfterGameState from "../../../rooms/states/after-game-state"
 import { useAppDispatch, useAppSelector } from "../hooks"
-import { preferences } from "../preferences"
+import { preference } from "../preferences"
 import {
   addPlayer,
   leaveAfter,
@@ -78,7 +78,7 @@ export default function AfterGame() {
       r.state.players.onAdd((player) => {
         dispatch(addPlayer(player))
         if (player.id === currentPlayerId) {
-          playSound(SOUNDS["FINISH" + player.rank], preferences.musicVolume / 100)
+          playSound(SOUNDS["FINISH" + player.rank], preference("musicVolume") / 100)
         }
       })
       r.state.listen("elligibleToELO", (value, previousValue) => {

--- a/app/public/src/pages/component/after/team.css
+++ b/app/public/src/pages/component/after/team.css
@@ -26,5 +26,4 @@
 .player-team-pokemons .pokemon-items img {
   width: 20px;
   height: 20px;
-  image-rendering: pixelated;
 }

--- a/app/public/src/pages/component/after/team.tsx
+++ b/app/public/src/pages/component/after/team.tsx
@@ -3,17 +3,27 @@ import { ArraySchema } from "@colyseus/schema"
 import { IPokemonRecord } from "../../../../../models/colyseus-models/game-record"
 import { getAvatarSrc } from "../../../../../utils/avatar"
 import "./team.css"
+import { cc } from "../../utils/jsx"
+import { usePreferences } from "../../../preferences"
+import PokemonPortrait from "../pokemon-portrait"
 
-export default function Team(props: { team: IPokemonRecord[] | ArraySchema<IPokemonRecord> }) {
+export default function Team(props: {
+  team: IPokemonRecord[] | ArraySchema<IPokemonRecord>
+}) {
+  const [{ antialiasing }] = usePreferences()
   return (
     <ul className="player-team-pokemons">
       {props.team.map((p, index) => {
         return (
           <li key={index}>
-            <img src={getAvatarSrc(p.avatar)} className="pokemon-portrait" />
+            <PokemonPortrait avatar={p.avatar} />
             <div className="pokemon-items">
               {p.items.map((item, i) => (
-                <img key={i} src={"/assets/item/" + item + ".png"} />
+                <img
+                  key={i}
+                  src={"/assets/item/" + item + ".png"}
+                  className={cc({ pixelated: !antialiasing })}
+                />
               ))}
             </div>
           </li>

--- a/app/public/src/pages/component/available-room-menu/tournament-item.tsx
+++ b/app/public/src/pages/component/available-room-menu/tournament-item.tsx
@@ -16,6 +16,7 @@ import { average } from "../../../../../utils/number"
 import { cc } from "../../utils/jsx"
 import { TOURNAMENT_REGISTRATION_TIME } from "../../../../../types/Config"
 import "./tournament-item.css"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function TournamentItem(props: {
   tournament: TournamentSchema
@@ -196,10 +197,7 @@ export function TournamentPlayer(props: {
       })}
     >
       {props.showScore && <span className="player-rank">{props.rank}</span>}
-      <img
-        src={getAvatarSrc(props.player.avatar)}
-        className="pokemon-portrait"
-      />
+      <PokemonPortrait avatar={props.player.avatar} />
       <p>
         <span className="player-name">{props.player.name}</span>
       </p>

--- a/app/public/src/pages/component/booster/booster-card.css
+++ b/app/public/src/pages/component/booster/booster-card.css
@@ -128,7 +128,6 @@
 .booster-card .front img {
   width: 100%;
   height: 65%;
-  image-rendering: pixelated;
 }
 
 .booster-card .front-text {

--- a/app/public/src/pages/component/booster/booster-card.tsx
+++ b/app/public/src/pages/component/booster/booster-card.tsx
@@ -7,8 +7,10 @@ import { PkmIndex } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../../../utils/avatar"
 import { cc } from "../../utils/jsx"
 import "./booster-card.css"
+import { usePreferences } from "../../../preferences"
 
 export function BoosterCard(props: { pkm: PkmWithConfig; shards: number }) {
+  const [{ antialiasing }] = usePreferences()
   const { t } = useTranslation()
   const pkm = props.pkm.name
   const pokemonData = getPokemonData(pkm)
@@ -35,6 +37,7 @@ export function BoosterCard(props: { pkm: PkmWithConfig; shards: number }) {
             props.pkm.shiny,
             props.pkm.emotion
           )}
+          className={cc({ pixelated: !antialiasing })}
         ></img>
         <div className="front-text">
           <p className="name">{t(`pkm.${pkm}`)}</p>

--- a/app/public/src/pages/component/bot-builder/bot-manager-panel.tsx
+++ b/app/public/src/pages/component/bot-builder/bot-manager-panel.tsx
@@ -8,6 +8,8 @@ import { addBotDatabase, deleteBotDatabase } from "../../../stores/NetworkStore"
 import { getAvatarSrc } from "../../../../../utils/avatar"
 import { rewriteBotRoundsRequiredto1, validateBot } from "./bot-logic"
 import "./bot-manager-panel.css"
+import { usePreference } from "../../../preferences"
+import PokemonPortrait from "../pokemon-portrait"
 
 export function BotManagerPanel() {
   const dispatch = useAppDispatch()
@@ -30,6 +32,7 @@ export function BotManagerPanel() {
 }
 
 function BotsList() {
+  const [antialiasing] = usePreference('antialiasing')
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
@@ -62,10 +65,7 @@ function BotsList() {
             {bots.map((b) => (
               <tr key={b.id}>
                 <td>
-                  <img
-                    src={getAvatarSrc(b.avatar)}
-                    className="pokemon-portrait"
-                  />
+                  <PokemonPortrait avatar={b.avatar} />
                 </td>
                 <td>{t(`pkm.${b.name}`)}</td>
                 <td>{b.author}</td>

--- a/app/public/src/pages/component/bot-builder/item-picker.tsx
+++ b/app/public/src/pages/component/bot-builder/item-picker.tsx
@@ -15,11 +15,13 @@ import {
 } from "../../../../../types/enum/Item"
 import { ItemDetailTooltip } from "../../../game/components/item-detail"
 import { cc } from "../../utils/jsx"
+import { usePreferences } from "../../../preferences"
 
 export default function ItemPicker(props: {
   selected: PkmWithConfig | Item
   selectEntity: React.Dispatch<React.SetStateAction<PkmWithConfig | Item>>
 }) {
+  const [{ antialiasing }] = usePreferences()
   const [itemHovered, setItemHovered] = useState<Item>()
 
   function handleOnDragStart(e: React.DragEvent, item: Item) {
@@ -52,7 +54,10 @@ export default function ItemPicker(props: {
             <img
               key={item}
               src={"assets/item/" + Item[item] + ".png"}
-              className={cc("item", { selected: item === props.selected })}
+              className={cc("item", {
+                selected: item === props.selected,
+                pixelated: !antialiasing
+              })}
               data-tooltip-id="detail-item"
               onMouseOver={() => setItemHovered(item)}
               onClick={() => props.selectEntity(item)}

--- a/app/public/src/pages/component/bot-builder/pokemon-picker.tsx
+++ b/app/public/src/pages/component/bot-builder/pokemon-picker.tsx
@@ -22,7 +22,7 @@ import SynergyIcon from "../icons/synergy-icon"
 import { Ability } from "../../../../../types/enum/Ability"
 import { selectCurrentPlayer, useAppSelector } from "../../../hooks"
 import { SpecialGameRule } from "../../../../../types/enum/SpecialGameRule"
-import { preferences, savePreferences } from "../../../preferences"
+import { usePreferences } from "../../../preferences"
 
 export default function PokemonPicker(props: {
   selected: PkmWithConfig | Item
@@ -73,6 +73,7 @@ function PokemonPickerTab(props: {
   addEntity: (e: PkmWithConfig) => void
   type: Synergy | "none"
 }) {
+  const [preferences, setPreferences] = usePreferences()
   const { t } = useTranslation()
   const [hoveredPokemon, setHoveredPokemon] = useState<Pkm>()
 
@@ -82,8 +83,6 @@ function PokemonPickerTab(props: {
   }
 
   const ingame = useLocation().pathname === "/game"
-  const [showEvolutions, setShowEvolutions] = useState(preferences.showEvolutions)
-  const [filterIngame, setFilterIngame] = useState(preferences.filterAvailableAddsAndRegionals)
   const [overlap, setOverlap] = useState<Synergy | null>(null)
   const additionalPokemons = useAppSelector(
     (state) => state.game.additionalPokemons
@@ -101,13 +100,17 @@ function PokemonPickerTab(props: {
     .filter((p) => {
       if (p.skill === Ability.DEFAULT) return false // pokemons with no ability are not ready for the show
       if (p.rarity === Rarity.SPECIAL) return true // show all summons & specials, even in the same family
-      if (showEvolutions) return true
+      if (preferences.showEvolutions) return true
       else return p.name === PkmFamily[p.name]
     })
-    .filter(p => !filterIngame || (
-      (!p.additional || additionalPokemons.includes(baseVariant(PkmFamily[p.name])) || specialGameRule === SpecialGameRule.EVERYONE_IS_HERE)
-      && (!p.regional || regionalPokemons?.includes(p.name))
-    ))
+    .filter(
+      (p) =>
+        !preferences.filterAvailableAddsAndRegionals ||
+        ((!p.additional ||
+          additionalPokemons.includes(baseVariant(PkmFamily[p.name])) ||
+          specialGameRule === SpecialGameRule.EVERYONE_IS_HERE) &&
+          (!p.regional || regionalPokemons?.includes(p.name)))
+    )
 
   const pokemonsPerRarity = groupBy(filteredPokemons, (p) => p.rarity)
   for (const rarity in pokemonsPerRarity) {
@@ -157,7 +160,8 @@ function PokemonPickerTab(props: {
                   className={cc("pokemon-portrait", {
                     additional: p.additional,
                     regional: p.regional,
-                    selected: p.name === props.selected["name"]
+                    selected: p.name === props.selected["name"],
+                    pixelated: !preferences.antialiasing
                   })}
                   onClick={() => {
                     props.selectEntity({
@@ -190,7 +194,10 @@ function PokemonPickerTab(props: {
                   draggable
                   onDragStart={(e) => handleOnDragStart(e, p.name)}
                 >
-                  <img src={getPortraitSrc(p.index)} />
+                  <img
+                    className={cc({ pixelated: !preferences.antialiasing })}
+                    src={getPortraitSrc(p.index)}
+                  />
                 </div>
               ))}
             </dd>
@@ -199,23 +206,23 @@ function PokemonPickerTab(props: {
       </dl>
       <div className="filters">
         <Checkbox
-          checked={showEvolutions}
-          onToggle={checked => {
-            setShowEvolutions(checked);
-            savePreferences({ showEvolutions: checked });
+          checked={preferences.showEvolutions}
+          onToggle={(checked) => {
+            setPreferences({ showEvolutions: checked })
           }}
           label={t("show_evolutions")}
           isDark
         />
-        {ingame && <Checkbox
-          checked={filterIngame}
-          onToggle={checked => {
-            setFilterIngame(checked);
-            savePreferences({ filterAvailableAddsAndRegionals: checked });
-          }}
-          label={t("show_only_available_picks")}
-          isDark
-        />}
+        {ingame && (
+          <Checkbox
+            checked={preferences.filterAvailableAddsAndRegionals}
+            onToggle={(checked) => {
+              setPreferences({ filterAvailableAddsAndRegionals: checked })
+            }}
+            label={t("show_only_available_picks")}
+            isDark
+          />
+        )}
         <details>
           <summary>{t("overlaps")}</summary>
           <ul className="synergy-overlaps">

--- a/app/public/src/pages/component/bot-builder/team-builder.css
+++ b/app/public/src/pages/component/bot-builder/team-builder.css
@@ -60,7 +60,6 @@
 #team-editor td img {
   width: 80px;
   height: 80px;
-  image-rendering: pixelated;
 }
 
 #team-editor td .pokemon-items {
@@ -116,7 +115,6 @@
 #item-picker img.item {
   width: 40px;
   height: 40px;
-  image-rendering: pixelated;
   cursor: var(--cursor-hover);
   margin: 2px;
 }
@@ -140,7 +138,6 @@
 
 #pokemon-picker .pokemon-portrait img {
   display: block;
-  image-rendering: pixelated;
 }
 
 #pokemon-picker .react-tabs__tab {

--- a/app/public/src/pages/component/bot-builder/team-editor.tsx
+++ b/app/public/src/pages/component/bot-builder/team-editor.tsx
@@ -2,6 +2,8 @@ import React from "react"
 import { IDetailledPokemon } from "../../../../../models/mongo-models/bot-v2"
 import { PkmIndex } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../../../utils/avatar"
+import { usePreferences } from "../../../preferences"
+import { cc } from "../../utils/jsx"
 
 export default function TeamEditor(props: {
   board: IDetailledPokemon[]
@@ -13,6 +15,8 @@ export default function TeamEditor(props: {
   ) => void
   handleDrop: (x: number, y: number, e: React.DragEvent) => void
 }) {
+  const [{ antialiasing }] = usePreferences()
+
   function handleOnDragStart(e: React.DragEvent, p: IDetailledPokemon) {
     e.dataTransfer.setData("cell", [p.x, p.y].join(","))
   }
@@ -64,6 +68,9 @@ export default function TeamEditor(props: {
                           )}
                           draggable
                           onDragStart={(e) => handleOnDragStart(e, p)}
+                          className={cc({
+                            pixelated: !antialiasing
+                          })}
                         />
                       )}
                       {p && p.items && (
@@ -78,6 +85,9 @@ export default function TeamEditor(props: {
                                   e.stopPropagation()
                                   props.handleEditorClick(x, y, true, j)
                                 }}
+                                className={cc({
+                                  pixelated: !antialiasing
+                                })}
                               />
                             )
                           })}

--- a/app/public/src/pages/component/chat/chat-message.tsx
+++ b/app/public/src/pages/component/chat/chat-message.tsx
@@ -2,8 +2,8 @@ import React from "react"
 import { IChatV2, Role } from "../../../../../types"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { removeMessage, searchById } from "../../../stores/NetworkStore"
-import { getAvatarSrc } from "../../../../../utils/avatar"
 import { cc } from "../../utils/jsx"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function ChatMessage(props: { message: IChatV2 }) {
   const dispatch = useAppDispatch()
@@ -23,10 +23,7 @@ export default function ChatMessage(props: { message: IChatV2 }) {
             "server-message": isServerMessage
           })}
         >
-          <img
-            src={getAvatarSrc(props.message.avatar)}
-            className="pokemon-portrait"
-          />
+          <PokemonPortrait avatar={props.message.avatar} />
           <div
             className="author-and-time"
             title="open profile"

--- a/app/public/src/pages/component/collection/pokemon-collection-item.css
+++ b/app/public/src/pages/component/collection/pokemon-collection-item.css
@@ -7,7 +7,6 @@
 .pokemon-collection-item > img {
   width: 80px;
   height: 80px;
-  image-rendering: pixelated;
   border-radius: 8px 8px 0 0;
 }
 
@@ -42,6 +41,5 @@
 .pokemon-collection-item p > img {
   width: 20px;
   height: 20px;
-  image-rendering: pixelated;
   margin-left: 0.5em;
 }

--- a/app/public/src/pages/component/collection/pokemon-collection-item.tsx
+++ b/app/public/src/pages/component/collection/pokemon-collection-item.tsx
@@ -8,6 +8,7 @@ import { Pkm } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../../../utils/avatar"
 import { cc } from "../../utils/jsx"
 import "./pokemon-collection-item.css"
+import { usePreferences } from "../../../preferences"
 
 export default function PokemonCollectionItem(props: {
   name: Pkm
@@ -18,6 +19,7 @@ export default function PokemonCollectionItem(props: {
   refundableOnly: boolean
   setPokemon: Dispatch<SetStateAction<Pkm | "">>
 }) {
+  const [{ antialiasing }] = usePreferences()
   if (
     props.index in PRECOMPUTED_EMOTIONS_PER_POKEMON_INDEX === false ||
     PRECOMPUTED_EMOTIONS_PER_POKEMON_INDEX[props.index].includes(1) === false
@@ -70,10 +72,14 @@ export default function PokemonCollectionItem(props: {
           props.config?.selectedEmotion
         )}
         loading="lazy"
+        className={cc({ pixelated: !antialiasing })}
       />
       <p>
         <span>{props.config ? props.config.dust : 0}</span>
-        <img src={getPortraitSrc(props.index)} />
+        <img
+          src={getPortraitSrc(props.index)}
+          className={cc({ pixelated: !antialiasing })}
+        />
       </p>
     </div>
   )

--- a/app/public/src/pages/component/collection/pokemon-emotion.css
+++ b/app/public/src/pages/component/collection/pokemon-emotion.css
@@ -9,7 +9,6 @@
 .pokemon-emotion > img {
   width: 80px;
   height: 80px;
-  image-rendering: pixelated;
   border-radius: 8px 8px 0 0;
 }
 
@@ -57,6 +56,5 @@
 .pokemon-emotion p > img {
   width: 20px;
   height: 20px;
-  image-rendering: pixelated;
   margin-left: 0.5em;
 }

--- a/app/public/src/pages/component/collection/pokemon-emotion.tsx
+++ b/app/public/src/pages/component/collection/pokemon-emotion.tsx
@@ -5,6 +5,7 @@ import { getEmotionCost } from "../../../../../types/Config"
 import { getPortraitSrc } from "../../../../../utils/avatar"
 import { cc } from "../../utils/jsx"
 import "./pokemon-emotion.css"
+import { usePreferences } from "../../../preferences"
 
 export default function PokemonEmotion(props: {
   index: string
@@ -16,6 +17,7 @@ export default function PokemonEmotion(props: {
   dust: number
   onClick: () => void
 }) {
+  const [{ antialiasing }] = usePreferences()
   const { t } = useTranslation()
   const cost = getEmotionCost(props.emotion, props.shiny)
   const canUnlock = !props.unlocked && cost <= props.dust
@@ -30,14 +32,24 @@ export default function PokemonEmotion(props: {
       })}
       onClick={props.onClick}
     >
-      <img src={getPortraitSrc(props.index, props.shiny, props.emotion)} />
-      {AvatarEmotions.includes(props.emotion) && (<span className="shortcut">Ctrl+{AvatarEmotions.indexOf(props.emotion) + 1}</span>)}
+      <img
+        src={getPortraitSrc(props.index, props.shiny, props.emotion)}
+        className={cc({ pixelated: !antialiasing })}
+      />
+      {AvatarEmotions.includes(props.emotion) && (
+        <span className="shortcut">
+          Ctrl+{AvatarEmotions.indexOf(props.emotion) + 1}
+        </span>
+      )}
       {props.unlocked ? (
         <p>{t(`emotion.${props.emotion}`)}</p>
       ) : (
         <p>
           <span>{cost}</span>
-          <img src={getPortraitSrc(props.index)} />
+          <img
+            src={getPortraitSrc(props.index)}
+            className={cc({ pixelated: !antialiasing })}
+          />
         </p>
       )}
     </div>

--- a/app/public/src/pages/component/collection/pokemon-emotions-modal.css
+++ b/app/public/src/pages/component/collection/pokemon-emotions-modal.css
@@ -15,7 +15,6 @@
   width: 80px;
   height: 80px;
   margin-right: 0.5em;
-  image-rendering: pixelated;
 }
 
 .pokemon-emotions-modal header img.unlocked {
@@ -33,11 +32,10 @@
   font-size: 120%;
 }
 
-.pokemon-emotions-modal header img  {
+.pokemon-emotions-modal header img {
   width: 40px;
   height: 40px;
   margin: 0 0.5em;
-  image-rendering: pixelated;
 }
 
 .pokemon-emotions-modal img.dust {

--- a/app/public/src/pages/component/collection/pokemon-emotions-modal.tsx
+++ b/app/public/src/pages/component/collection/pokemon-emotions-modal.tsx
@@ -22,11 +22,13 @@ import PokemonEmotion from "./pokemon-emotion"
 import "./pokemon-emotions-modal.css"
 import { BoosterPriceByRarity } from "../../../../../types/Config"
 import { getPokemonData } from "../../../../../models/precomputed/precomputed-pokemon-data"
+import { usePreferences } from "../../../preferences"
 
 export default function PokemonEmotionsModal(props: {
   pokemon: Pkm
   onClose: () => void
 }) {
+  const [{ antialiasing }] = usePreferences()
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const pokemonCollection = useAppSelector(
@@ -84,13 +86,17 @@ export default function PokemonEmotionsModal(props: {
             pConfig.selectedShiny,
             pConfig.selectedEmotion
           )}
-          className={cc({ unlocked: pConfig != null })}
+          className={cc({ unlocked: pConfig != null, pixelated: !antialiasing })}
         />
         <h2>{t(`pkm.${props.pokemon}`)}</h2>
         <div className="spacer" />
         <p className="dust">
           {pConfig.dust} {t("shards")}{" "}
-          <img src={getPortraitSrc(index)} className="dust" alt="dust" />
+          <img
+            src={getPortraitSrc(index)}
+            className={cc("dust", { pixelated: !antialiasing })}
+            alt="dust"
+          />
         </p>
       </>}
       body={<>

--- a/app/public/src/pages/component/debug/debug-scene.tsx
+++ b/app/public/src/pages/component/debug/debug-scene.tsx
@@ -5,8 +5,8 @@ import { Orientation } from "../../../../../types/enum/Game"
 import { Pkm } from "../../../../../types/enum/Pokemon"
 import { Status } from "../../../../../types/enum/Status"
 import { DebugScene } from "../../../game/scenes/debug-scene"
-import { loadPreferences } from "../../../preferences"
 import "./debug-scene.css"
+import { preference } from "../../../preferences"
 
 export default function DebugSceneContainer({
   pkm = Pkm.RATTATA,
@@ -53,7 +53,7 @@ export default function DebugSceneContainer({
       debugScene.current = new DebugScene(height, width, onProgress, onComplete)
 
       gameRef.current = new Phaser.Game({
-        type: +(loadPreferences().renderer ?? Phaser.AUTO),
+        type: +(preference("renderer") ?? Phaser.AUTO),
         parent: "debug-scene",
         pixelArt: true,
         width,

--- a/app/public/src/pages/component/game/game-additional-pokemons.tsx
+++ b/app/public/src/pages/component/game/game-additional-pokemons.tsx
@@ -8,6 +8,8 @@ import { SpecialGameRule } from "../../../../../types/enum/SpecialGameRule"
 import { useAppSelector } from "../../../hooks"
 import { getPortraitSrc } from "../../../../../utils/avatar"
 import SynergyIcon from "../icons/synergy-icon"
+import { cc } from "../../utils/jsx"
+import { usePreferences } from "../../../preferences"
 
 export function GameAdditionalPokemonsIcon() {
   return (
@@ -30,6 +32,7 @@ export function GameAdditionalPokemonsIcon() {
 }
 
 export function GameAdditionalPokemons() {
+  const [{ antialiasing }] = usePreferences()
   const { t } = useTranslation()
 
   const specialGameRule = useAppSelector((state) => state.game.specialGameRule)
@@ -66,7 +69,7 @@ export function GameAdditionalPokemons() {
 
             return (
               <div
-                className={`my-box clickable game-pokemon-portrait`}
+                className={cc(`my-box clickable game-pokemon-portrait`, { pixelated: !antialiasing })}
                 key={"game-additional-pokemons-" + index}
                 style={{
                   backgroundColor: rarityColor,

--- a/app/public/src/pages/component/game/game-dps-heal.tsx
+++ b/app/public/src/pages/component/game/game-dps-heal.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { IDps } from "../../../../../types"
-import { getAvatarSrc } from "../../../../../utils/avatar"
 import ProgressBar from "../progress-bar/progress-bar"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function GameDpsHeal(props: {
   maxHeal: number
@@ -11,10 +11,7 @@ export default function GameDpsHeal(props: {
   const { t } = useTranslation()
   return (
     <div className="game-dps-bar">
-      <img
-        className="pokemon-portrait"
-        src={getAvatarSrc(props.dpsMeter.name)}
-      />
+      <PokemonPortrait avatar={props.dpsMeter.name} />
       <div className="game-dps-progress-wrapper">
         <p>{props.dpsMeter.heal + props.dpsMeter.shield}</p>
         <ProgressBar className="my-progress is-primary">

--- a/app/public/src/pages/component/game/game-dps-meter.tsx
+++ b/app/public/src/pages/component/game/game-dps-meter.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react"
+import React from "react"
 import { useTranslation } from "react-i18next"
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs"
 import { selectCurrentPlayer, useAppSelector } from "../../../hooks"
-import { preferences, savePreferences } from "../../../preferences"
+import { usePreference, usePreferences } from "../../../preferences"
 import { getAvatarSrc } from "../../../../../utils/avatar"
 import GamePlayerDpsMeter from "./game-player-dps-meter"
 import GamePlayerDpsTakenMeter from "./game-player-dps-taken-meter"
@@ -10,8 +10,11 @@ import GamePlayerHpsMeter from "./game-player-hps-meter"
 import { GamePhaseState, Team } from "../../../../../types/enum/Game"
 import { PVEStages } from "../../../../../models/pve-stages"
 import "./game-dps-meter.css"
+import { cc } from "../../utils/jsx"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function GameDpsMeter() {
+  const [{ antialiasing }] = usePreferences()
   const { t } = useTranslation()
   const currentPlayer = useAppSelector(selectCurrentPlayer)
   const team = useAppSelector(
@@ -25,7 +28,7 @@ export default function GameDpsMeter() {
   const myDpsMeter = team === Team.BLUE_TEAM ? blueDpsMeter : redDpsMeter
   const opponentDpsMeter = team === Team.BLUE_TEAM ? redDpsMeter : blueDpsMeter
 
-  const [isOpen, setOpen] = useState(preferences.showDpsMeter)
+  const [isOpen, setOpen] = usePreference("showDpsMeter")
 
   if (!currentPlayer) return null
 
@@ -37,8 +40,7 @@ export default function GameDpsMeter() {
   const opponentAvatar = currentPlayer.opponentAvatar
 
   function toggleOpen() {
-    setOpen(!isOpen)
-    savePreferences({ showDpsMeter: !isOpen })
+    setOpen((old) => !old)
   }
 
   if (opponentAvatar == "") {
@@ -60,15 +62,12 @@ export default function GameDpsMeter() {
       >
         <header>
           <div>
-            <img src={getAvatarSrc(avatar)} className="pokemon-portrait"></img>
+            <PokemonPortrait avatar={avatar} />
             <p>{name}</p>
           </div>
           <h2>vs</h2>
           <div>
-            <img
-              src={getAvatarSrc(opponentAvatar)}
-              className="pokemon-portrait"
-            ></img>
+            <PokemonPortrait avatar={opponentAvatar} />
             <p>{isPVE ? t(opponentName) : opponentName}</p>
           </div>
         </header>

--- a/app/public/src/pages/component/game/game-dps-taken.tsx
+++ b/app/public/src/pages/component/game/game-dps-taken.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import { IDps } from "../../../../../types"
-import { getAvatarSrc } from "../../../../../utils/avatar"
 import { useTranslation } from "react-i18next"
 import ProgressBar from "../progress-bar/progress-bar"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function GameDpsTaken(props: {
   maxDamageTaken: number
@@ -11,7 +11,7 @@ export default function GameDpsTaken(props: {
   const { t } = useTranslation()
   return (
     <div className="game-dps-bar">
-      <img className="pokemon-portrait" src={getAvatarSrc(props.dps.name)} />
+      <PokemonPortrait avatar={props.dps.name} />
       <div className="game-dps-progress-wrapper">
         <p>
           {props.dps.physicalDamageReduced +

--- a/app/public/src/pages/component/game/game-dps.tsx
+++ b/app/public/src/pages/component/game/game-dps.tsx
@@ -1,14 +1,14 @@
 import React from "react"
 import { IDps } from "../../../../../types"
-import { getAvatarSrc } from "../../../../../utils/avatar"
 import { useTranslation } from "react-i18next"
 import ProgressBar from "../progress-bar/progress-bar"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function GameDps(props: { maxDamage: number; dps: IDps }) {
   const { t } = useTranslation()
   return (
     <div className="game-dps-bar">
-      <img className="pokemon-portrait" src={getAvatarSrc(props.dps.name)} />
+      <PokemonPortrait avatar={props.dps.name} />
       <div className="game-dps-progress-wrapper">
         <p>
           {props.dps.physicalDamage +

--- a/app/public/src/pages/component/game/game-item.tsx
+++ b/app/public/src/pages/component/game/game-item.tsx
@@ -5,6 +5,8 @@ import { Item } from "../../../../../types/enum/Item"
 import { useAppDispatch } from "../../../hooks"
 import { itemClick } from "../../../stores/NetworkStore"
 import { addIconsToDescription } from "../../utils/descriptions"
+import { cc } from "../../utils/jsx"
+import { usePreference } from "../../../preferences"
 
 const style: CSS.Properties = {
   width: "320px",
@@ -17,13 +19,16 @@ const style: CSS.Properties = {
 }
 
 export default function GameItem(props: { item: Item }) {
+  const [antialiasing] = usePreference("antialiasing")
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
+
   return (
     <div className="my-container" style={style}>
       <img
-        style={{ width: "4rem", height: "4rem", imageRendering: "pixelated" }}
+        style={{ width: "4rem", height: "4rem" }}
         src={"assets/item/" + props.item + ".png"}
+        className={cc({ pixelated: !antialiasing })}
       ></img>
       <h3 style={{ margin: "0.25em 0" }}>{t(`item.${props.item}`)}</h3>
       <p style={{ marginBottom: "0.5em" }}>{addIconsToDescription(t(`item_description.${props.item}`))}</p>

--- a/app/public/src/pages/component/game/game-player-loading.css
+++ b/app/public/src/pages/component/game/game-player-loading.css
@@ -8,7 +8,6 @@
   width: 8vh;
   background-size: cover;
   border-radius: 50%;
-  image-rendering: pixelated;
   box-shadow: inset 0 0 0 0.8vh black;
   margin: auto;
 }

--- a/app/public/src/pages/component/game/game-player-loading.tsx
+++ b/app/public/src/pages/component/game/game-player-loading.tsx
@@ -7,8 +7,10 @@ import { getAvatarSrc } from "../../../../../utils/avatar"
 import { getGameScene } from "../../game"
 import { cc } from "../../utils/jsx"
 import "./game-player-loading.css"
+import { usePreference } from "../../../preferences"
 
 export default function GamePlayerLoadingBar(props: { player: IPlayer }) {
+  const [antialiasing] = usePreference("antialiasing")
   const { t } = useTranslation()
   const selfPlayerId = getGameScene()?.uid
   const loadingPercent = props.player.loadingProgress
@@ -20,7 +22,9 @@ export default function GamePlayerLoadingBar(props: { player: IPlayer }) {
       })}
     >
       <div
-        className="game-player-loading-icon"
+        className={cc("game-player-loading-icon", {
+          pixelated: !antialiasing
+        })}
         style={{
           backgroundImage: `url('${getAvatarSrc(props.player.avatar)}')`
         }}

--- a/app/public/src/pages/component/game/game-player.css
+++ b/app/public/src/pages/component/game/game-player.css
@@ -6,7 +6,6 @@
   right: 0.5%;
   background-size: cover;
   border-radius: 50%;
-  image-rendering: pixelated;
   box-shadow: inset 0 0 0 0.8vh black;
   z-index: 30;
 }

--- a/app/public/src/pages/component/game/game-player.tsx
+++ b/app/public/src/pages/component/game/game-player.tsx
@@ -10,12 +10,14 @@ import GamePlayerDetail from "./game-player-detail"
 
 import "react-circular-progressbar/dist/styles.css"
 import "./game-player.css"
+import { usePreference } from "../../../preferences"
 
 export default function GamePlayer(props: {
   player: IPlayer
   click: (id: string) => void
   index: number
 }) {
+  const [antialiasing] = usePreference("antialiasing")
   const spectatedPlayerId = useAppSelector(
     (state) => state.game.currentPlayerId
   )
@@ -34,7 +36,8 @@ export default function GamePlayer(props: {
       className={cc("game-player", {
         spectated: spectatedPlayerId === props.player.id,
         self: selfPlayerId === props.player.id,
-        dead: props.player.life <= 0
+        dead: props.player.life <= 0,
+        pixelated: !antialiasing
       })}
       onClick={playerClick}
       data-tooltip-id={"detail-" + props.player.id}

--- a/app/public/src/pages/component/game/game-pokemon-detail.css
+++ b/app/public/src/pages/component/game/game-pokemon-detail.css
@@ -48,7 +48,6 @@
   border-style: solid;
   border-width: 4px;
   border-radius: 8px;
-  image-rendering: pixelated;
   box-sizing: content-box;
 }
 
@@ -59,7 +58,6 @@
   top: 23px;
   left: 7px;
   border-radius: 50%;
-  image-rendering: pixelated;
   filter: grayscale(1) contrast(0.2) brightness(1.8);
 }
 

--- a/app/public/src/pages/component/game/game-pokemon-detail.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-detail.tsx
@@ -14,12 +14,15 @@ import { addIconsToDescription } from "../../utils/descriptions"
 import { AbilityTooltip } from "../ability/ability-tooltip"
 import SynergyIcon from "../icons/synergy-icon"
 import "./game-pokemon-detail.css"
+import { cc } from "../../utils/jsx"
+import { usePreference } from "../../../preferences"
 
 export function GamePokemonDetail(props: {
   pokemon: Pkm | Pokemon
   shiny?: boolean
   emotion?: Emotion
 }) {
+  const [antialiasing] = usePreference("antialiasing")
   const { t } = useTranslation()
   const pokemon: Pokemon = useMemo(
     () =>
@@ -51,7 +54,9 @@ export function GamePokemonDetail(props: {
   return (
     <div className="game-pokemon-detail in-shop">
       <img
-        className="game-pokemon-detail-portrait"
+        className={cc("game-pokemon-detail-portrait", {
+          pixelated: !antialiasing
+        })}
         style={{ borderColor: RarityColor[pokemon.rarity] }}
         src={getPortraitSrc(
           pokemon.index,

--- a/app/public/src/pages/component/game/game-pokemon-duo-portrait.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-duo-portrait.tsx
@@ -10,6 +10,7 @@ import { cc } from "../../utils/jsx"
 import SynergyIcon from "../icons/synergy-icon"
 import { GamePokemonDetail } from "./game-pokemon-detail"
 import "./game-pokemon-portrait.css"
+import { usePreference } from "../../../preferences"
 
 export default function GamePokemonDuoPortrait(props: {
   index: number
@@ -17,6 +18,7 @@ export default function GamePokemonDuoPortrait(props: {
   duo: PkmDuo
   click?: React.MouseEventHandler<HTMLDivElement>
 }) {
+  const [antialiasing] = usePreference("antialiasing")
   const duo = PkmDuos[props.duo].map((p) => getPokemonData(p))
   const rarityColor = RarityColor[duo[0].rarity]
   const pokemonCollection = useAppSelector(
@@ -40,7 +42,8 @@ export default function GamePokemonDuoPortrait(props: {
           <div
             className={cc(
               "game-pokemon-portrait-duo-part",
-              "game-pokemon-portrait-duo-part-" + (i === 0 ? "down" : "up")
+              "game-pokemon-portrait-duo-part-" + (i === 0 ? "down" : "up"),
+              { pixelated: !antialiasing }
             )}
             data-tooltip-id={`tooltip-${props.origin}-${props.index}-${p.index}`}
             style={{

--- a/app/public/src/pages/component/game/game-pokemon-portrait.css
+++ b/app/public/src/pages/component/game/game-pokemon-portrait.css
@@ -4,7 +4,6 @@
   --portrait-size: calc(var(--container-height) - 5px);
   width: 7.5vw;
   height: var(--container-height);
-  image-rendering: pixelated;
   padding: 0;
   background-repeat: no-repeat;
   background-size: contain;
@@ -72,7 +71,6 @@
   display: inline-block;
   width: 22px;
   height: 22px;
-  image-rendering: pixelated;
   margin-left: 4px;
   vertical-align: middle;
 }
@@ -82,7 +80,6 @@
   height: 40px;
   border: 1px solid white;
   border-radius: 4px;
-  image-rendering: pixelated;
 }
 
 .game-pokemon-portrait-planned-icon {
@@ -110,7 +107,6 @@
   background-size: contain;
   background-repeat: no-repeat;
   border-radius: 8px;
-  image-rendering: pixelated;
 }
 
 .game-pokemon-portrait-duo-part-down {

--- a/app/public/src/pages/component/game/game-pokemon-portrait.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-portrait.tsx
@@ -16,6 +16,7 @@ import { Money } from "../icons/money"
 import SynergyIcon from "../icons/synergy-icon"
 import { GamePokemonDetail } from "./game-pokemon-detail"
 import "./game-pokemon-portrait.css"
+import { usePreference } from "../../../preferences"
 
 export default function GamePokemonPortrait(props: {
   index: number
@@ -26,6 +27,7 @@ export default function GamePokemonPortrait(props: {
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>,
   inPlanner?: boolean
 }) {
+  const [antialiasing] = usePreference("antialiasing")
   const pokemon = useMemo(
     () =>
       typeof props.pokemon === "string"
@@ -140,7 +142,8 @@ export default function GamePokemonPortrait(props: {
       className={cc("my-box", "clickable", "game-pokemon-portrait", {
         shimmer: shouldShimmer,
         disabled: !canBuy && props.origin === "shop",
-        planned: props.inPlanner ?? false
+        planned: props.inPlanner ?? false,
+        pixelated: !antialiasing
       })}
       style={{
         backgroundColor: rarityColor,
@@ -178,12 +181,16 @@ export default function GamePokemonPortrait(props: {
               pokemonConfig?.selectedShiny,
               pokemonConfig?.selectedEmotion
             )}
-            className="game-pokemon-portrait-evolution-portrait"
+            className={cc("game-pokemon-portrait-evolution-portrait", {
+              pixelated: !antialiasing
+            })}
           />
           <img
             src="/assets/ui/evolution.png"
             alt=""
-            className="game-pokemon-portrait-evolution-icon"
+            className={cc("game-pokemon-portrait-evolution-icon", {
+              pixelated: !antialiasing
+            })}
           />
         </div>
       )}

--- a/app/public/src/pages/component/game/game-pokemons-proposition.tsx
+++ b/app/public/src/pages/component/game/game-pokemons-proposition.tsx
@@ -12,8 +12,11 @@ import { addIconsToDescription } from "../../utils/descriptions"
 import GamePokemonDuoPortrait from "./game-pokemon-duo-portrait"
 import GamePokemonPortrait from "./game-pokemon-portrait"
 import "./game-pokemon-propositions.css"
+import { cc } from "../../utils/jsx"
+import { usePreference } from "../../../preferences"
 
 export default function GamePokemonsPropositions() {
+  const [antialiasing] = usePreference("antialiasing")
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const pokemonsProposition = useAppSelector(
@@ -85,10 +88,12 @@ export default function GamePokemonsPropositions() {
                         style={{
                           width: "2rem",
                           height: "2rem",
-                          imageRendering: "pixelated",
                           verticalAlign: "middle"
                         }}
                         src={"assets/item/" + item + ".png"}
+                        className={cc({
+                          pixelated: !antialiasing
+                        })}
                       />
                       <p>
                         {addIconsToDescription(t(`item_description.${item}`))}

--- a/app/public/src/pages/component/game/game-stage-info.tsx
+++ b/app/public/src/pages/component/game/game-stage-info.tsx
@@ -21,8 +21,11 @@ import SynergyIcon from "../icons/synergy-icon"
 import TimerBar from "./game-timer-bar"
 import { DungeonDetails } from "../../../../../types/enum/Dungeon"
 import "./game-stage-info.css"
+import PokemonPortrait from "../pokemon-portrait"
+import { usePreferences } from "../../../preferences"
 
 export default function GameStageInfo() {
+  const [{ antialiasing }] = usePreferences()
   const { t } = useTranslation()
   const phase = useAppSelector((state) => state.game.phase)
   const weather = useAppSelector((state) => state.game.weather)
@@ -85,7 +88,7 @@ export default function GameStageInfo() {
           })}
         >
           <div className="player-information">
-            <img src={getAvatarSrc(avatar)} className="pokemon-portrait" />
+            <PokemonPortrait avatar={avatar} />
             {title && <p className="player-title">{t(`title.${title}`)}</p>}
             <p className="player-name">{name}</p>
           </div>
@@ -93,10 +96,7 @@ export default function GameStageInfo() {
             <>
               <span>vs</span>
               <div className="player-information">
-                <img
-                  src={getAvatarSrc(opponentAvatar)}
-                  className="pokemon-portrait"
-                />
+                <PokemonPortrait avatar={opponentAvatar} />
                 {opponentTitle && (
                   <p className="player-title">{t(`title.${opponentTitle}`)}</p>
                 )}

--- a/app/public/src/pages/component/jukebox/jukebox.tsx
+++ b/app/public/src/pages/component/jukebox/jukebox.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { DungeonMusic } from "../../../../../types/enum/Dungeon"
-import { preferences, savePreferences } from "../../../preferences"
+import { usePreference } from "../../../preferences"
 import { getGameScene } from "../../game"
 import { playMusic, preloadMusic } from "../../utils/audio"
 import { cc } from "../../utils/jsx"
@@ -23,7 +23,7 @@ export default function Jukebox(props: {
   ) as DungeonMusic
   const [music, setMusic] = useState<DungeonMusic>(musicPlaying)
   const [loading, setLoading] = useState<boolean>(false)
-  const [volume, setVolume] = useState<number>(preferences.musicVolume)
+  const [volume, setVolume] = usePreference("musicVolume")
 
   useEffect(() => {
     if (musicPlaying !== music && !loading) {
@@ -55,11 +55,6 @@ export default function Jukebox(props: {
   function handleVolumeChange(e: React.ChangeEvent<HTMLInputElement>) {
     const newVolume = Number(e.target.value)
     setVolume(newVolume)
-    savePreferences({ musicVolume: newVolume })
-    const gameScene = getGameScene()
-    if (gameScene && gameScene.music) {
-      gameScene.music.setVolume(newVolume / 100)
-    }
   }
 
   function nextMusic(delta: number) {

--- a/app/public/src/pages/component/leaderboard/leaderboard-item.tsx
+++ b/app/public/src/pages/component/leaderboard/leaderboard-item.tsx
@@ -6,8 +6,8 @@ import {
 } from "../../../../../types/interfaces/LeaderboardInfo"
 import { useAppDispatch } from "../../../hooks"
 import { searchById } from "../../../stores/NetworkStore"
-import { getAvatarSrc } from "../../../../../utils/avatar"
 import { EloBadge } from "../profile/elo-badge"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function LeaderboardItem(props: {
   item: ILeaderboardInfo | ILeaderboardBotInfo
@@ -32,10 +32,7 @@ export default function LeaderboardItem(props: {
     >
       <div style={{ display: "flex", gap: "5px" }}>
         <span className="player-rank">{props.item.rank}</span>
-        <img
-          src={getAvatarSrc(props.item.avatar)}
-          className="pokemon-portrait"
-        />
+        <PokemonPortrait avatar={props.item.avatar} />
       </div>
       <span
         style={{

--- a/app/public/src/pages/component/meta-report/item-statistic.tsx
+++ b/app/public/src/pages/component/meta-report/item-statistic.tsx
@@ -3,11 +3,15 @@ import { useTranslation } from "react-i18next"
 import { IItemsStatistic } from "../../../../../models/mongo-models/items-statistic"
 import { PkmIndex } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../../../utils/avatar"
+import { cc } from "../../utils/jsx"
+import { usePreference } from "../../../preferences"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function ItemStatistic(props: {
   item: IItemsStatistic
   rank: number
 }) {
+  const [antialiasing] = usePreference("antialiasing")
   const { t } = useTranslation()
   return (
     <div className="item-stat my-box">
@@ -16,9 +20,9 @@ export default function ItemStatistic(props: {
         src={"assets/item/" + props.item.name + ".png"}
         style={{
           width: "48px",
-          height: "48px",
-          imageRendering: "pixelated"
+          height: "48px"
         }}
+        className={cc({ pixelated: !antialiasing })}
       ></img>
       <span>{t(`item.${props.item.name}`)}</span>
       <span>
@@ -30,11 +34,7 @@ export default function ItemStatistic(props: {
       <div style={{ display: "flex", gap: "0.5em", alignItems: "center" }}>
         <label>{t("popular_holders")}:</label>
         {props.item.pokemons.map((pokemon) => (
-          <img
-            key={pokemon}
-            className="pokemon-portrait"
-            src={getPortraitSrc(PkmIndex[pokemon])}
-          />
+          <PokemonPortrait portrait={PkmIndex[pokemon]} key={pokemon} />
         ))}
       </div>
     </div>

--- a/app/public/src/pages/component/meta-report/pokemon-statistic.tsx
+++ b/app/public/src/pages/component/meta-report/pokemon-statistic.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../../../../types/enum/Pokemon"
 import { Synergy } from "../../../../../types/enum/Synergy"
 import { getPortraitSrc } from "../../../../../utils/avatar"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function PokemonStatistic(props: {
   pokemons: IPokemonsStatistic[]
@@ -96,10 +97,7 @@ export default function PokemonStatistic(props: {
           >
             {family.pokemons.map((pokemon, i) => (
               <li key={pokemon.name}>
-                <img
-                  className="pokemon-portrait"
-                  src={getPortraitSrc(PkmIndex[pokemon.name])}
-                />
+                <PokemonPortrait portrait={PkmIndex[pokemon.name]} />
                 <span>{t(`pkm.${pokemon.name}`)}</span>
               </li>
             ))}
@@ -135,10 +133,7 @@ export default function PokemonStatistic(props: {
                   gridTemplateColumns: "40px 6ch 1fr 1.5fr 2fr"
                 }}
               >
-                <img
-                  className="pokemon-portrait"
-                  src={getPortraitSrc(PkmIndex[pokemon.name])}
-                />
+                <PokemonPortrait portrait={PkmIndex[pokemon.name]} />
                 <span>
                   {pokemon.count === 0 ? "???" : pokemon.rank.toFixed(1)}
                 </span>

--- a/app/public/src/pages/component/meta-report/team-comp.tsx
+++ b/app/public/src/pages/component/meta-report/team-comp.tsx
@@ -5,6 +5,7 @@ import { Pkm, PkmIndex } from "../../../../../types/enum/Pokemon"
 import { Synergy } from "../../../../../types/enum/Synergy"
 import { getPortraitSrc } from "../../../../../utils/avatar"
 import SynergyIcon from "../icons/synergy-icon"
+import PokemonPortrait from "../pokemon-portrait"
 
 export function rankType(
   a: Synergy,
@@ -84,10 +85,7 @@ export default function TeamComp(props: { team: IMeta; rank: number }) {
               }}
               key={pokemon}
             >
-              <img
-                className="pokemon-portrait"
-                src={getPortraitSrc(PkmIndex[pokemon])}
-              />
+              <PokemonPortrait portrait={PkmIndex[pokemon]} />
               <span>
                 {((props.team.pokemons[pokemon] ?? 0) * 100).toFixed(0) + "%"}
               </span>

--- a/app/public/src/pages/component/pokemon-portrait.tsx
+++ b/app/public/src/pages/component/pokemon-portrait.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+
+import { getAvatarSrc, getPortraitSrc } from "../../../../utils/avatar"
+import { usePreference } from "../../preferences"
+import { cc } from "../utils/jsx"
+import { Emotion } from "../../../../types"
+
+interface PortraitOptions {
+  index?: string
+  shiny?: boolean
+  emotion?: Emotion
+}
+
+type Props = (
+  | { avatar: string }
+  | { portrait: string | PortraitOptions | undefined }
+) &
+  React.ImgHTMLAttributes<HTMLImageElement>
+
+export default function PokemonPortrait(props: Props) {
+  const [antialiasing] = usePreference("antialiasing")
+  let src
+  if ("avatar" in props) {
+    src = getAvatarSrc(props.avatar)
+  } else {
+    src =
+      typeof props.portrait === "object"
+        ? getPortraitSrc(
+            props.portrait.index,
+            props.portrait.shiny,
+            props.portrait.emotion
+          )
+        : getPortraitSrc(props.portrait)
+  }
+  const { className, ...rest } = props
+
+  return (
+    <img
+      src={src}
+      className={cc(
+        "pokemon-portrait",
+        { pixelated: !antialiasing },
+        className || ""
+      )}
+      {...rest}
+    />
+  )
+}

--- a/app/public/src/pages/component/profile/avatar-tab.tsx
+++ b/app/public/src/pages/component/profile/avatar-tab.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { changeAvatar } from "../../../stores/NetworkStore"
 import { getPortraitSrc } from "../../../../../utils/avatar"
 import { PokemonTypeahead } from "../typeahead/pokemon-typeahead"
+import PokemonPortrait from "../pokemon-portrait"
 
 export function AvatarTab() {
   const { t } = useTranslation()
@@ -37,9 +38,9 @@ export function AvatarTab() {
                   : pokemonConfig.emotions
               ).map((emotion) => {
                 return (
-                  <img
+                  <PokemonPortrait
                     key={`${type}-${pokemonConfig.id}${emotion}`}
-                    className="clickable pokemon-portrait"
+                    className="clickable"
                     onClick={() => {
                       dispatch(
                         changeAvatar({
@@ -49,12 +50,12 @@ export function AvatarTab() {
                         })
                       )
                     }}
-                    src={getPortraitSrc(
-                      pokemonConfig.id,
-                      type === "shiny",
+                    portrait={{
+                      index: pokemonConfig.id,
+                      shiny: type === "shiny",
                       emotion
-                    )}
-                  ></img>
+                    }}
+                  />
                 )
               })
             })

--- a/app/public/src/pages/component/profile/avatar.tsx
+++ b/app/public/src/pages/component/profile/avatar.tsx
@@ -6,6 +6,7 @@ import { EloBadge } from "./elo-badge"
 import { RoleBadge } from "./role-badge"
 
 import "./avatar.css"
+import PokemonPortrait from "../pokemon-portrait"
 
 export function Avatar(props: {
   name: string
@@ -18,7 +19,7 @@ export function Avatar(props: {
 
   return (
     <div className="avatar player my-box">
-      <img className="pokemon-portrait" src={getAvatarSrc(props.avatar)} />
+      <PokemonPortrait avatar={props.avatar} />
       <div className="player-portrait">
         <span className="player-title-role">
           {props.title && (

--- a/app/public/src/pages/component/profile/inline-avatar.tsx
+++ b/app/public/src/pages/component/profile/inline-avatar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Role } from "../../../../../types"
 import { getAvatarSrc } from "../../../../../utils/avatar"
 import { RoleBadge } from "./role-badge"
+import PokemonPortrait from "../pokemon-portrait"
 
 export function InlineAvatar(props: {
   avatar: string
@@ -21,10 +22,9 @@ export function InlineAvatar(props: {
         gap: "0.25em"
       }}
     >
-      <img
+      <PokemonPortrait
+        avatar={props.avatar}
         style={{ width: "40px", height: "40px" }}
-        src={getAvatarSrc(props.avatar)}
-        className="pokemon-portrait"
       />
       {props.title && (
         <span className="player-title">{t(`title.${props.title}`)}</span>

--- a/app/public/src/pages/component/profile/player-box.tsx
+++ b/app/public/src/pages/component/profile/player-box.tsx
@@ -11,6 +11,7 @@ import { getAvatarSrc } from "../../../../../utils/avatar"
 import SynergyIcon from "../icons/synergy-icon"
 import { EloBadge } from "./elo-badge"
 import { RoleBadge } from "./role-badge"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function PlayerBox(props: { user: IUserMetadata, history?: IGameRecord[] }) {
   const { t } = useTranslation()
@@ -56,10 +57,7 @@ export default function PlayerBox(props: { user: IUserMetadata, history?: IGameR
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: "0.5em" }}>
-          <img
-            src={getAvatarSrc(props.user.avatar)}
-            className="pokemon-portrait"
-          />
+          <PokemonPortrait avatar={props.user.avatar} />
           {props.user.title && (
             <p className="player-title">{t(`title.${props.user.title}`)}</p>
           )}
@@ -108,10 +106,9 @@ export default function PlayerBox(props: { user: IUserMetadata, history?: IGameR
         </p>
         <p>
           {favoritePokemons.map((name) => (
-            <img
+            <PokemonPortrait
               key={name}
-              src={getAvatarSrc(PkmIndex[name] + "/Normal")}
-              className="pokemon-portrait"
+              avatar={PkmIndex[name] + "/Normal"}
             />
           ))}
         </p>

--- a/app/public/src/pages/component/profile/search-results.tsx
+++ b/app/public/src/pages/component/profile/search-results.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { searchById } from "../../../stores/NetworkStore"
 import { getAvatarSrc } from "../../../../../utils/avatar"
 import { cc } from "../../utils/jsx"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function SearchResults() {
   const { t } = useTranslation()
@@ -22,10 +23,7 @@ export default function SearchResults() {
               dispatch(searchById(suggestion.id))
             }}
           >
-            <img
-              src={getAvatarSrc(suggestion.avatar)}
-              className="pokemon-portrait"
-            />
+            <PokemonPortrait avatar={suggestion.avatar} />
             <span>{suggestion.name}</span>
           </li>
         ))}

--- a/app/public/src/pages/component/synergy/synergy-detail-component.tsx
+++ b/app/public/src/pages/component/synergy/synergy-detail-component.tsx
@@ -21,6 +21,7 @@ import { cc } from "../../utils/jsx"
 import SynergyIcon from "../icons/synergy-icon"
 import { EffectDescriptionComponent } from "./effect-description"
 import { SpecialGameRule } from "../../../../../types/enum/SpecialGameRule"
+import { usePreference } from "../../../preferences"
 
 export default function SynergyDetailComponent(props: {
   type: Synergy
@@ -166,6 +167,7 @@ export default function SynergyDetailComponent(props: {
 }
 
 function PokemonPortrait(props: { p: IPokemonData, player?: IPlayer }) {
+  const [antialiasing] = usePreference("antialiasing")
   const isOnTeam = (p: Pkm) => props.player != null && values(props.player.board).some((x) => PkmFamily[x.name] === p)
   return (
     <div
@@ -177,7 +179,7 @@ function PokemonPortrait(props: { p: IPokemonData, player?: IPlayer }) {
       key={props.p.name}
       style={{ color: RarityColor[props.p.rarity], border: "3px solid " + RarityColor[props.p.rarity] }}
     >
-      <img src={getPortraitSrc(props.p.index)} />
+      <img src={getPortraitSrc(props.p.index)} className={cc({ pixelated: !antialiasing })} />
     </div>
   )
 }

--- a/app/public/src/pages/component/wiki/wiki-ability.tsx
+++ b/app/public/src/pages/component/wiki/wiki-ability.tsx
@@ -11,8 +11,10 @@ import { addIconsToDescription } from "../../utils/descriptions"
 import { cc } from "../../utils/jsx"
 import { GamePokemonDetail } from "../game/game-pokemon-detail"
 import { IPokemonData } from "../../../../../types/interfaces/PokemonData"
+import { usePreference } from "../../../preferences"
 
 export default function WikiAbility() {
+  const [antialiasing] = usePreference("antialiasing")
   const { t } = useTranslation()
   const [hoveredPokemon, setHoveredPokemon] = useState<Pkm>()
 
@@ -57,7 +59,7 @@ export default function WikiAbility() {
                             setHoveredPokemon(p.name)
                           }}
                         >
-                          <img src={getPortraitSrc(p.index)} />
+                          <img src={getPortraitSrc(p.index)} className={cc({ pixelated: !antialiasing })} />
                         </div>
                       </li>
                     ))}

--- a/app/public/src/pages/component/wiki/wiki-items.tsx
+++ b/app/public/src/pages/component/wiki/wiki-items.tsx
@@ -17,8 +17,11 @@ import { Synergy } from "../../../../../types/enum/Synergy"
 import { ItemDetailTooltip } from "../../../game/components/item-detail"
 import { addIconsToDescription } from "../../utils/descriptions"
 import SynergyIcon from "../icons/synergy-icon"
+import { cc } from "../../utils/jsx"
+import { usePreference } from "../../../preferences"
 
 export default function WikiItems() {
+  const [antialiasing] = usePreference("antialiasing")
   const [itemHovered, setItemHovered] = useState<Item>()
   const { t } = useTranslation()
   return (
@@ -142,7 +145,9 @@ export default function WikiItems() {
               <br />
               <img
                 src={"assets/environment/berry_trees/" + i + "_6.png"}
-                className="tree"
+                className={cc("tree", {
+                  pixelated: !antialiasing
+                })}
               ></img>
             </li>
           ))}

--- a/app/public/src/pages/component/wiki/wiki-pokemons.tsx
+++ b/app/public/src/pages/component/wiki/wiki-pokemons.tsx
@@ -17,6 +17,7 @@ import { cc } from "../../utils/jsx"
 import { GamePokemonDetail } from "../game/game-pokemon-detail"
 import { PokemonTypeahead } from "../typeahead/pokemon-typeahead"
 import WikiPokemonDetail from "./wiki-pokemon-detail"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function WikiPokemons() {
   const { t } = useTranslation()
@@ -97,10 +98,7 @@ export function WikiPokemon(props: {
         {pokemons.map((pkm) => {
           return (
             <Tab key={"title-" + pkm}>
-              <img
-                className="pokemon-portrait"
-                src={getPortraitSrc(PkmIndex[pkm])}
-              ></img>
+              <PokemonPortrait portrait={PkmIndex[pkm]} />
             </Tab>
           )
         })}

--- a/app/public/src/pages/component/wiki/wiki-regions.tsx
+++ b/app/public/src/pages/component/wiki/wiki-regions.tsx
@@ -6,8 +6,12 @@ import { DungeonDetails, DungeonPMDO } from "../../../../../types/enum/Dungeon"
 import { Pkm, PkmFamily, PkmIndex } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../../../utils/avatar"
 import SynergyIcon from "../icons/synergy-icon"
+import { cc } from "../../utils/jsx"
+import { usePreference } from "../../../preferences"
+import PokemonPortrait from "../pokemon-portrait"
 
 export default function WikiRegions() {
+  const [antialiasing] = usePreference("antialiasing")
   const { t } = useTranslation()
 
   const [pokemonsPerRegion, setPokemonsPerRegion] = useState<{ [key in DungeonPMDO]?: Pkm[] }>({})
@@ -60,15 +64,11 @@ export default function WikiRegions() {
                   src={`/assets/maps/${dungeon}-preview.png`}
                   loading="lazy"
                   alt={dungeon}
+                  className={cc({ pixelated: !antialiasing })}
                 />
                 <div className="wiki-regional-mons">
                   {(pokemonsPerRegion[dungeon] ?? []).map((pkm) => (
-                    <img
-                      key={pkm}
-                      className="pokemon-portrait"
-                      loading="lazy"
-                      src={getPortraitSrc(PkmIndex[pkm])}
-                    ></img>
+                    <PokemonPortrait key={pkm} loading="lazy" portrait={PkmIndex[pkm]} />
                   ))}
                 </div>
               </li>

--- a/app/public/src/pages/component/wiki/wiki-statistic.tsx
+++ b/app/public/src/pages/component/wiki/wiki-statistic.tsx
@@ -2,93 +2,125 @@ import CSS from "csstype"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { addIconsToDescription } from "../../utils/descriptions"
-
-const imgStyle: CSS.Properties = {
-  width: "64px",
-  height: "64px",
-  imageRendering: "pixelated",
-  marginRight: "10px"
-}
+import { cc } from "../../utils/jsx"
+import { usePreference } from "../../../preferences"
 
 export default function WikiStatistic() {
+  const [antialiasing] = usePreference("antialiasing")
   const { t } = useTranslation()
   return (
     <ul className="wiki-stat">
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/HP.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/HP.png"
+        ></img>
         <h2>{t("stat.HEALTH_POINTS")}</h2>
         <p className="description">
           {addIconsToDescription(t("stat_description.HP"))}
         </p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/SHIELD.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/SHIELD.png"
+        ></img>
         <h2>{t("stat.SHIELD")}</h2>
         <p className="description">{t("stat_description.SHIELD")}</p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/DEF.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/DEF.png"
+        ></img>
         <h2>{t("stat.DEF")}</h2>
         <p className="description">
           {addIconsToDescription(t("stat_description.DEF"))}
         </p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/SPE_DEF.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/SPE_DEF.png"
+        ></img>
         <h2>{t("stat.SPE_DEF")}</h2>
         <p className="description">
           {addIconsToDescription(t("stat_description.SPE_DEF"))}
         </p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/PP.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/PP.png"
+        ></img>
         <h2>{t("stat.POWER_POINTS")}</h2>
         <p className="description">
           {addIconsToDescription(t("stat_description.MAX_PP"))}
         </p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/AP.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/AP.png"
+        ></img>
         <h2>{t("stat.AP")}</h2>
         <p className="description">
           {addIconsToDescription(t("stat_description.AP"))}
         </p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/ATK.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/ATK.png"
+        ></img>
         <h2>{t("stat.ATK")}</h2>
         <p className="description">
           {addIconsToDescription(t("stat_description.ATK"))}
         </p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/RANGE.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/RANGE.png"
+        ></img>
         <h2>{t("stat.RANGE")}</h2>
         <p className="description">
           {addIconsToDescription(t("stat_description.RANGE"))}
         </p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/ATK_SPEED.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/ATK_SPEED.png"
+        ></img>
         <h2>{t("stat.ATK_SPEED")}</h2>
         <p className="description">{t("stat_description.ATK_SPEED")}</p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/CRIT_CHANCE.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/CRIT_CHANCE.png"
+        ></img>
         <h2>{t("stat.CRIT_CHANCE")}</h2>
         <p className="description">
           {addIconsToDescription(t("stat_description.CRIT_CHANCE"))}
         </p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/CRIT_POWER.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/CRIT_POWER.png"
+        ></img>
         <h2>{t("stat.CRIT_POWER")}</h2>
         <p className="description">
           {addIconsToDescription(t("stat_description.CRIT_POWER"))}
         </p>
       </li>
       <li className="my-box">
-        <img style={imgStyle} src="assets/icons/LUCK.png"></img>
+        <img
+          className={cc({ pixelated: !antialiasing })}
+          src="assets/icons/LUCK.png"
+        ></img>
         <h2>{t("stat.LUCK")}</h2>
         <p className="description">
           {addIconsToDescription(t("stat_description.LUCK"))}

--- a/app/public/src/pages/component/wiki/wiki-types.tsx
+++ b/app/public/src/pages/component/wiki/wiki-types.tsx
@@ -19,6 +19,7 @@ import { cc } from "../../utils/jsx"
 import { GamePokemonDetail } from "../game/game-pokemon-detail"
 import { EffectDescriptionComponent } from "../synergy/effect-description"
 import { Checkbox } from "../checkbox/checkbox"
+import { usePreference } from "../../../preferences"
 
 export default function WikiTypes() {
   const { t } = useTranslation()
@@ -50,6 +51,7 @@ export default function WikiTypes() {
 }
 
 export function WikiType(props: { type: Synergy }) {
+  const [antialiasing] = usePreference('antialiasing')
   const { t } = useTranslation()
   const [showEvolutions, setShowEvolutions] = useState(false)
   const [overlap, setOverlap] = useState<Synergy | null>(null)
@@ -159,6 +161,7 @@ export function WikiType(props: { type: Synergy }) {
                         <img
                           src={getPortraitSrc(p.index)}
                           data-tooltip-id={`pokemon-detail-${p.index}`}
+                          className={cc({ pixelated: !antialiasing })}
                         />
                         <Tooltip
                           id={`pokemon-detail-${p.index}`}
@@ -201,6 +204,7 @@ export function WikiAllTypes() {
   }
 
   const [hoveredPokemon, setHoveredPokemon] = useState<Pkm>()
+  const [antialiasing] = usePreference('antialiasing')
   const { t } = useTranslation()
 
   return (
@@ -229,6 +233,7 @@ export function WikiAllTypes() {
                       <img
                         src={getPortraitSrc(p.index)}
                         data-tooltip-id={`pokemon-detail-${p.index}`}
+                        className={cc({ pixelated: !antialiasing })}
                       />
                     </li>
                   )

--- a/app/public/src/pages/component/wiki/wiki-weather.tsx
+++ b/app/public/src/pages/component/wiki/wiki-weather.tsx
@@ -13,9 +13,11 @@ import { addIconsToDescription } from "../../utils/descriptions"
 import { cc } from "../../utils/jsx"
 import { GamePokemonDetail } from "../game/game-pokemon-detail"
 import SynergyIcon from "../icons/synergy-icon"
+import { usePreference } from "../../../preferences"
 
 
 export default function WikiWeather() {
+  const [antialiasing] = usePreference('antialiasing')
   const { t } = useTranslation()
   return (
     <div id="wiki-weather">
@@ -53,7 +55,7 @@ export default function WikiWeather() {
                       })}
                       data-tooltip-id={`pokemon-detail-${p.index}`}
                     >
-                      <img src={getPortraitSrc(p.index)} />
+                      <img src={getPortraitSrc(p.index)} className={cc({ pixelated: !antialiasing })} />
                       <Tooltip
                         id={`pokemon-detail-${p.index}`}
                         className="custom-theme-tooltip game-pokemon-detail-tooltip"

--- a/app/public/src/pages/component/wiki/wiki.css
+++ b/app/public/src/pages/component/wiki/wiki.css
@@ -141,6 +141,12 @@
   border: 2px solid #000000;
 }
 
+#wiki-page .wiki-stat li > img {
+  width: 64px;
+  height: 64px;
+  margin-right: 10px;
+}
+
 #wiki-page .wiki-status li .status-label {
   white-space: initial;
 }
@@ -227,7 +233,6 @@
   border: 1px solid #000000;
   border-radius: 4px;
   box-shadow: 2px 2px 0 #00000060;
-  image-rendering: pixelated;
   height: 250px;
   object-fit: cover;
 }
@@ -327,7 +332,6 @@
 }
 
 #wiki-items img.tree {
-  image-rendering: pixelated;
   width: 50px;
   margin: -8px 8px 0 8px;
 }

--- a/app/public/src/pages/utils/audio.ts
+++ b/app/public/src/pages/utils/audio.ts
@@ -1,7 +1,12 @@
 import { type Scene } from "phaser"
 import { DungeonMusic } from "../../../../types/enum/Dungeon"
 import { logger } from "../../../../utils/logger"
-import { preferences } from "../../preferences"
+import {
+  IPreferencesState,
+  preference,
+  subscribeToPreferences
+} from "../../preferences"
+import { getGameScene } from "../game"
 
 export const SOUNDS = {
   BUTTON_CLICK: "buttonclick.ogg",
@@ -63,7 +68,7 @@ export function playSound(key: Soundkey, volume = 1) {
   const sound = AUDIO_ELEMENTS[key]
   if (sound) {
     sound.currentTime = 0
-    sound.volume = (volume * preferences.sfxVolume) / 100
+    sound.volume = (volume * preference('sfxVolume')) / 100
     sound.play()
   }
 }
@@ -73,13 +78,21 @@ type SceneWithMusic = Phaser.Scene & { music?: Phaser.Sound.WebAudioSound }
 export function playMusic(scene: SceneWithMusic, name: string) {
   if (scene == null || scene.music?.key === "music_" + name) return
   if (scene.music) scene.music.destroy()
-  scene.music = scene.sound.add("music_" + name, {
+
+  const music = scene.sound.add("music_" + name, {
     loop: true
   }) as Phaser.Sound.WebAudioSound
-  scene.sound.pauseOnBlur = !preferences.playInBackground;
-  const musicVolume = preferences.musicVolume / 100
+
+  const unsubscribeToPreferences = subscribeToPreferences(({ musicVolume }) => {
+    music.setVolume(musicVolume / 100)
+  })
+  music.on("stop", unsubscribeToPreferences)
+
+  scene.music = music
+  scene.sound.pauseOnBlur = !preference("playInBackground")
+
   try {
-    scene.music.play({ volume: musicVolume, loop: true })
+    scene.music.play({ volume: preference("musicVolume") / 100, loop: true })
   } catch (err) {
     logger.error("can't play music", err)
   }

--- a/app/public/src/preferences.ts
+++ b/app/public/src/preferences.ts
@@ -1,5 +1,7 @@
 import Phaser from "phaser"
 import { localStore, LocalStoreKeys } from "./pages/utils/store"
+import { SetStateAction, useCallback, useEffect, useState } from "react"
+import { removeInArray } from "../../utils/array"
 
 export type Keybindings = {
   sell: string
@@ -21,6 +23,7 @@ export interface IPreferencesState {
   disableAnimatedTilemap: boolean
   keybindings: Keybindings
   renderer: number
+  antialiasing: boolean
 }
 
 const defaultPreferences: IPreferencesState = {
@@ -41,12 +44,11 @@ const defaultPreferences: IPreferencesState = {
     lock: "R",
     switch: "SPACE",
     emote: "A"
-  }
+  },
+  antialiasing: false
 }
 
-export const preferences: IPreferencesState = loadPreferences()
-
-export function loadPreferences(): IPreferencesState {
+function loadPreferences(): IPreferencesState {
   if (localStore.has(LocalStoreKeys.PREFERENCES)) {
     return {
       ...defaultPreferences,
@@ -61,7 +63,79 @@ export function loadPreferences(): IPreferencesState {
   }
 }
 
-export async function savePreferences(modified: Partial<IPreferencesState>) {
-  localStore.put(LocalStoreKeys.PREFERENCES, modified)
-  Object.assign(preferences, modified)
+type Subscription = (newPreferences: IPreferencesState) => void
+let preferences: IPreferencesState = Object.freeze(loadPreferences())
+const subscriptions: Subscription[] = []
+
+// returns a method that unsubscribes
+export function subscribeToPreferences(fn: Subscription, runInitially = false) {
+  subscriptions.push(fn)
+  if (runInitially) fn(preferences)
+  return unsubscribeToPreferences.bind(undefined, fn)
+}
+
+export function unsubscribeToPreferences(fn: Subscription) {
+  removeInArray(subscriptions, fn)
+}
+
+export function preference<T extends keyof IPreferencesState>(
+  key: T
+): IPreferencesState[T] {
+  return preferences[key]
+}
+
+// save preferences and notify subscribers
+export function savePreferences(
+  modified:
+    | Partial<IPreferencesState>
+    | ((old: IPreferencesState) => Partial<IPreferencesState>)
+) {
+  const resolved: Partial<IPreferencesState> =
+    typeof modified === "function" ? modified(preferences) : modified
+  localStore.put(LocalStoreKeys.PREFERENCES, resolved)
+  preferences = Object.freeze({ ...preferences, ...resolved })
+  subscriptions.forEach((s) => s(preferences))
+}
+
+// react hooks
+export function usePreferences(): [IPreferencesState, typeof savePreferences] {
+  const [preferenceState, setPreferenceState] = useState(preferences)
+
+  // unsubscribes on unmount since `subscribeToPreferences` returns an unsubscribe fn
+  useEffect(() => subscribeToPreferences(setPreferenceState), [])
+
+  return [preferenceState, savePreferences]
+}
+
+export function usePreference<T extends keyof IPreferencesState>(
+  key: T
+): [
+  IPreferencesState[T],
+  (
+    set:
+      | IPreferencesState[T]
+      | ((old: IPreferencesState[T]) => IPreferencesState[T])
+  ) => void
+] {
+  const [preferenceState, setPreferenceState] = useState<IPreferencesState[T]>(
+    preferences[key]
+  )
+
+  // unsubscribes on unmount since `subscribeToPreferences` returns an unsubscribe fn
+  useEffect(
+    () =>
+      subscribeToPreferences((newPreferences: IPreferencesState) => {
+        setPreferenceState(newPreferences[key])
+      }),
+    [key]
+  )
+
+  const update = useCallback(
+    (value: IPreferencesState[T] | ((old: IPreferencesState[T]) => void)) => {
+      savePreferences({ [key]: value })
+    },
+    [key]
+  )
+
+  return [preferenceState, update]
 }

--- a/app/public/src/style/index.css
+++ b/app/public/src/style/index.css
@@ -185,7 +185,6 @@ p:last-child {
 .game-emote-bubble img {
   width: 80px;
   height: 80px;
-  image-rendering: pixelated;
 }
 
 .game-emote-bubble:after {
@@ -278,7 +277,6 @@ p:last-child {
   border: 1px solid #000000;
   border-radius: 4px;
   box-shadow: 2px 2px 0 #00000060;
-  image-rendering: pixelated;
   position: relative;
 }
 
@@ -319,4 +317,8 @@ p:last-child {
   color: black;
   text-shadow: 1px 1px 1px white, -1px 1px 1px white, 1px -1px 1px white, -1px
     -1px 1px white;
+}
+
+.pixelated {
+  image-rendering: pixelated;
 }

--- a/app/public/src/style/toastify.css
+++ b/app/public/src/style/toastify.css
@@ -19,17 +19,4 @@
 .toast-new-pokemon img {
   width: 40px;
   height: 40px;
-  image-rendering: pixelated;
-}
-
-.toast-emote {
-  right: 85px !important;
-  border: none !important;
-  background-color: transparent !important;
-}
-
-.toast-emote img {
-  width: 80px;
-  height: 80px;
-  image-rendering: pixelated;
 }


### PR DESCRIPTION
- Add antialiasing preference
  - Change styles accordingly
- Add `PokemonPortrait` component to DRY up some images
- Refactor preferences a bit
  - Add subscriptions and React hooks so components can update in response to preferences changing
  - Freeze object and remove export to prevent accidental writes to preferences without going through `savePreferences` (and notifying subscribers, etc)
  - Move volume update logic to `playMusic` so options modals etc don't have to concerns themselves with it
  - Remove extrenuous instances of `loadPreferences` and don't export it since they're loaded initially anyway
- Clean up keybind modal a little bit
  - Rename `keyRemapped` -> `currentlyRemapping` for clarity
  - Memoize

lmk if it's too big and ill break it up. or if you just generally dont fw the concept