### PR TITLE
fix pointer down propagation in carousel rounds

### DIFF
--- a/app/public/src/game/components/draggable-object.ts
+++ b/app/public/src/game/components/draggable-object.ts
@@ -27,7 +27,7 @@ export default class DraggableObject extends GameObjects.Container {
           _y: number,
           event: Phaser.Types.Input.EventData
         ) => {
-          this.onPointerDown(pointer)
+          this.onPointerDown(pointer, event)
         }
       )
       .on("pointerup", () => this.onPointerUp())
@@ -55,7 +55,7 @@ export default class DraggableObject extends GameObjects.Container {
     }
   }
 
-  onPointerDown(pointer) {
+  onPointerDown(pointer, event) {
     if (!this.dragDisabled) {
       document.body.classList.add("grabbing")
     }

--- a/app/public/src/game/components/item-container.ts
+++ b/app/public/src/game/components/item-container.ts
@@ -121,9 +121,13 @@ export default class ItemContainer extends DraggableObject {
     }
   }
 
-  onPointerDown(pointer: Phaser.Input.Pointer) {
-    super.onPointerDown(pointer)
+  onPointerDown(
+    pointer: Phaser.Input.Pointer,
+    event: Phaser.Types.Input.EventData
+  ) {
+    super.onPointerDown(pointer, event)
     this.parentContainer.bringToTop(this)
+    event.stopPropagation()
     if (pointer.rightButtonDown() && !preference("showDetailsOnHover")) {
       if (!this.detail?.visible) {
         this.openDetail()

--- a/app/public/src/game/components/pokemon-avatar.ts
+++ b/app/public/src/game/components/pokemon-avatar.ts
@@ -249,8 +249,8 @@ export default class PokemonAvatar extends PokemonSprite {
     }
   }
 
-  onPointerDown(pointer: Phaser.Input.Pointer): void {
-    super.onPointerDown(pointer)
+  onPointerDown(pointer: Phaser.Input.Pointer, event): void {
+    super.onPointerDown(pointer, event)
     const scene = this.scene as GameScene
 
     if (
@@ -280,7 +280,7 @@ export class EmoteBubble extends GameObjects.DOMElement {
 
     const emoteImg = document.createElement("img")
     emoteImg.src = getAvatarSrc(emoteAvatar)
-    emoteImg.className = cc({ pixelated: !preference('antialiasing') })
+    emoteImg.className = cc({ pixelated: !preference("antialiasing") })
 
     this.dom.appendChild(emoteImg)
     this.setElement(this.dom)

--- a/app/public/src/game/components/pokemon-special.tsx
+++ b/app/public/src/game/components/pokemon-special.tsx
@@ -41,8 +41,9 @@ export default class PokemonSpecial extends PokemonSprite {
     this.dialogTitle = dialogTitle
   }
 
-  onPointerDown(pointer) {
-    super.onPointerDown(pointer)
+  onPointerDown(pointer, event) {
+    super.onPointerDown(pointer, event)
+    event.stopPropagation()
     this.animationManager.animatePokemon(this, PokemonActionState.EMOTE, false)
   }
 

--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -357,8 +357,11 @@ export default class PokemonSprite extends DraggableObject {
     s.lastPokemonDetail = this
   }
 
-  onPointerDown(pointer: Phaser.Input.Pointer) {
-    super.onPointerDown(pointer)
+  onPointerDown(
+    pointer: Phaser.Input.Pointer,
+    event: Phaser.Types.Input.EventData
+  ) {
+    super.onPointerDown(pointer, event)
     if (
       this.shouldShowTooltip &&
       !preference("showDetailsOnHover") &&


### PR DESCRIPTION
During carousel rounds, if you right click on an item to see the detail, the click is not intercepted and counted as a movement. It should intercept the click

https://discord.com/channels/737230355039387749/1340096570238046258