### PR TITLE
Fix regional picks in lobby team planner

### DIFF
--- a/app/public/src/pages/component/bot-builder/pokemon-picker.tsx
+++ b/app/public/src/pages/component/bot-builder/pokemon-picker.tsx
@@ -105,7 +105,7 @@ function PokemonPickerTab(props: {
     })
     .filter(
       (p) =>
-        !preferences.filterAvailableAddsAndRegionals ||
+        !ingame || !preferences.filterAvailableAddsAndRegionals ||
         ((!p.additional ||
           additionalPokemons.includes(baseVariant(PkmFamily[p.name])) ||
           specialGameRule === SpecialGameRule.EVERYONE_IS_HERE) &&


### PR DESCRIPTION
Adjust the filtering logic for regional Pokémon in the lobby team planner to ensure proper functionality based on user preferences.

https://discord.com/channels/737230355039387749/1352321049538203812