### PR TITLE
Fix Engineer title requiring Steel 2 instead of Steel 8

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1034,7 +1034,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
           case Effect.BEAT_UP:
             player.titles.add(Title.DELINQUENT)
             break
-          case Effect.STEEL_SURGE:
+          case Effect.MAX_MELTDOWN:
             player.titles.add(Title.ENGINEER)
             break
           case Effect.DEEP_MINER:


### PR DESCRIPTION
I checked the other synergy titles. They're all good.
https://discord.com/channels/737230355039387749/1352788572801073213