### PR TITLE
improve wiki pokemons selected tab style

### DIFF
--- a/app/public/src/pages/component/wiki/wiki-pokemon-detail.tsx
+++ b/app/public/src/pages/component/wiki/wiki-pokemon-detail.tsx
@@ -15,7 +15,7 @@ import SynergyIcon from "../icons/synergy-icon"
 import Credits from "./Credits"
 import "./wiki-pokemon-detail.css"
 
-export default function WikiPokemonDetail(props: { pokemon: Pkm }) {
+export default function WikiPokemonDetail(props: { pokemon: Pkm, selectPkm: (pkm: Pkm) => void }) {
   const { t } = useTranslation()
   const pokemon = useMemo(
     () => PokemonFactory.createPokemonFromName(props.pokemon),
@@ -75,7 +75,7 @@ export default function WikiPokemonDetail(props: { pokemon: Pkm }) {
           {evolutions.length === 0 ? (
             "No evolution"
           ) : (evolutions.map((evolution) => (
-            <div key={evolution}>
+            <div key={evolution} onClick={() => props.selectPkm(evolution)} style={{ cursor: "pointer" }}>
               <img
                 src={getPortraitSrc(PkmIndex[evolution])}
                 style={{ marginRight: "0.5em" }}

--- a/app/public/src/pages/component/wiki/wiki-pokemons.tsx
+++ b/app/public/src/pages/component/wiki/wiki-pokemons.tsx
@@ -97,7 +97,7 @@ export function WikiPokemon(props: {
       <TabList>
         {pokemons.map((pkm) => {
           return (
-            <Tab key={"title-" + pkm}>
+            <Tab key={"title-" + pkm} className="react-tabs__tab icon-tab">
               <PokemonPortrait portrait={PkmIndex[pkm]} />
             </Tab>
           )
@@ -107,7 +107,7 @@ export function WikiPokemon(props: {
       {pokemons.map((pkm) => {
         return (
           <TabPanel key={pkm}>
-            <WikiPokemonDetail pokemon={pkm} />
+            <WikiPokemonDetail pokemon={pkm} selectPkm={props.onSelect} />
           </TabPanel>
         )
       })}

--- a/app/public/src/style/react-tabs.css
+++ b/app/public/src/style/react-tabs.css
@@ -39,3 +39,44 @@
 .react-tabs__tab-panel--selected {
   padding: 0.5em;
 }
+
+/**
+ * `@property` is required for the animation to work.
+ * Without it, the angle values won’t interpolate properly.
+ *
+ * @see https://dev.to/afif/we-can-finally-animate-css-gradient-kdk
+ */
+@property --bg-angle {
+  inherits: false;
+  initial-value: 0deg;
+  syntax: "<angle>";
+}
+
+/**
+ * To animate the gradient, we set the custom property to 1 full
+ * rotation. The animation starts at the default value of `0deg`.
+ */
+@keyframes spin {
+  to {
+    --bg-angle: 360deg;
+  }
+}
+
+.react-tabs__tab--selected.icon-tab {
+  animation: spin 2.5s infinite linear;
+  /* Background colors don’t work with `background-origin`, so use a gradient. */
+  background: conic-gradient(
+      from var(--bg-angle) in oklch longer hue,
+      oklch(0.85 0.37 0) 0 0
+    )
+    border-box; /* extends to outer border edges */
+
+  /* a clear border lets the background gradient shine through */
+  border: 6px solid transparent;
+  margin: -6px -4px;
+  z-index: 2;
+}
+
+.react-tabs__tab--selected.icon-tab::after {
+  content: none;
+}


### PR DESCRIPTION
its becoming increasingly hard to notice which tab is selected in pokemon wiki with the amount of pokemons we have

Changing the selected tab style for something animated and colorful. Also added links to evolution directly in WikiPokemonDetail