### PR TITLE
Fix-room-deleted-roomid

### DIFF
--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -1614,8 +1614,8 @@ export class DeleteRoomCommand extends Command<
         )
       }
 
-      roomsIdToDelete.forEach((roomToDelete) => {
-        this.room.presence.publish("room-deleted", roomId)
+      roomsIdToDelete.forEach((roomIdToDelete) => {
+        this.room.presence.publish("room-deleted", roomIdToDelete)
       })
     } catch (error) {
       logger.error(`DeleteRoomCommand error:`, error)


### PR DESCRIPTION
fix the argument for room-deleted event. This only impacts tournament lobby remake so was not a problem until now