### PR TITLE
fix berry trees per region

### DIFF
--- a/app/core/matter/mini-game.ts
+++ b/app/core/matter/mini-game.ts
@@ -25,6 +25,7 @@ import {
 import { DungeonDetails, DungeonPMDO } from "../../types/enum/Dungeon"
 import { PokemonActionState } from "../../types/enum/Game"
 import {
+  Berries,
   CraftableItems,
   Item,
   ItemComponents,
@@ -617,8 +618,14 @@ export class MiniGame {
       if (player && PortalCarouselStages.includes(state.stageLevel)) {
         if (avatar.portalId && this.portals?.has(avatar.portalId)) {
           const portal = this.portals.get(avatar.portalId)!
-          player.map = portal.map
-          player.updateRegionalPool(state, true)
+          if (portal.map !== player.map) {
+            player.map = portal.map
+            player.updateRegionalPool(state, true)
+            for (let i = 0; i < player.berryTreesType.length; i++) {
+              player.berryTreesType[i] = pickRandomIn(Berries)
+              player.berryTreesStage[i] = 0
+            }
+          }
         }
 
         const symbols = this.symbolsByPortal.get(avatar.portalId) ?? []

--- a/app/public/dist/client/changelog/patch-6.0.md
+++ b/app/public/dist/client/changelog/patch-6.0.md
@@ -36,6 +36,7 @@
 # Changes to Synergies
 
 - New synergy Gourmet: Gourmet Pokémon can be equipped with a Chef's Hat. Chefs will cook up their Signature Dish between fights and feed adjacent allies, giving them various buffs and effects.
+- Berry trees no longer change every time a berry is collected. Instead, they change when you change region.
 
 # Changes to Items
 

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -863,7 +863,6 @@ export class OnPickBerryCommand extends Command<
     if (player && player.berryTreesStage[berryIndex] >= 3) {
       player.berryTreesStage[berryIndex] = 0
       player.items.push(player.berryTreesType[berryIndex])
-      player.berryTreesType[berryIndex] = pickRandomIn(Berries)
     }
   }
 }


### PR DESCRIPTION
Berry trees no longer change every time a berry is collected. Instead, they change when you change region.