### PR TITLE
Fix Power Lens causing effects triggered on dead pokemon

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -338,6 +338,16 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
       if (attacker?.passive === Passive.BERSERK) {
         attacker.addAbilityPower(3, attacker, 0, false, false)
       }
+
+      const damageResult = this.state.handleDamage({
+        target: this,
+        damage: specialDamage,
+        board,
+        attackType,
+        attacker,
+        shouldTargetGainMana: true
+      })
+
       if (
         this.items.has(Item.POWER_LENS) &&
         specialDamage >= 1 &&
@@ -355,14 +365,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
           shouldTargetGainMana: true
         })
       }
-      return this.state.handleDamage({
-        target: this,
-        damage: specialDamage,
-        board,
-        attackType,
-        attacker,
-        shouldTargetGainMana: true
-      })
+      return damageResult
     }
   }
 


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1338051157213577299
Effects in handleDamage assume the attacker is alive. With power lens, this assumption isn't always true. This fix makes the assumption hold true.