### PR TITLE
memory optimization: lazy load and unload pokemon anims

### DIFF
--- a/app/public/src/game/animation-manager.ts
+++ b/app/public/src/game/animation-manager.ts
@@ -13,7 +13,6 @@ import { fpsToDuration } from "../../../utils/number"
 import atlas from "../assets/atlas.json"
 import delays from "../../../types/delays.json"
 import durations from "../assets/pokemons/durations.json"
-import indexList from "../assets/pokemons/indexList.json"
 import PokemonSprite from "./components/pokemon"
 import { getPokemonData } from "../../../models/precomputed/precomputed-pokemon-data"
 import { Passive } from "../../../types/enum/Passive"
@@ -26,88 +25,6 @@ export default class AnimationManager {
 
   constructor(game: Phaser.Scene) {
     this.game = game
-
-    indexList.forEach((index) => {
-      const tints = Object.values(PokemonTint) as PokemonTint[]
-      const pkm = PkmByIndex[index]
-      const pokemonData = getPokemonData(pkm)
-      tints.forEach((shiny) => {
-        if (!pkm && !AnimationConfig[pkm]) {
-          logger.warn(`No animation config for ${pkm}`)
-          return
-        }
-        const config = AnimationConfig[pkm]
-
-        if (config.shinyUnavailable && shiny === PokemonTint.SHINY) return
-
-        const actions: Set<AnimationType> = new Set([AnimationType.Idle])
-        actions.add(config.hurt ?? AnimationType.Hurt)
-
-        if (pokemonData.passive !== Passive.INANIMATE) {
-          actions.add(AnimationType.Walk)
-          actions.add(config.sleep ?? AnimationType.Sleep)
-          actions.add(config.eat ?? AnimationType.Eat)
-          actions.add(config.hop ?? AnimationType.Hop)
-          actions.add(config.attack ?? AnimationType.Attack)
-          actions.add(config.ability ?? AnimationType.SpAttack)
-          actions.add(config.emote ?? AnimationType.Pose)
-        }
-
-        //logger.debug(`Init animations: ${index} => ${actions.join(",")}`)
-
-        actions.forEach((action) => {
-          const spriteTypes = config.noShadow
-            ? [SpriteType.ANIM]
-            : [SpriteType.ANIM, SpriteType.SHADOW]
-          spriteTypes.forEach((mode) => {
-            const directionArray =
-              AnimationComplete[action] === false
-                ? [Orientation.DOWN]
-                : Object.values(Orientation)
-            directionArray.forEach((direction) => {
-              const durationArray: number[] =
-                durations[`${index}/${shiny}/${action}/${mode}`]
-              if (!durationArray && action === AnimationType.Eat) {
-                // Very few pokemons have eat animations, so we use sleep animations instead as a fallback
-                config.eat = AnimationType.Sleep
-                return
-              }
-              if (durationArray) {
-                const frameArray = this.game.anims.generateFrameNames(index, {
-                  start: 0,
-                  end: durationArray.length - 1,
-                  zeroPad: 4,
-                  prefix: `${shiny}/${action}/${mode}/${direction}/`
-                })
-                for (let i = 0; i < durationArray.length; i++) {
-                  if (frameArray[i]) {
-                    frameArray[i]["duration"] =
-                      durationArray[i] * (1000 / FPS_POKEMON_ANIMS)
-                  }
-                }
-                const shouldLoop = [
-                  AnimationType.Idle,
-                  AnimationType.Sleep,
-                  AnimationType.Eat,
-                  AnimationType.Hop
-                ].includes(action)
-
-                this.game.anims.create({
-                  key: `${index}/${shiny}/${action}/${mode}/${direction}`,
-                  frames: frameArray,
-                  repeat: shouldLoop ? -1 : 0
-                })
-              } else {
-                logger.warn(
-                  "duration array missing for",
-                  `${index}/${shiny}/${action}/${mode}`
-                )
-              }
-            })
-          })
-        })
-      })
-    })
 
     for (const pack in atlas.packs) {
       if (atlas.packs[pack].anims) {
@@ -127,6 +44,134 @@ export default class AnimationManager {
 
     this.createMinigameAnimations()
     this.createEnvironmentAnimations()
+  }
+
+  createPokemonAnimations(index: string, shiny: PokemonTint) {
+    const pkm = PkmByIndex[index]
+
+    if (!pkm && !AnimationConfig[pkm]) {
+      logger.warn(`No animation config for ${pkm}`)
+      return
+    }
+    const pokemonData = getPokemonData(pkm)
+    const config = AnimationConfig[pkm]
+
+    if (config.shinyUnavailable && shiny === PokemonTint.SHINY) return
+
+    const actions: Set<AnimationType> = new Set([AnimationType.Idle])
+    actions.add(config.hurt ?? AnimationType.Hurt)
+
+    if (pokemonData.passive !== Passive.INANIMATE) {
+      actions.add(AnimationType.Walk)
+      actions.add(config.sleep ?? AnimationType.Sleep)
+      actions.add(config.eat ?? AnimationType.Eat)
+      actions.add(config.hop ?? AnimationType.Hop)
+      actions.add(config.attack ?? AnimationType.Attack)
+      actions.add(config.ability ?? AnimationType.SpAttack)
+      actions.add(config.emote ?? AnimationType.Pose)
+    }
+
+    //logger.debug(`Init animations: ${index} => ${actions.join(",")}`)
+
+    actions.forEach((action) => {
+      const spriteTypes = config.noShadow
+        ? [SpriteType.ANIM]
+        : [SpriteType.ANIM, SpriteType.SHADOW]
+      spriteTypes.forEach((mode) => {
+        const directionArray =
+          AnimationComplete[action] === false
+            ? [Orientation.DOWN]
+            : Object.values(Orientation)
+        directionArray.forEach((direction) => {
+          const durationArray: number[] =
+            durations[`${index}/${shiny}/${action}/${mode}`]
+          if (!durationArray && action === AnimationType.Eat) {
+            // Very few pokemons have eat animations, so we use sleep animations instead as a fallback
+            config.eat = AnimationType.Sleep
+            return
+          }
+          if (durationArray) {
+            const frameArray = this.game.anims.generateFrameNames(index, {
+              start: 0,
+              end: durationArray.length - 1,
+              zeroPad: 4,
+              prefix: `${shiny}/${action}/${mode}/${direction}/`
+            })
+            for (let i = 0; i < durationArray.length; i++) {
+              if (frameArray[i]) {
+                frameArray[i]["duration"] =
+                  durationArray[i] * (1000 / FPS_POKEMON_ANIMS)
+              }
+            }
+            const shouldLoop = [
+              AnimationType.Idle,
+              AnimationType.Sleep,
+              AnimationType.Eat,
+              AnimationType.Hop
+            ].includes(action)
+
+            const key = `${index}/${shiny}/${action}/${mode}/${direction}`
+            if (!this.game.anims.exists(key)) {
+              this.game.anims.create({
+                key: `${index}/${shiny}/${action}/${mode}/${direction}`,
+                frames: frameArray,
+                repeat: shouldLoop ? -1 : 0
+              })
+            }
+          } else {
+            logger.warn(
+              "duration array missing for",
+              `${index}/${shiny}/${action}/${mode}`
+            )
+          }
+        })
+      })
+    })
+  }
+
+  unloadPokemonAnimations(index: string, shiny: PokemonTint) {
+    const pkm = PkmByIndex[index]
+
+    if (!pkm && !AnimationConfig[pkm]) {
+      logger.warn(`No animation config for ${pkm}`)
+      return
+    }
+    const pokemonData = getPokemonData(pkm)
+    const config = AnimationConfig[pkm]
+
+    if (config.shinyUnavailable && shiny === PokemonTint.SHINY) return
+
+    const actions: Set<AnimationType> = new Set([AnimationType.Idle])
+    actions.add(config.hurt ?? AnimationType.Hurt)
+
+    if (pokemonData.passive !== Passive.INANIMATE) {
+      actions.add(AnimationType.Walk)
+      actions.add(config.sleep ?? AnimationType.Sleep)
+      actions.add(config.eat ?? AnimationType.Eat)
+      actions.add(config.hop ?? AnimationType.Hop)
+      actions.add(config.attack ?? AnimationType.Attack)
+      actions.add(config.ability ?? AnimationType.SpAttack)
+      actions.add(config.emote ?? AnimationType.Pose)
+    }
+
+    //logger.debug(`Remove animations: ${index} => ${actions.join(",")}`)
+
+    actions.forEach((action) => {
+      const spriteTypes = config.noShadow
+        ? [SpriteType.ANIM]
+        : [SpriteType.ANIM, SpriteType.SHADOW]
+      spriteTypes.forEach((mode) => {
+        const directionArray =
+          AnimationComplete[action] === false
+            ? [Orientation.DOWN]
+            : Object.values(Orientation)
+        directionArray.forEach((direction) => {
+          this.game.anims.remove(
+            `${index}/${shiny}/${action}/${mode}/${direction}`
+          )
+        })
+      })
+    })
   }
 
   createAnimation({

--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../../types/enum/Game"
 import { Item } from "../../../../types/enum/Item"
 import { Passive } from "../../../../types/enum/Passive"
-import { AnimationConfig, Pkm } from "../../../../types/enum/Pokemon"
+import { AnimationConfig, PkmByIndex } from "../../../../types/enum/Pokemon"
 import { max } from "../../../../utils/number"
 import { transformAttackCoordinate } from "../../pages/utils/utils"
 import AnimationManager from "../animation-manager"
@@ -374,7 +374,7 @@ export default class BattleManager {
         if (value != 0) {
           this.animationManager.play(
             pkm,
-            AnimationConfig[pkm.name as Pkm].ability,
+            AnimationConfig[PkmByIndex[pkm.index]].ability,
             { flip: this.flip, lock: true, repeat: 0 }
           )
           pkm.specialAttackAnimation(this.group, value)
@@ -691,7 +691,9 @@ export default class BattleManager {
         }
       } else if (field === "index") {
         if (pkm.index !== value) {
+          pkm.lazyloadAnimations(this.scene, true) // unload previous index animations
           pkm.index = value as IPokemonEntity["index"]
+          pkm.lazyloadAnimations(this.scene) // load the new ones
           pkm.displayAnimation("EVOLUTION")
           this.animationManager.animatePokemon(
             pkm,


### PR DESCRIPTION
Instead of loading all the existing pokemons anims immediately, i changed it so it creates and removes animations based on which sprite is used in current scene (a spriteCountPerPokemon Map is used for that)

It is a noticeable improvement for the final loading times and for RAM usage (-15% in my tests). Most of the RAM is still used by textures though.

Also fixed ability cast animations for pokemons transforming mid fight and changing their index