### PR TITLE
query param to cache burst pokemon anims

### DIFF
--- a/app/public/src/game/components/loading-manager.ts
+++ b/app/public/src/game/components/loading-manager.ts
@@ -100,7 +100,7 @@ export default class LoadingManager {
           const multiatlas = {
             textures: [
               {
-                image: image,
+                image: `${image}?v=${pkg.version}`,
                 format: "RGBA8888",
                 size: {
                   w: data.s[0],


### PR DESCRIPTION
add ?v=6.0.0 to all pokemon anims spritesheets to force cache bursting

AFAIK this is the last resource that doesnt have filename-based cache bursting, and the only cache problem players have in 6.0 update