### PR TITLE
tweak max synergy stones count in late game carousels and rewards

### DIFF
--- a/app/core/matter/mini-game.ts
+++ b/app/core/matter/mini-game.ts
@@ -27,6 +27,7 @@ import { PokemonActionState } from "../../types/enum/Game"
 import {
   Berries,
   CraftableItems,
+  CraftableNonSynergyItems,
   Item,
   ItemComponents,
   SynergyStones
@@ -416,6 +417,15 @@ export class MiniGame {
       } while (count >= maxCopiesPerItem && tries < 10)
       items.push(item)
     }
+
+    if (itemsSet === CraftableItems) {
+      while (items.filter((i) => SynergyStones.includes(i)).length > 4) {
+        // ensure that there are at most 4 synergy stones in the carousel
+        const index = items.findIndex((i) => SynergyStones.includes(i))
+        items[index] = pickRandomIn(CraftableNonSynergyItems)
+      }
+    }
+
     return items
   }
 

--- a/app/models/pve-stages.ts
+++ b/app/models/pve-stages.ts
@@ -4,7 +4,8 @@ import {
   CraftableItems,
   Item,
   NonSpecialItemComponents,
-  ShinyItems
+  ShinyItems,
+  CraftableNonSynergyItems
 } from "../types/enum/Item"
 import { Pkm } from "../types/enum/Pokemon"
 import { pickNRandomIn, pickRandomIn } from "../utils/random"
@@ -121,7 +122,10 @@ export const PVEStages: { [turn: number]: PVEStage } = {
       [Pkm.ARTICUNO, 6, 2]
     ],
     getRewardsPropositions(player: Player) {
-      return pickNRandomIn(CraftableItems, 3)
+      return [
+        ...pickNRandomIn(CraftableNonSynergyItems, 2),
+        ...pickNRandomIn(CraftableItems, 1)
+      ]
     }
   },
 
@@ -135,7 +139,10 @@ export const PVEStages: { [turn: number]: PVEStage } = {
       [Pkm.SUICUNE, 6, 2]
     ],
     getRewardsPropositions(player: Player) {
-      return pickNRandomIn(CraftableItems, 3)
+      return [
+        ...pickNRandomIn(CraftableNonSynergyItems, 2),
+        ...pickNRandomIn(CraftableItems, 1)
+      ]
     }
   },
 
@@ -149,7 +156,10 @@ export const PVEStages: { [turn: number]: PVEStage } = {
       [Pkm.PRIMAL_GROUDON, 6, 2]
     ],
     getRewardsPropositions(player: Player) {
-      return pickNRandomIn(CraftableItems, 3)
+      return [
+        ...pickNRandomIn(CraftableNonSynergyItems, 2),
+        ...pickNRandomIn(CraftableItems, 1)
+      ]
     }
   },
 
@@ -166,7 +176,10 @@ export const PVEStages: { [turn: number]: PVEStage } = {
       [Pkm.REGIDRAGO, 5, 2]
     ],
     getRewardsPropositions(player: Player) {
-      return pickNRandomIn(CraftableItems, 3)
+      return [
+        ...pickNRandomIn(CraftableNonSynergyItems, 2),
+        ...pickNRandomIn(CraftableItems, 1)
+      ]
     }
   },
 

--- a/app/public/dist/client/changelog/patch-6.0.md
+++ b/app/public/dist/client/changelog/patch-6.0.md
@@ -79,6 +79,8 @@
 - Regional variants are no longer found in maps with common synergies between the variant and the original Pokémon
 - When an effect is considering the strongest Pokémon, or the pokémon with the highest stat, if several Pokémon are equal, it now selects a random Pokémon among those. Before, it was based on board position. This is especially relevant for Ghost curses.
 - Farthest reachable target algorithm has been improved to favor the farthest target when there are multiple equidistant free cells. This impacts several abilities and effects, such as Comet Shard and all dashers abilities
+- PVE rewards from stage 24 onwards now propose 1 synergy stone maximum
+- Item carousels now propose 4 synergy stones maximum
 
 # UI
 

--- a/app/types/enum/Item.ts
+++ b/app/types/enum/Item.ts
@@ -370,6 +370,10 @@ export const WeatherByWeatherRocks = reverseMap(WeatherRocksByWeather)
 
 export const CraftableItems: Item[] = Object.keys(ItemRecipe) as Item[]
 
+export const CraftableNonSynergyItems: Item[] = CraftableItems.filter(
+  (item) => SynergyGivenByItem.hasOwnProperty(item) === false
+)
+
 export const SynergyStones = [
   Item.OLD_AMBER,
   Item.DAWN_STONE,


### PR DESCRIPTION
- PVE rewards from stage 24 onwards now propose 1 synergy stone maximum
- Item carousels now propose 4 synergy stones maximum

https://discord.com/channels/737230355039387749/1340412738979238010