### PR TITLE
Show popular items on in-game pokemon tooltips

### DIFF
--- a/app/models/mongo-models/pokemons-statistic-v2.ts
+++ b/app/models/mongo-models/pokemons-statistic-v2.ts
@@ -2,18 +2,22 @@ import { Schema, model } from "mongoose"
 import { Item } from "../../types/enum/Item"
 import { Pkm } from "../../types/enum/Pokemon"
 
+export interface IPokemonsStatisticV2Pokemon {
+  rank: number
+  count: number
+  name: Pkm
+  items: Item[]
+  item_count: number
+}
+
 export interface IPokemonsStatisticV2 {
   tier: string
-  pokemons: Map<
-    string,
-    {
-      rank: number
-      count: number
-      name: Pkm
-      items: Item[]
-      item_count: number
-    }
-  >
+  pokemons: Map<string, IPokemonsStatisticV2Pokemon>
+}
+
+export interface ISerializedPokemonsStatisticV2 {
+  tier: string
+  pokemons: Record<string, IPokemonsStatisticV2Pokemon>
 }
 
 const pokemonsStatistic = new Schema({

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -3125,6 +3125,7 @@
   "play_music_in_background": "Play music in background",
   "toggle_fullscreen": "Toggle fullscreen",
   "show_details_on_hover": "Show details on hover instead of right click",
+  "sticky_shop_tooltips": "Sticky shop tooltips (stay open on hover)",
   "show_damage_numbers": "Show damage numbers",
   "disable_animated_tilemap": "Disable background animations",
   "antialiasing": "Enable anti-aliasing",

--- a/app/public/src/game/components/pokemon-detail.tsx
+++ b/app/public/src/game/components/pokemon-detail.tsx
@@ -15,6 +15,7 @@ import { getPortraitSrc } from "../../../../utils/avatar"
 import { DishByPkm } from "../../../../core/dishes"
 import { cc } from "../../pages/utils/jsx"
 import { preference } from "../../preferences"
+import GamePopularItems from "../../pages/component/game/game-popular-items"
 
 export default class PokemonDetail extends GameObjects.DOMElement {
   dom: HTMLDivElement
@@ -63,6 +64,9 @@ export default class PokemonDetail extends GameObjects.DOMElement {
 
     this.dom = document.createElement("div")
     this.dom.className = "my-container game-pokemon-detail-tooltip"
+    this.dom.addEventListener("contextmenu", (e) => {
+      e.preventDefault()
+    })
     const wrap = document.createElement("div")
     wrap.className = "game-pokemon-detail"
 
@@ -156,6 +160,10 @@ export default class PokemonDetail extends GameObjects.DOMElement {
       typesList.appendChild(ty)
     })
     wrap.appendChild(typesList)
+
+    const popularItems = document.createElement("div")
+    ReactDOM.createRoot(popularItems).render(<GamePopularItems pokemon={name} />)
+    wrap.appendChild(popularItems)
 
     let stats = [
       { stat: Stat.HP, elm: this.hp },

--- a/app/public/src/pages/component/game/game-pokemon-detail.css
+++ b/app/public/src/pages/component/game/game-pokemon-detail.css
@@ -8,6 +8,7 @@
   grid-template-columns: 88px 1fr auto;
   grid-template-areas:
     "portrait entry types"
+    "portrait entry items"
     "stats stats stats"
     "dish dish dish"
     "passive passive passive"
@@ -19,8 +20,26 @@
   padding: 5px;
 }
 
-.game-pokemon-detail p {
-  margin: 0;
+.game-pokemon-detail-popular-items {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  justify-content: start;
+  grid-area: items;
+  gap: 0.1rem;
+}
+
+.game-pokemon-detail-popular-items-items {
+  display: flex;
+  flex-direction: row;
+  align-items: start;
+  justify-content: start;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.game-pokemon-detail-popular-items-item {
+  height: 1.5rem;
 }
 
 .game-pokemon-detail-entry {

--- a/app/public/src/pages/component/game/game-pokemon-detail.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-detail.tsx
@@ -18,20 +18,23 @@ import "./game-pokemon-detail.css"
 import { Synergy } from "../../../../../types/enum/Synergy"
 import { cc } from "../../utils/jsx"
 import { usePreference } from "../../../preferences"
+import GamePopularItems from "./game-popular-items"
 
-export function GamePokemonDetail(props: {
-  pokemon: Pkm | Pokemon
-  shiny?: boolean
-  emotion?: Emotion
-}) {
+export function GamePokemonDetail(
+  props: {
+    pokemon: Pkm | Pokemon
+    shiny?: boolean
+    emotion?: Emotion
+  } & JSX.IntrinsicElements["div"]
+) {
+  const { pokemon: pkm, shiny, emotion, ...restProps } = props
+
   const [antialiasing] = usePreference("antialiasing")
   const { t } = useTranslation()
   const pokemon: Pokemon = useMemo(
     () =>
-      typeof props.pokemon === "string"
-        ? PokemonFactory.createPokemonFromName(props.pokemon)
-        : props.pokemon,
-    [props.pokemon]
+      typeof pkm === "string" ? PokemonFactory.createPokemonFromName(pkm) : pkm,
+    [pkm]
   )
 
   const pokemonStats = useMemo(
@@ -54,7 +57,7 @@ export function GamePokemonDetail(props: {
   )
 
   return (
-    <div className="game-pokemon-detail in-shop">
+    <div className="game-pokemon-detail in-shop" {...restProps}>
       <img
         className={cc("game-pokemon-detail-portrait", {
           pixelated: !antialiasing
@@ -62,8 +65,8 @@ export function GamePokemonDetail(props: {
         style={{ borderColor: RarityColor[pokemon.rarity] }}
         src={getPortraitSrc(
           pokemon.index,
-          props.shiny ?? pokemon.shiny,
-          props.emotion ?? pokemon.emotion
+          shiny ?? pokemon.shiny,
+          emotion ?? pokemon.emotion
         )}
       />
       <div className="game-pokemon-detail-entry">
@@ -94,6 +97,8 @@ export function GamePokemonDetail(props: {
           <SynergyIcon type={type} key={type} />
         ))}
       </div>
+
+      <GamePopularItems pokemon={pokemon.name} />
 
       <div className="game-pokemon-detail-stats">
         {pokemonStats.map(({ stat, value }) => (

--- a/app/public/src/pages/component/game/game-pokemon-portrait.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-portrait.tsx
@@ -16,7 +16,7 @@ import { Money } from "../icons/money"
 import SynergyIcon from "../icons/synergy-icon"
 import { GamePokemonDetail } from "./game-pokemon-detail"
 import "./game-pokemon-portrait.css"
-import { usePreference } from "../../../preferences"
+import { usePreference, usePreferences } from "../../../preferences"
 
 export default function GamePokemonPortrait(props: {
   index: number
@@ -27,7 +27,7 @@ export default function GamePokemonPortrait(props: {
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>,
   inPlanner?: boolean
 }) {
-  const [antialiasing] = usePreference("antialiasing")
+  const [{ antialiasing, stickyShopTooltips }] = usePreferences()
   const pokemon = useMemo(
     () =>
       typeof props.pokemon === "string"
@@ -165,6 +165,7 @@ export default function GamePokemonPortrait(props: {
         id={`tooltip-${props.origin}-${props.index}`}
         className="custom-theme-tooltip game-pokemon-detail-tooltip"
         place="top"
+        clickable={stickyShopTooltips}
       >
         <GamePokemonDetail
           key={pokemonInPortrait.id}

--- a/app/public/src/pages/component/game/game-popular-items.tsx
+++ b/app/public/src/pages/component/game/game-popular-items.tsx
@@ -1,0 +1,62 @@
+import React, { useMemo } from "react"
+import { Pkm } from "../../../../../types/enum/Pokemon"
+import { getGameScene } from "../../game"
+import { Item } from "../../../../../types/enum/Item"
+import { usePreference } from "../../../preferences"
+import { cc } from "../../utils/jsx"
+import { Tooltip } from "react-tooltip"
+import { ItemDetailTooltip } from "../../../game/components/item-detail"
+import { useTranslation } from "react-i18next"
+
+export default function GamePopularItems(props: { pokemon: Pkm }) {
+  const [antialiasing] = usePreference("antialiasing")
+  const { t } = useTranslation()
+
+  const popularItems = useMemo(() => {
+    const scene = getGameScene()
+    if (!scene) return null
+
+    const map: Map<Pkm, Item[]> = scene.cache.json.get("meta-pokemon")
+    if (!map) return null
+
+    const itemList = map.get(props.pokemon)
+    if (!itemList) return null
+
+    return itemList.slice(0, 5)
+  }, [props.pokemon])
+
+  return (
+    <div className="game-pokemon-detail-popular-items">
+      {!!popularItems?.length && (
+        <>
+          <div className="game-pokemon-detail-popular-items-header">
+            {t("popular_items")}:
+          </div>
+          <div className="game-pokemon-detail-popular-items-items">
+            {popularItems.map((item) => (
+              <img
+                key={item}
+                src={"assets/item/" + item + ".png"}
+                className={cc("game-pokemon-detail-popular-items-item", {
+                  pixelated: !antialiasing
+                })}
+                data-tooltip-id="tooltip-game-pokemon-detail-item"
+                data-item={item}
+              ></img>
+            ))}
+          </div>
+
+          <Tooltip
+            render={({ activeAnchor }) =>
+              !!activeAnchor && (
+                <ItemDetailTooltip item={activeAnchor.dataset.item as Item} />
+              )
+            }
+            id="tooltip-game-pokemon-detail-item"
+            className="custom-theme-tooltip item-detail-tooltip"
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/app/public/src/pages/component/options/game-options-modal.tsx
+++ b/app/public/src/pages/component/options/game-options-modal.tsx
@@ -135,6 +135,16 @@ export default function GameOptionsModal(props: {
           <p>
             <Checkbox
               isDark
+              checked={preferences.stickyShopTooltips}
+              onToggle={(checked) =>
+                setPreferences({ stickyShopTooltips: checked })
+              }
+              label={t("sticky_shop_tooltips")}
+            />
+          </p>
+          <p>
+            <Checkbox
+              isDark
               checked={preferences.showDamageNumbers}
               onToggle={(checked) =>
                 setPreferences({ showDamageNumbers: checked })

--- a/app/public/src/preferences.ts
+++ b/app/public/src/preferences.ts
@@ -24,6 +24,7 @@ export interface IPreferencesState {
   keybindings: Keybindings
   renderer: number
   antialiasing: boolean
+  stickyShopTooltips: boolean
 }
 
 const defaultPreferences: IPreferencesState = {
@@ -45,13 +46,20 @@ const defaultPreferences: IPreferencesState = {
     switch: "SPACE",
     emote: "A"
   },
-  antialiasing: false
+  antialiasing: false,
+  stickyShopTooltips: true
+}
+
+// for when we add a preference or change a default that may interfere with a practiced player's muscle memory, etc
+const defaultPreferencesForExistingPlayers: Partial<IPreferencesState> = {
+  stickyShopTooltips: false
 }
 
 function loadPreferences(): IPreferencesState {
   if (localStore.has(LocalStoreKeys.PREFERENCES)) {
     return {
       ...defaultPreferences,
+      ...defaultPreferencesForExistingPlayers,
       ...localStore.get(LocalStoreKeys.PREFERENCES),
       keybindings: {
         ...defaultPreferences.keybindings,

--- a/app/utils/array.ts
+++ b/app/utils/array.ts
@@ -39,3 +39,7 @@ export function count<T>(arr: T[] | ArraySchema<T>, el: T): number {
 export function wrapInArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
 }
+
+export function compactArray<T>(value: (T | undefined | null)[]): T[] {
+  return value.filter(n => n) as T[];
+}

--- a/db-commands/seed-detailled-statistics.ts
+++ b/db-commands/seed-detailled-statistics.ts
@@ -1,0 +1,101 @@
+import dotenv from "dotenv"
+import { connect } from "mongoose"
+import { nanoid } from "nanoid"
+import { BotV2, IBot } from "../app/models/mongo-models/bot-v2"
+import { logger } from "../app/utils/logger"
+import { readFile } from "fs/promises"
+import DetailledStatistic, {
+  IDetailledStatistic,
+  Pokemon as IDetailledStatisticPokemon
+} from "../app/models/mongo-models/detailled-statistic-v2"
+import { MAX_PLAYERS_PER_GAME } from "../app/types/Config"
+import { computeSynergies } from "../app/models/colyseus-models/synergies"
+import { PokemonClasses } from "../app/models/colyseus-models/pokemon"
+import { Passive } from "../app/types/enum/Passive"
+import { getAvatarString } from "../app/utils/avatar"
+
+async function main() {
+  dotenv.config()
+
+  logger.debug("retrieving data ...")
+  const data = await readFile(
+    process.argv[2] || "db-commands/botv2.json",
+    "utf8"
+  )
+  if (!data) {
+    logger.error("Couldn't load botv2.json")
+    process.exit(1)
+  }
+
+  logger.debug("parsing JSON data ...")
+  let botData: IBot[]
+  try {
+    botData = JSON.parse(data)
+  } catch (e) {
+    logger.error("Parsing error:", e)
+    process.exit(1)
+  }
+
+  const stats: IDetailledStatistic[] = []
+
+  logger.debug("process data ...")
+  for (let i = 0; i < botData.length; i += MAX_PLAYERS_PER_GAME) {
+    const slice = botData
+      .slice(i, Math.min(i + MAX_PLAYERS_PER_GAME, botData.length))
+      .sort((a, b) => b.elo - a.elo)
+
+    slice.forEach((bot, rank) => {
+      bot.steps.forEach(({ board }) => {
+        const pokemon = board
+          .filter((botPokemon) => botPokemon.y != 0)
+          .map((botPokemon) => ({
+            pokemon: new PokemonClasses[botPokemon.name](
+              botPokemon.shiny,
+              botPokemon.emotion
+            ),
+            botPokemon
+          }))
+          .filter(({ pokemon }) => pokemon.passive !== Passive.INANIMATE)
+
+        const statPokemon = pokemon.map(({ pokemon, botPokemon }) => {
+          const avatar = getAvatarString(
+            pokemon.index,
+            pokemon.shiny,
+            pokemon.emotion
+          )
+          const s: IDetailledStatisticPokemon = {
+            name: botPokemon.name,
+            avatar: avatar,
+            items: botPokemon.items
+          }
+          return s
+        })
+
+        const synergiesMap = computeSynergies(pokemon.map((p) => p.pokemon))
+
+        stats.push({
+          time: Date.now(),
+          name: bot.name,
+          pokemons: statPokemon,
+          rank: rank + 1,
+          nbplayers: slice.length,
+          avatar: bot.avatar,
+          playerId: bot.id,
+          elo: bot.elo,
+          synergies: synergiesMap
+        })
+      })
+    })
+  }
+
+  logger.debug("connect to db ...")
+  const db = await connect(process.env.MONGO_URI!)
+
+  logger.debug("import into db ...")
+  await DetailledStatistic.create(stats)
+
+  await db.disconnect()
+  logger.debug("all done !")
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "start": "node ./app/public/dist/server/app/index.js",
     "add-bot": "ts-node -T --preferTsExts ./db-commands/populate-bot-from-pastebin.ts",
     "seed-bots": "ts-node -T --preferTsExts ./db-commands/populate-bots-from-local.ts",
+    "seed-stats": "ts-node -T --preferTsExts ./db-commands/seed-detailled-statistics.ts",
     "monitor-bot": "node ./app/public/dist/server/scheduled/monitor-bot.js",
     "translate": "npx @inlang/cli machine translate -f",
     "postinstall": "npm run download-music && cd edit/assetpack && npm install",


### PR DESCRIPTION
To help newer players

- Load meta info in loading manager and create a cached map of pokemon to items popular for them and pokemon they evolve into
- Show these on pokemon tooltips
- If the server doesn't respond with meta information or a pokemon has no data then we try to gracefully omit this section

Misc:
- Add an option to make shop tooltips "sticky" (remaining open on hover) to aid new players in discovery (lets them hover over items, keywords, etc to see what they are)
  - Enable this by default for new players but not for existing players since it could annoy them if they're used to the tooltips disappearing
- Prevent right clicking on pokemon from opening a context menu (would happen when their details popped up where the mouse cursor was)
- Add script to seed the detailed statistics table with bot data

<details><summary>Preview</summary>
<p>

![image](https://github.com/user-attachments/assets/09b2d06e-446f-4512-847a-7652f405b763)

</p>
</details> 