### PR TITLE
Game room delete as admin

### DIFF
--- a/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/available-room-menu.tsx
@@ -76,7 +76,7 @@ export default function AvailableRoomMenu() {
           <ul>
             {preparationRooms.map((r) => (
               <li key={r.roomId}>
-                <RoomItem room={r} click={onRoomAction} />
+                <RoomItem room={r} click={action => onRoomAction(r, action)} />
               </li>
             ))}
           </ul>

--- a/app/public/src/pages/component/available-room-menu/game-room-item.tsx
+++ b/app/public/src/pages/component/available-room-menu/game-room-item.tsx
@@ -1,17 +1,19 @@
 import { RoomAvailable } from "colyseus.js"
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { IGameMetadata } from "../../../../../types"
+import { IGameMetadata, Role } from "../../../../../types"
 import { useAppSelector } from "../../../hooks"
 import { cc } from "../../utils/jsx"
 import "./room-item.css"
 
 export default function GameRoomItem(props: {
   room: RoomAvailable<IGameMetadata>
-  onJoin: (spectate: boolean) => void
+  click: (action: string) => void
 }) {
   const { t } = useTranslation()
   const myUid = useAppSelector((state) => state.network.uid)
+  const user = useAppSelector((state) => state.network.profile)
+  const isAdmin = user?.role === Role.ADMIN
   const playerIds = props.room.metadata?.playerIds ?? []
   const spectate = playerIds.includes(myUid) === false
 
@@ -27,9 +29,10 @@ export default function GameRoomItem(props: {
         {playerIds.length !== 1 ? "s" : ""}, {t("stage")}{" "}
         {props.room.metadata?.stageLevel}
       </span>
+      {isAdmin && <button title={t("delete_room")} onClick={() => { props.click("delete") }}>X</button>}
       <button
         className={cc("bubbly", spectate ? "blue" : "green")}
-        onClick={() => props.onJoin(spectate)}
+        onClick={() => props.click(spectate ? "spectate" : "join")}
       >
         {spectate ? t("spectate") : t("reconnect")}
       </button>

--- a/app/public/src/pages/component/available-room-menu/game-rooms-menu.tsx
+++ b/app/public/src/pages/component/available-room-menu/game-rooms-menu.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import GameState from "../../../../../rooms/states/game-state"
-import { ICustomLobbyState, IGameMetadata } from "../../../../../types"
+import { ICustomLobbyState, IGameMetadata, Role, Transfer } from "../../../../../types"
 import { throttle } from "../../../../../utils/function"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { resetLobby } from "../../../stores/LobbyStore"
@@ -23,6 +23,7 @@ export function GameRoomsMenu() {
   const lobby: Room<ICustomLobbyState> | undefined = useAppSelector(
     (state) => state.network.lobby
   )
+  const user = useAppSelector((state) => state.network.profile)
 
   const joinGame = throttle(async function joinGame(
     selectedRoom: RoomAvailable<IGameMetadata>
@@ -47,6 +48,14 @@ export function GameRoomsMenu() {
     }
   }, 1000)
 
+  const onRoomAction = (room: RoomAvailable<IGameMetadata>, action: string) => {
+    if (action === "join" || action === "spectate") {
+      joinGame(room)
+    } else if (action === "delete" && user?.role === Role.ADMIN) {
+      confirm('Delete room ?') && lobby?.send(Transfer.DELETE_ROOM, room.roomId)
+    }
+  }
+
   return (
     <div className="my-container room-menu custom-bg">
       <h2>{t("in_game")}</h2>
@@ -56,7 +65,7 @@ export function GameRoomsMenu() {
       <ul className="hidden-scrollable">
         {gameRooms.map((r) => (
           <li key={r.roomId}>
-            <GameRoomItem room={r} onJoin={(spectate) => joinGame(r)} />
+            <GameRoomItem room={r} click={(action) => onRoomAction(r, action)} />
           </li>
         ))}
       </ul>

--- a/app/public/src/pages/component/available-room-menu/room-item.tsx
+++ b/app/public/src/pages/component/available-room-menu/room-item.tsx
@@ -15,7 +15,7 @@ import "./room-item.css"
 
 export default function RoomItem(props: {
   room: RoomAvailable<IPreparationMetadata>
-  click: (room: RoomAvailable<IPreparationMetadata>, action: string) => void
+  click: (action: string) => void
 }) {
   const { t } = useTranslation()
   const user = useAppSelector((state) => state.network.profile)
@@ -124,7 +124,7 @@ export default function RoomItem(props: {
       <span>
         {props.room.clients}/{nbPlayersExpected}
       </span>
-      {isAdmin && <button title="Delete room" onClick={() => { props.click(props.room, "delete") }}>X</button>}
+      {isAdmin && <button title={t("delete_room")} onClick={() => { props.click("delete") }}>X</button>}
       <button
         title={disabledReason ?? t("join")}
         disabled={!canJoin || joining}
@@ -135,7 +135,7 @@ export default function RoomItem(props: {
         )}
         onClick={() => {
           if (canJoin && !joining) {
-            props.click(props.room, "join")
+            props.click("join")
             setJoining(true)
             setTimeout(() => setJoining(false), 3000)
           }

--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -24,7 +24,6 @@ import {
   changeRoomMinMaxRanks,
   changeRoomName,
   changeRoomPassword,
-  deleteRoom,
   gameStartRequest,
   setSpecialRule,
   setNoElo,
@@ -123,17 +122,6 @@ export default function PreparationMenu() {
       }
     }
   }, 1000)
-
-  const deleteRoomButton = (isModerator || isAdmin) && (
-    <button
-      className="bubbly red"
-      onClick={() => {
-        dispatch(deleteRoom())
-      }}
-    >
-      {t("delete_room")}
-    </button>
-  )
 
   const changeMinRank = (newMinRank: EloRank) => {
     dispatch(
@@ -409,8 +397,6 @@ export default function PreparationMenu() {
 
       <div className="actions">
         {roomNameInput}
-        <div className="spacer"></div>
-        {deleteRoomButton}
       </div>
 
       {(BOTS_ENABLED || isAdmin) && (

--- a/app/public/src/stores/NetworkStore.ts
+++ b/app/public/src/stores/NetworkStore.ts
@@ -278,9 +278,6 @@ export const networkSlice = createSlice({
     kick: (state, action: PayloadAction<string>) => {
       state.preparation?.send(Transfer.KICK, action.payload)
     },
-    deleteRoom: (state) => {
-      state.preparation?.send(Transfer.DELETE_ROOM)
-    },
     ban: (state, action: PayloadAction<{ uid: string; reason: string }>) => {
       state.lobby?.send(Transfer.BAN, action.payload)
     },
@@ -358,7 +355,6 @@ export const {
   searchById,
   setTitle,
   kick,
-  deleteRoom,
   createTournament,
   setErrorAlertMessage,
   deleteAccount,

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -537,27 +537,6 @@ export class OnKickPlayerCommand extends Command<
   }
 }
 
-export class OnDeleteRoomCommand extends Command<
-  PreparationRoom,
-  {
-    client: Client
-  }
-> {
-  execute({ client }) {
-    try {
-      const user = this.state.users.get(client.auth?.uid)
-      if (user && [Role.ADMIN, Role.MODERATOR].includes(user.role)) {
-        this.room.clients.forEach((cli) => {
-          cli.leave(CloseCodes.ROOM_DELETED)
-        })
-        this.room.disconnect()
-      }
-    } catch (error) {
-      logger.error(error)
-    }
-  }
-}
-
 export class OnLeaveCommand extends Command<
   PreparationRoom,
   {

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -11,7 +11,6 @@ import { logger } from "../utils/logger"
 import { values } from "../utils/schemas"
 import {
   OnAddBotCommand,
-  OnDeleteRoomCommand,
   OnGameStartRequestCommand,
   OnJoinCommand,
   OnKickPlayerCommand,
@@ -188,15 +187,6 @@ export default class PreparationRoom extends Room<PreparationState> {
       logger.info(Transfer.KICK, this.roomName)
       try {
         this.dispatcher.dispatch(new OnKickPlayerCommand(), { client, message })
-      } catch (error) {
-        logger.error(error)
-      }
-    })
-
-    this.onMessage(Transfer.DELETE_ROOM, (client) => {
-      logger.info(Transfer.DELETE_ROOM, this.roomName)
-      try {
-        this.dispatcher.dispatch(new OnDeleteRoomCommand(), { client })
       } catch (error) {
         logger.error(error)
       }


### PR DESCRIPTION
- Allow to remove ongoing game rooms as admin from the lobby screen
- Removed the delete room in prep room screen since it can be done without entering the prep room now
- Listen to room Leave from game.tsx to redirect to lobby with appropriate message when room is deleted by admin or when user is banned