### PR TITLE
adjust component rule at stage 19

### DIFF
--- a/app/core/matter/mini-game.ts
+++ b/app/core/matter/mini-game.ts
@@ -289,13 +289,6 @@ export class MiniGame {
       if (state.townEncounter !== encounter) {
         encounter = null // prevent getting the same encounter twice in a row
       }
-      if (
-        state.stageLevel === ItemCarouselStages[2] &&
-        state.nbComponentsFromCarousel % 2 === 0
-      ) {
-        state.nbComponentsFromCarousel++
-        encounter = null // ensure we have an even number of components at stage 20 to not stay with 1 component
-      }
       state.townEncounter = encounter ?? null
     } else {
       state.townEncounter = null
@@ -313,10 +306,6 @@ export class MiniGame {
   }
 
   initializeItemsCarousel(state: GameState) {
-    if (!state.townEncounter && state.stageLevel < ItemCarouselStages[2]) {
-      state.nbComponentsFromCarousel++
-    }
-
     const items = this.pickRandomItems(state)
 
     for (let j = 0; j < items.length; j++) {

--- a/app/models/pve-stages.ts
+++ b/app/models/pve-stages.ts
@@ -9,6 +9,7 @@ import {
 } from "../types/enum/Item"
 import { Pkm } from "../types/enum/Pokemon"
 import { pickNRandomIn, pickRandomIn } from "../utils/random"
+import { values } from "../utils/schemas"
 import Player from "./colyseus-models/player"
 
 export type PVEStage = {
@@ -115,8 +116,33 @@ export const PVEStages: { [turn: number]: PVEStage } = {
       [Pkm.HO_OH, 5, 1]
     ],
     marowakItems: [[Item.COMET_SHARD], [Item.SACRED_ASH]],
+    getRewardsPropositions(player: Player) {
+      const items = values(player.board)
+        .flatMap((p) => values(p.items))
+        .concat(player.items)
+      const nbComponents = items.filter((i) =>
+        ItemComponents.includes(i)
+      ).length
+      if (nbComponents % 2 === 0) {
+        return [
+          ...pickNRandomIn(CraftableNonSynergyItems, 2),
+          ...pickNRandomIn(CraftableItems, 1)
+        ]
+      }
+      return []
+    },
     getRewards(player: Player) {
-      return [pickRandomIn(NonSpecialItemComponents)]
+      const items = values(player.board)
+        .flatMap((p) => values(p.items))
+        .concat(player.items)
+      const nbComponents = items.filter((i) =>
+        ItemComponents.includes(i)
+      ).length
+      if (nbComponents % 2 === 1) {
+        // ensure we dont stay with a single useless component
+        return [pickRandomIn(NonSpecialItemComponents)]
+      }
+      return []
     }
   },
 

--- a/app/public/dist/client/changelog/patch-6.0.md
+++ b/app/public/dist/client/changelog/patch-6.0.md
@@ -118,3 +118,4 @@
 - Added experience required per level in Wiki > Data
 - ELO decay now starts after 15 days of inactivity instead of 10
 - Removed Scribbles Kecleon's Shop and Synergy wheel, replaced by town encounters
+- Stage 19 rewards will now be complete items instead of components if player has an even number of components at that stage

--- a/app/rooms/states/game-state.ts
+++ b/app/rooms/states/game-state.ts
@@ -63,7 +63,6 @@ export default class GameState extends Schema {
   minRank: EloRank | null = null
   maxRank: EloRank | null = null
   wanderers: Map<string, Pkm> = new Map<string, Pkm>()
-  nbComponentsFromCarousel = 0
 
   constructor(
     preparationId: string,


### PR DESCRIPTION
Instead of cancelling stage 17 carousel encounter in case of odd component count, i compute the number of components owned by the player before stage 19, and give full items if even number. This is more safe to avoid useless remaining component in more scenarios like unown-I