### PR TITLE
Fix ghost battles sometimes calling afterSimulationStart hooks for one team twice

### DIFF
--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -157,19 +157,20 @@ export default class Simulation extends Schema implements ISimulation {
     this.applyPostEffects(blueBoard, redBoard)
 
     // afterSimulationStart hooks
-    for (const player of [this.bluePlayer, this.redPlayer]) {
+    for (const [player, team] of [
+      [this.bluePlayer, this.blueTeam] as const,
+      [this.redPlayer, this.redTeam] as const
+    ]) {
       if (player) {
-        const entityTeam =
-          player.team === Team.BLUE_TEAM ? this.blueTeam : this.redTeam
         player.board.forEach((pokemon) => {
-          const entity = values(entityTeam).find(
+          const entity = values(team).find(
             (p) => p.refToBoardPokemon === pokemon
           )
           if (entity) {
             pokemon.afterSimulationStart({
               simulation: this,
               player,
-              team: entityTeam,
+              team,
               entity
             })
           }


### PR DESCRIPTION
Same issue as what happened with isGhostOpponent. Simulation should never be checking the player's team, because it won't be relevant to that simulation for ghost simulations. There are no more checks for the player's team in simulation.

https://discord.com/channels/737230355039387749/1338402236128301077