### PR TITLE
Delete pending game id after reconnect

### DIFF
--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -601,6 +601,7 @@ export default class GameRoom extends Room<GameState> {
 
       // allow disconnected client to reconnect into this room until 5 minutes
       await this.allowReconnection(client, 300)
+      this.presence.hdel(client.auth.uid, "pending_game_id")
       const userProfile = await UserMetadata.findOne({ uid: client.auth.uid })
       client.send(Transfer.USER_PROFILE, userProfile) // send profile info again after a /game page refresh
       this.dispatcher.dispatch(new OnJoinCommand(), { client })


### PR DESCRIPTION
Fix a possible edgecase where pending_game_id is not cleared after a first disconnect / reconnect during the allowed reconnection time, but then another disconnect or exception triggers the elimination logic

tryfix for https://discord.com/channels/737230355039387749/1359120951458926772