### PR TITLE
stores preparation room chat in database

### DIFF
--- a/app/models/mongo-models/chat-v2.ts
+++ b/app/models/mongo-models/chat-v2.ts
@@ -24,9 +24,10 @@ const chatSchema = new Schema({
     required: true
   },
   time: {
-    type: Number,
-    required: true,
-    default: Date.now()
+    type: Date,
+    expires: 7 * 24 * 60 * 60, // stored for 7 days
+    default: Date.now,
+    required: true
   }
 })
 

--- a/app/rooms/states/lobby-state.ts
+++ b/app/rooms/states/lobby-state.ts
@@ -20,18 +20,15 @@ export default class LobbyState extends Schema {
     const id = nanoid()
     const time = Date.now()
     const message = new Message(id, payload, authorId, author, avatar, time)
-    chatV2
-      .create({
-        id: id,
-        payload: payload,
-        authorId: authorId,
-        author: author,
-        avatar: avatar,
-        time: time
-      })
-      .then(() => {
-        this.messages.push(message)
-      })
+    this.messages.push(message)
+    chatV2.create({
+      id: id,
+      payload: payload,
+      authorId: authorId,
+      author: author,
+      avatar: avatar,
+      time: time
+    })
   }
 
   removeMessage(id: string) {

--- a/app/rooms/states/preparation-state.ts
+++ b/app/rooms/states/preparation-state.ts
@@ -5,6 +5,7 @@ import Message from "../../models/colyseus-models/message"
 import { EloRank } from "../../types/Config"
 import { GameMode } from "../../types/enum/Game"
 import { SpecialGameRule } from "../../types/enum/SpecialGameRule"
+import chatV2 from "../../models/mongo-models/chat-v2"
 
 export interface IPreparationState {
   users: MapSchema<GameUser>
@@ -81,6 +82,14 @@ export default class PreparationState
       params.avatar ?? "",
       time
     )
+    chatV2.create({
+      id: id,
+      payload: message.payload,
+      authorId: message.authorId,
+      author: message.author,
+      avatar: message.avatar,
+      time: time
+    })
     this.messages.push(message)
   }
 


### PR DESCRIPTION
stores all the chat messages including preparation room messages into database, with a 7 days TTL (handled by mongoose expires property, very handy)

will be useful for moderation