### PR TITLE
add a flag to prevent creating tournament lobbies twice

### DIFF
--- a/app/models/colyseus-models/tournament.ts
+++ b/app/models/colyseus-models/tournament.ts
@@ -2,7 +2,7 @@ import { Schema, MapSchema, ArraySchema, type } from "@colyseus/schema"
 import {
   ITournament,
   ITournamentBracket,
-  ITournamentPlayer,
+  ITournamentPlayer
 } from "../../types/interfaces/Tournament"
 import { resetArraySchema } from "../../utils/schemas"
 
@@ -21,7 +21,7 @@ export class TournamentPlayerSchema
     avatar: string,
     elo: number,
     ranks: number[] | ArraySchema<number> = [],
-    eliminated: boolean = false,
+    eliminated: boolean = false
   ) {
     super()
     this.name = name
@@ -43,7 +43,7 @@ export class TournamentBracketSchema
   constructor(
     name: string,
     playersId: string[] | ArraySchema<string>,
-    finished: boolean = false,
+    finished: boolean = false
   ) {
     super()
     this.name = name
@@ -61,6 +61,7 @@ export class TournamentSchema extends Schema implements ITournament {
   @type({ map: TournamentBracketSchema }) brackets =
     new MapSchema<TournamentBracketSchema>()
   @type("boolean") finished: boolean
+  pendingLobbiesCreation: boolean = false
 
   constructor(
     id: string,
@@ -68,7 +69,7 @@ export class TournamentSchema extends Schema implements ITournament {
     startDate: string,
     players: Map<string, ITournamentPlayer>,
     brackets: Map<string, ITournamentBracket>,
-    finished: boolean = false,
+    finished: boolean = false
   ) {
     super()
     this.id = id
@@ -85,8 +86,8 @@ export class TournamentSchema extends Schema implements ITournament {
             p.avatar,
             p.elo,
             p.ranks,
-            p.eliminated,
-          ),
+            p.eliminated
+          )
         )
       })
     }
@@ -95,7 +96,7 @@ export class TournamentSchema extends Schema implements ITournament {
       brackets.forEach((b, bracketId) => {
         this.brackets.set(
           bracketId,
-          new TournamentBracketSchema(b.name, b.playersId, b.finished),
+          new TournamentBracketSchema(b.name, b.playersId, b.finished)
         )
       })
     }

--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -1317,6 +1317,8 @@ export class CreateTournamentLobbiesCommand extends Command<
         mongoTournament.brackets = convertSchemaToRawObject(tournament.brackets)
         await mongoTournament.save()
       }
+
+      tournament.pendingLobbiesCreation = false
     } catch (error) {
       logger.error(error)
     }
@@ -1373,7 +1375,11 @@ export class EndTournamentMatchCommand extends Command<
         }
       })
 
-      if (values(tournament.brackets).every((b) => b.finished)) {
+      if (
+        !tournament.pendingLobbiesCreation &&
+        values(tournament.brackets).every((b) => b.finished)
+      ) {
+        tournament.pendingLobbiesCreation = true // prevent executing command multiple times
         //save brackets and player ranks to db before moving to next stage
         const mongoTournament = await Tournament.findById(tournamentId)
         if (mongoTournament) {


### PR DESCRIPTION
add pendingLobbiesCreation boolean flag to tournament that locks the NextStageCommand until all lobbies are created

Hopefully this will avoid what happened on todays tournament where NextStageCommand got called twice (i suspect because the two remaining lobbies finished almost at the same time during an async command)