### PR TITLE
failcheck for matchmaker no process

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -77,7 +77,11 @@ if (process.env.NODE_APP_INSTANCE) {
           ? p1.roomCount - p2.roomCount
           : p1.ccu - p2.ccu
       )
-      return stats[0].processId
+      if (stats.length === 0) {
+        return undefined // no process available, will trigger a ServerError
+      } else {
+        return stats[0]?.processId
+      }
     }
   }
 }


### PR DESCRIPTION
failcheck for this exception
> 2025-04-05T17:00:01: TypeError: Cannot read properties of undefined (reading 'processId') 2025-04-05T17:00:01: at /home/deploy/source/app/app.config.ts:80:2

sometimes matchMaker.fetchAll() returns no process, i don't know why. But this failcheck will help pop a proper ServerError and avoid creating a room without a process