### PR TITLE
Disabled right click browser menu when in game

### DIFF
--- a/app/public/dist/client/changelog/patch-6.0.md
+++ b/app/public/dist/client/changelog/patch-6.0.md
@@ -89,6 +89,7 @@
 - Added anti-aliasing in Interface options
 - Artificial items are now automatically dropped when benching the unit that was holding them.
 - Added search bar in Wiki > Abilities
+- Disabled right click browser menu when in game
 
 # Bugfix
 

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -758,7 +758,7 @@ export default function Game() {
   ])
 
   return (
-    <main id="game-wrapper">
+    <main id="game-wrapper" onContextMenu={(e) => e.preventDefault()}>
       {loaded ? (
         <>
           <MainSidebar page="game" leave={leave} leaveLabel={t("leave_game")} />


### PR DESCRIPTION
I saw too many players being annoyed by browser context menu when right clicking the wrong thing in game

We'll see if some players actually need the browser menu, but i doubt it