### PR TITLE
Clear simulation.room and entity.simulation

### DIFF
--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -1467,17 +1467,23 @@ export default class Simulation extends Schema implements ISimulation {
   stop() {
     this.blueTeam.forEach((pokemon, key) => {
       // logger.debug('deleting ' + pokemon.name);
+      // @ts-ignore: entity shouldnt be used after simulation stop, so we can safely delete it
+      delete pokemon.simulation // remove circular reference to help garbage collection
       this.blueTeam.delete(key)
     })
 
     this.redTeam.forEach((pokemon, key) => {
       // logger.debug('deleting ' + pokemon.name);
+      // @ts-ignore: entity shouldnt be used after simulation stop, so we can safely delete it
+      delete pokemon.simulation // remove circular reference to help garbage collection
       this.redTeam.delete(key)
     })
 
     this.weather = Weather.NEUTRAL
     this.winnerId = ""
     this.room.broadcast(Transfer.SIMULATION_STOP)
+    // @ts-ignore: room shouldnt be used after simulation stop, so we can safely delete it
+    delete this.room // remove circular reference to help garbage collection
   }
 
   onFinish() {


### PR DESCRIPTION
Delete circular references PokemonEntity#simulation and Simulation#room after simulation stop, with the hope that it will help with garbage collection

Had to add @ts-ignore annotations for that, but its much better than having to refactor the whole code to get rid of the circular reference.