### PR TITLE
Fix Trick-or-Treat damage handling

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -10488,8 +10488,15 @@ export class TrickOrTreatStrategy extends AbilityStrategy {
     } else if (pokemon.ap <= 50) {
       // 0-50 AP: shrink unit size and HP
       const lifeReduction = 0.4 / (1 + pokemon.ap / 100)
-      target.life = Math.floor(target.life * lifeReduction)
-      target.hp = Math.floor(target.hp * lifeReduction)
+      target.handleSpecialDamage(
+        target.life * (1 - lifeReduction),
+        board,
+        AttackType.TRUE,
+        pokemon,
+        false,
+        false
+      )
+      target.hp = min(1)(Math.floor(target.hp * lifeReduction))
       target.status.triggerFlinch(3000, target, pokemon)
     } else if (pokemon.ap <= 100) {
       // 51-100 AP: transforms the unit into magikarp for X seconds, replacing its ability with splash


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1339744574784147476
The target's life could be set to 0 (with `Math.floor`) outside of `handleDamage` which doesn't execute the death sequence and causes them to be stuck on the board at 0 HP.