### PR TITLE
Stat Application Refactor

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -39,7 +39,7 @@ import {
   EvolutionTime
 } from "../../types/Config"
 import { Effect } from "../../types/enum/Effect"
-import { AttackType, Orientation, Team } from "../../types/enum/Game"
+import { AttackType, Orientation, Stat, Team } from "../../types/enum/Game"
 import { ArtificialItems, Berries, Item } from "../../types/enum/Item"
 import { Pkm, PkmIndex } from "../../types/enum/Pokemon"
 import { Synergy } from "../../types/enum/Synergy"
@@ -444,7 +444,7 @@ export class SongOfDesireStrategy extends AbilityStrategy {
           pokemon,
           false
         )
-        targetCharmed.addAttack(-3, pokemon, 1, crit)
+        targetCharmed.applyStat(Stat.ATK, -3, pokemon, 1, crit)
       }
     }
   }
@@ -623,7 +623,7 @@ export class ElectricSurgeStrategy extends AbilityStrategy {
         pokemon.team === ally.team &&
         ally.types.has(Synergy.ELECTRIC)
       ) {
-        ally.addSpeed(buff, pokemon, 1, crit)
+        ally.applyStat(Stat.SPEED, buff, pokemon, 1, crit)
       }
     })
   }
@@ -646,7 +646,7 @@ export class PsychicSurgeStrategy extends AbilityStrategy {
         pokemon.team === ally.team &&
         ally.types.has(Synergy.PSYCHIC)
       ) {
-        ally.addAbilityPower(buff, pokemon, 1, crit)
+        ally.applyStat(Stat.AP, buff, pokemon, 1, crit)
       }
     })
   }
@@ -670,7 +670,7 @@ export class MistySurgeStrategy extends AbilityStrategy {
         pokemon.team === ally.team &&
         ally.types.has(Synergy.FAIRY)
       ) {
-        ally.addPP(ppGain, pokemon, 1, crit)
+        ally.applyStat(Stat.PP, ppGain, pokemon, 1, crit)
         ally.handleHeal(hpGain, pokemon, 1, crit)
       }
     })
@@ -694,7 +694,7 @@ export class GrassySurgeStrategy extends AbilityStrategy {
         pokemon.team === ally.team &&
         ally.types.has(Synergy.GRASS)
       ) {
-        ally.addAttack(buff, pokemon, 1, crit)
+        ally.applyStat(Stat.ATK, buff, pokemon, 1, crit)
       }
     })
   }
@@ -724,7 +724,7 @@ export class PsychicStrategy extends AbilityStrategy {
           pokemon,
           crit
         )
-        cell.value.addPP(-15, pokemon, 0, false)
+        cell.value.applyStat(Stat.PP, -15, pokemon, 0, false)
         cell.value.count.manaBurnCount++
       }
     })
@@ -984,7 +984,7 @@ export class SchoolingStrategy extends AbilityStrategy {
     if (pokemon.player && !pokemon.isGhostOpponent) {
       pokemon.player.board.forEach((ally, id) => {
         if (ally && ally.name === Pkm.WISHIWASHI && isOnBench(ally)) {
-          pokemon.addMaxHP(50, pokemon, 0, false, true)
+          pokemon.applyStat(Stat.HP, 50, pokemon, 0, false, true)
           pokemon.player!.board.delete(id)
         }
       })
@@ -1014,8 +1014,8 @@ export class ElectroWebStrategy extends AbilityStrategy {
             pokemon,
             crit
           )
-          cell.value.addSpeed(-steal, pokemon, 1, crit)
-          pokemon.addSpeed(steal, pokemon, 1, crit)
+          cell.value.applyStat(Stat.SPEED, -steal, pokemon, 1, crit)
+          pokemon.applyStat(Stat.SPEED, steal, pokemon, 1, crit)
         }
       })
   }
@@ -1032,7 +1032,7 @@ export class MysticalFireStrategy extends AbilityStrategy {
     super.process(pokemon, state, board, target, crit)
     const damage = [20, 40, 80][pokemon.stars - 1] ?? 80
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    target.addAbilityPower(-10, pokemon, 1, crit)
+    target.applyStat(Stat.AP, -10, pokemon, 1, crit)
   }
 }
 
@@ -1263,9 +1263,9 @@ export class KingShieldStrategy extends AbilityStrategy {
     if (pokemon.name === Pkm.AEGISLASH) {
       pokemon.commands.push(
         new DelayedCommand(() => {
-          pokemon.addAttack(10, pokemon, 1, crit)
-          pokemon.addDefense(-5, pokemon, 1, crit)
-          pokemon.addSpecialDefense(-5, pokemon, 1, crit)
+          pokemon.applyStat(Stat.ATK, 10, pokemon, 1, crit)
+          pokemon.applyStat(Stat.DEF, -5, pokemon, 1, crit)
+          pokemon.applyStat(Stat.SPE_DEF, -5, pokemon, 1, crit)
           pokemon.name = Pkm.AEGISLASH_BLADE
           pokemon.index = PkmIndex[Pkm.AEGISLASH_BLADE]
         }, 1500)
@@ -1273,9 +1273,9 @@ export class KingShieldStrategy extends AbilityStrategy {
     } else if (pokemon.name === Pkm.AEGISLASH_BLADE) {
       pokemon.commands.push(
         new DelayedCommand(() => {
-          pokemon.addAttack(-10, pokemon, 1, crit)
-          pokemon.addDefense(5, pokemon, 1, crit)
-          pokemon.addSpecialDefense(5, pokemon, 1, crit)
+          pokemon.applyStat(Stat.ATK, -10, pokemon, 1, crit)
+          pokemon.applyStat(Stat.DEF, 5, pokemon, 1, crit)
+          pokemon.applyStat(Stat.SPE_DEF, 5, pokemon, 1, crit)
           pokemon.name = Pkm.AEGISLASH
           pokemon.index = PkmIndex[Pkm.AEGISLASH]
         }, 1500)
@@ -1407,9 +1407,9 @@ export class ClangorousSoulStrategy extends AbilityStrategy {
     )
     cells.forEach((cell) => {
       if (cell.value && pokemon.team == cell.value.team) {
-        cell.value.addAttack(buff, pokemon, 1, crit)
-        cell.value.addDefense(buff, pokemon, 1, crit)
-        cell.value.addSpecialDefense(buff, pokemon, 1, crit)
+        cell.value.applyStat(Stat.ATK, buff, pokemon, 1, crit)
+        cell.value.applyStat(Stat.DEF, buff, pokemon, 1, crit)
+        cell.value.applyStat(Stat.SPE_DEF, buff, pokemon, 1, crit)
       }
     })
   }
@@ -1444,7 +1444,7 @@ export class LiquidationStrategy extends AbilityStrategy {
     }
 
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    target.addDefense(-defReduction, pokemon, 1, crit)
+    target.applyStat(Stat.DEF, -defReduction, pokemon, 1, crit)
   }
 }
 
@@ -1492,7 +1492,7 @@ export class ShadowBoneStrategy extends AbilityStrategy {
       if (tg && pokemon.team != tg.team && x == target.positionX) {
         tg.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
         if (chance(0.5, pokemon)) {
-          tg.addDefense(-6, pokemon, 1, crit)
+          tg.applyStat(Stat.DEF, -6, pokemon, 1, crit)
         }
       }
     })
@@ -1551,7 +1551,7 @@ export class GrowlStrategy extends AbilityStrategy {
       .forEach((cell) => {
         if (cell.value && cell.value.team !== pokemon.team) {
           cell.value.status.triggerFlinch(3000, cell.value, pokemon)
-          cell.value.addAttack(-atkDebuff, pokemon, 1, crit)
+          cell.value.applyStat(Stat.ATK, -atkDebuff, pokemon, 1, crit)
         }
       })
   }
@@ -1600,7 +1600,7 @@ export class FairyWindStrategy extends AbilityStrategy {
     const ppGain = [5, 10, 20][pokemon.stars - 1] ?? 0
     board.forEach((x: number, y: number, tg: PokemonEntity | undefined) => {
       if (tg && pokemon.team === tg.team && tg.id !== pokemon.id) {
-        tg.addPP(ppGain, pokemon, 0.5, crit)
+        tg.applyStat(Stat.PP, ppGain, pokemon, 0.5, crit)
       }
     })
   }
@@ -1639,8 +1639,8 @@ export class HighJumpKickStrategy extends AbilityStrategy {
     super.process(pokemon, state, board, target, crit)
     const damage = [15, 30, 60][pokemon.stars - 1] ?? 60
     const ppStolen = max(40)(target.pp)
-    pokemon.addPP(ppStolen, pokemon, 0, false)
-    target.addPP(-ppStolen, pokemon, 0, false)
+    pokemon.applyStat(Stat.PP, ppStolen, pokemon, 0, false)
+    target.applyStat(Stat.PP, -ppStolen, pokemon, 0, false)
     target.count.manaBurnCount++
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
   }
@@ -1657,7 +1657,7 @@ export class TropKickStrategy extends AbilityStrategy {
     super.process(pokemon, state, board, target, crit)
     const damage = [50, 100, 200][pokemon.stars - 1] ?? 200
     const atkDebuff = [3, 5, 7][pokemon.stars - 1] ?? 7
-    target.addAttack(-atkDebuff, pokemon, 1, crit)
+    target.applyStat(Stat.ATK, -atkDebuff, pokemon, 1, crit)
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
   }
 }
@@ -1970,8 +1970,8 @@ export class AccelerockStrategy extends AbilityStrategy {
     const nbEffects = max(Math.floor(pokemon.def / 2))(
       Math.round(5 * (1 + pokemon.ap / 100) * (crit ? pokemon.critPower : 1))
     )
-    pokemon.addDefense(-2 * nbEffects, pokemon, 0, false)
-    pokemon.addSpeed(nbEffects * 5, pokemon, 0, false)
+    pokemon.applyStat(Stat.DEF, -2 * nbEffects, pokemon, 0, false)
+    pokemon.applyStat(Stat.SPEED, nbEffects * 5, pokemon, 0, false)
     pokemon.cooldown = 0
   }
 }
@@ -2122,7 +2122,7 @@ export class RockTombStrategy extends AbilityStrategy {
     const debuff = [10, 20, 40][pokemon.stars - 1] ?? 40
 
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    target.addSpeed(-debuff, pokemon, 0, false)
+    target.applyStat(Stat.SPEED, -debuff, pokemon, 0, false)
   }
 }
 
@@ -2142,7 +2142,7 @@ export class RoarOfTimeStrategy extends AbilityStrategy {
     const strongest = getStrongestUnit(candidates)
     if (strongest) {
       strongest.status.addResurrection(strongest)
-      strongest.addSpeed(speedBuff, pokemon, 1, true)
+      strongest.applyStat(Stat.SPEED, speedBuff, pokemon, 1, true)
     }
   }
 }
@@ -2248,7 +2248,7 @@ export class SeedFlareStrategy extends AbilityStrategy {
       .getCellsInRadius(pokemon.positionX, pokemon.positionY, 5)
       .forEach((cell) => {
         if (cell.value && pokemon.team !== cell.value.team) {
-          cell.value.addSpecialDefense(-3, pokemon, 0, false)
+          cell.value.applyStat(Stat.SPE_DEF, -3, pokemon, 0, false)
           cell.value.handleSpecialDamage(
             damage,
             board,
@@ -2589,7 +2589,7 @@ export class FieryDanceStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const damage = [25, 50, 100][pokemon.stars - 1] ?? 100
-    pokemon.addAbilityPower(30, pokemon, 0, crit)
+    pokemon.applyStat(Stat.AP, 30, pokemon, 0, crit)
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
   }
 }
@@ -2634,7 +2634,7 @@ export class GuillotineStrategy extends AbilityStrategy {
       crit
     )
     if (death) {
-      pokemon.addPP(pokemon.maxPP * 0.5, pokemon, 0, false)
+      pokemon.applyStat(Stat.PP, pokemon.maxPP * 0.5, pokemon, 0, false)
     }
   }
 }
@@ -2849,7 +2849,7 @@ export class SolarBeamStrategy extends AbilityStrategy {
     let damage = pokemon.stars === 3 ? 120 : pokemon.stars === 2 ? 60 : 30
     if (pokemon.simulation.weather === Weather.SUN) {
       damage = damage * 2
-      pokemon.addPP(40, pokemon, 0, false)
+      pokemon.applyStat(Stat.PP, 40, pokemon, 0, false)
     }
     effectInLine(board, pokemon, target, (cell) => {
       if (cell.value != null && cell.value.team !== pokemon.team) {
@@ -2977,7 +2977,7 @@ export class WishStrategy extends AbilityStrategy {
         ally.life < ally.hp
       ) {
         ally.handleHeal(heal, pokemon, 1, crit)
-        ally.addLuck(20, pokemon, 1, crit)
+        ally.applyStat(Stat.LUCK, 20, pokemon, 1, crit)
         count -= 1
       }
     })
@@ -3044,7 +3044,7 @@ export class CalmMindStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const buff = 1
-    pokemon.addAttack(buff * pokemon.baseAtk, pokemon, 1, crit)
+    pokemon.applyStat(Stat.ATK, buff * pokemon.baseAtk, pokemon, 1, crit)
   }
 }
 
@@ -3060,7 +3060,7 @@ export class CosmicPowerMoonStrategy extends AbilityStrategy {
     const apGain = 25
     board.forEach((x, y, ally) => {
       if (ally && ally.id !== pokemon.id && ally.team === pokemon.team) {
-        ally.addAbilityPower(apGain, pokemon, 1, crit)
+        ally.applyStat(Stat.AP, apGain, pokemon, 1, crit)
       }
     })
   }
@@ -3078,7 +3078,7 @@ export class CosmicPowerSunStrategy extends AbilityStrategy {
     const atkBuffMultiplier = 0.25
     board.forEach((x, y, ally) => {
       if (ally && ally.id !== pokemon.id && ally.team === pokemon.team) {
-        ally.addAttack(atkBuffMultiplier * ally.baseAtk, pokemon, 1, crit)
+        ally.applyStat(Stat.ATK, atkBuffMultiplier * ally.baseAtk, pokemon, 1, crit)
       }
     })
   }
@@ -3094,8 +3094,8 @@ export class DefenseCurlStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const buff = [5, 10, 15][pokemon.stars - 1] ?? 15
-    pokemon.addDefense(buff, pokemon, 1, crit)
-    pokemon.addSpecialDefense(buff, pokemon, 1, crit)
+    pokemon.applyStat(Stat.DEF, buff, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPE_DEF, buff, pokemon, 1, crit)
     pokemon.cooldown = Math.round(250 * (50 / pokemon.speed))
   }
 }
@@ -3131,7 +3131,7 @@ export class SoakStrategy extends AbilityStrategy {
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
     board.forEach((x: number, y: number, ally: PokemonEntity | undefined) => {
       if (ally && pokemon.team == ally.team) {
-        ally.addPP(10, pokemon, 0, false)
+        ally.applyStat(Stat.PP, 10, pokemon, 0, false)
       }
     })
   }
@@ -3251,7 +3251,7 @@ export class TailwindStrategy extends AbilityStrategy {
     const buff = [5, 10, 15][pokemon.stars - 1] ?? 15
     board.forEach((x: number, y: number, ally: PokemonEntity | undefined) => {
       if (ally && pokemon.team == ally.team) {
-        ally.addSpeed(buff, pokemon, 1, crit)
+        ally.applyStat(Stat.SPEED, buff, pokemon, 1, crit)
       }
     })
   }
@@ -3558,8 +3558,8 @@ export class NutrientsStrategy extends AbilityStrategy {
 
     if (lowestHealthAlly) {
       lowestHealthAlly.handleHeal(heal, pokemon, 1, crit)
-      lowestHealthAlly.addDefense(2, pokemon, 1, crit)
-      lowestHealthAlly.addSpecialDefense(2, pokemon, 1, crit)
+      lowestHealthAlly.applyStat(Stat.DEF, 2, pokemon, 1, crit)
+      lowestHealthAlly.applyStat(Stat.SPE_DEF, 2, pokemon, 1, crit)
       broadcastAbility(pokemon, {
         positionX: pokemon.positionX,
         positionY: pokemon.positionY,
@@ -3588,7 +3588,7 @@ export class SyrupBombStrategy extends AbilityStrategy {
     ).sort((a, b) => b.speed - a.speed)[0]
 
     if (highestSpeedEnemy) {
-      highestSpeedEnemy.addSpeed(-30, pokemon, 1, crit)
+      highestSpeedEnemy.applyStat(Stat.SPEED, -30, pokemon, 1, crit)
       highestSpeedEnemy.handleSpecialDamage(
         damage,
         board,
@@ -3885,8 +3885,8 @@ export class DragonTailStrategy extends AbilityStrategy {
     const damage = [30, 60, 100][pokemon.stars - 1] ?? 100
     const defenseBuff = [2, 4, 6][pokemon.stars - 1] ?? 6
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    pokemon.addDefense(defenseBuff, pokemon, 1, crit)
-    pokemon.addSpecialDefense(defenseBuff, pokemon, 1, crit)
+    pokemon.applyStat(Stat.DEF, defenseBuff, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPE_DEF, defenseBuff, pokemon, 1, crit)
   }
 }
 
@@ -4047,7 +4047,7 @@ export class TormentStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const boost = [20, 40, 60][pokemon.stars - 1] ?? 60
-    pokemon.addSpeed(boost, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPEED, boost, pokemon, 1, crit)
     pokemon.cooldown = Math.round(500 * (50 / pokemon.speed))
   }
 }
@@ -4106,7 +4106,7 @@ export class ShadowBallStrategy extends AbilityStrategy {
 
     board.forEach((x: number, y: number, v: PokemonEntity | undefined) => {
       if (v && pokemon.team != v.team) {
-        v.addSpecialDefense(-2, pokemon, 0, false)
+        v.applyStat(Stat.SPE_DEF, -2, pokemon, 0, false)
       }
     })
   }
@@ -4287,7 +4287,7 @@ export class HappyHourStrategy extends AbilityStrategy {
     const buff = [2, 5, 8][pokemon.stars - 1] ?? 8
     board.forEach((x: number, y: number, ally: PokemonEntity | undefined) => {
       if (ally && pokemon.team == ally.team) {
-        ally.addAttack(buff, pokemon, 1, crit)
+        ally.applyStat(Stat.ATK, buff, pokemon, 1, crit)
       }
     })
   }
@@ -4332,7 +4332,7 @@ export class NastyPlotStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const buff = 10
-    pokemon.addAttack(buff, pokemon, 1, crit)
+    pokemon.applyStat(Stat.ATK, buff, pokemon, 1, crit)
     pokemon.cooldown = Math.round(250 * (50 / pokemon.speed))
   }
 }
@@ -4346,8 +4346,8 @@ export class TakeHeartStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, state, board, target, crit)
-    pokemon.addAttack(8, pokemon, 1, crit)
-    pokemon.addSpecialDefense(8, pokemon, 1, crit)
+    pokemon.applyStat(Stat.ATK, 8, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPE_DEF, 8, pokemon, 1, crit)
     pokemon.status.clearNegativeStatus()
     pokemon.cooldown = Math.round(100 * (50 / pokemon.speed))
   }
@@ -4384,11 +4384,11 @@ export class SpectralThiefStrategy extends AbilityStrategy {
       target.atk = target.baseAtk
       target.def = target.baseDef
       target.speDef = target.baseSpeDef
-      pokemon.addAttack(boostAtk, pokemon, 0, false)
-      pokemon.addDefense(boostDef, pokemon, 0, false)
-      pokemon.addSpecialDefense(boostSpeDef, pokemon, 0, false)
-      pokemon.addAbilityPower(boostAP, pokemon, 0, false)
-      pokemon.addSpeed(boostSpeed, pokemon, 0, false)
+      pokemon.applyStat(Stat.ATK, boostAtk, pokemon, 0, false)
+      pokemon.applyStat(Stat.DEF, boostDef, pokemon, 0, false)
+      pokemon.applyStat(Stat.SPE_DEF, boostSpeDef, pokemon, 0, false)
+      pokemon.applyStat(Stat.AP, boostAP, pokemon, 0, false)
+      pokemon.applyStat(Stat.SPEED, boostSpeed, pokemon, 0, false)
     }
   }
 }
@@ -4476,7 +4476,7 @@ export class MeteorMashStrategy extends AbilityStrategy {
     super.process(pokemon, state, board, target, crit)
     const nbHits = 3
     const damage = [15, 30, 60][pokemon.stars - 1] ?? 60
-    pokemon.addAttack(2, pokemon, 1, crit)
+    pokemon.applyStat(Stat.ATK, 2, pokemon, 1, crit)
     for (let n = 0; n < nbHits; n++) {
       target.handleSpecialDamage(
         damage,
@@ -4536,7 +4536,7 @@ export class FleurCannonStrategy extends AbilityStrategy {
         )
       }
     })
-    pokemon.addAbilityPower(-20, pokemon, 0, false)
+    pokemon.applyStat(Stat.AP, -20, pokemon, 0, false)
   }
 }
 
@@ -4725,7 +4725,7 @@ export class DragonDartsStrategy extends AbilityStrategy {
       )
     }
     if (target.life <= 0) {
-      pokemon.addPP(40, pokemon, 0, false)
+      pokemon.applyStat(Stat.PP, 40, pokemon, 0, false)
     }
   }
 }
@@ -4886,7 +4886,7 @@ export class AgilityStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const boost = [10, 20, 30][pokemon.stars - 1] ?? 30
-    pokemon.addSpeed(boost, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPEED, boost, pokemon, 1, crit)
     pokemon.cooldown = 0
   }
 }
@@ -5041,14 +5041,14 @@ export class ForecastStrategy extends AbilityStrategy {
       if (p && pokemon.team === p.team) {
         p.addShield(10, pokemon, 1, crit)
         if (pokemon.name === Pkm.CASTFORM_SUN) {
-          p.addAttack(4, pokemon, 1, crit)
+          p.applyStat(Stat.ATK, 4, pokemon, 1, crit)
         }
         if (pokemon.name === Pkm.CASTFORM_RAIN) {
-          p.addPP(8, pokemon, 1, crit)
+          p.applyStat(Stat.PP, 8, pokemon, 1, crit)
         }
         if (pokemon.name === Pkm.CASTFORM_HAIL) {
-          p.addDefense(2, pokemon, 1, crit)
-          p.addSpecialDefense(2, pokemon, 1, crit)
+          p.applyStat(Stat.DEF, 2, pokemon, 1, crit)
+          p.applyStat(Stat.SPE_DEF, 2, pokemon, 1, crit)
         }
       }
     })
@@ -5168,9 +5168,9 @@ export class GeomancyStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, state, board, target, crit)
-    pokemon.addAttack(15, pokemon, 1, crit)
-    pokemon.addSpecialDefense(10, pokemon, 1, crit)
-    pokemon.addSpeed(20, pokemon, 0, false)
+    pokemon.applyStat(Stat.ATK, 15, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPE_DEF, 10, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPEED, 20, pokemon, 0, false)
   }
 }
 
@@ -5251,8 +5251,8 @@ export class GrowthStrategy extends AbilityStrategy {
       attackBuff *= 2 // grows twice as fast if sunny weather
       hpBuff *= 2
     }
-    pokemon.addAttack(attackBuff, pokemon, 1, crit)
-    pokemon.addMaxHP(hpBuff, pokemon, 1, crit)
+    pokemon.applyStat(Stat.ATK, attackBuff, pokemon, 1, crit)
+    pokemon.applyStat(Stat.HP, hpBuff, pokemon, 1, crit)
     pokemon.cooldown = Math.round(250 * (50 / pokemon.speed))
   }
 }
@@ -5533,11 +5533,11 @@ export class SilverWindStrategy extends AbilityStrategy {
     const farthestCoordinate =
       board.getFarthestTargetCoordinateAvailablePlace(pokemon)
 
-    pokemon.addAttack(1, pokemon, 0, false)
-    pokemon.addDefense(1, pokemon, 0, false)
-    pokemon.addSpecialDefense(1, pokemon, 0, false)
-    pokemon.addSpeed(10, pokemon, 0, false)
-    pokemon.addAbilityPower(10, pokemon, 0, false)
+    pokemon.applyStat(Stat.ATK, 1, pokemon, 0, false)
+    pokemon.applyStat(Stat.DEF, 1, pokemon, 0, false)
+    pokemon.applyStat(Stat.SPE_DEF, 1, pokemon, 0, false)
+    pokemon.applyStat(Stat.SPEED, 10, pokemon, 0, false)
+    pokemon.applyStat(Stat.AP, 10, pokemon, 0, false)
 
     if (farthestCoordinate) {
       const cells = board.getCellsBetween(
@@ -5584,7 +5584,7 @@ export class IcyWindStrategy extends AbilityStrategy {
           pokemon,
           crit
         )
-        cell.value.addSpeed(-speedDebuff, pokemon, 0, false)
+        cell.value.applyStat(Stat.SPEED, -speedDebuff, pokemon, 0, false)
       }
     })
   }
@@ -5688,7 +5688,7 @@ export class RolloutStrategy extends AbilityStrategy {
     const multiplier = 2
     const defenseBoost = [2, 5, 10][pokemon.stars - 1] ?? 10
 
-    pokemon.addDefense(defenseBoost, pokemon, 1, crit)
+    pokemon.applyStat(Stat.DEF, defenseBoost, pokemon, 1, crit)
     target.handleSpecialDamage(
       multiplier * pokemon.def,
       board,
@@ -5712,7 +5712,7 @@ export class IceBallStrategy extends AbilityStrategy {
     const multiplier = [0.5, 1, 1.5][pokemon.stars - 1] ?? 1.5
     const speDefBoost = 10
 
-    pokemon.addSpecialDefense(speDefBoost, pokemon, 0, false)
+    pokemon.applyStat(Stat.SPE_DEF, speDefBoost, pokemon, 0, false)
     target.handleSpecialDamage(
       baseDamage + multiplier * pokemon.speDef,
       board,
@@ -5732,7 +5732,7 @@ export class ThrashStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, state, board, target, crit)
-    pokemon.addAttack(pokemon.baseAtk, pokemon, 1, crit)
+    pokemon.applyStat(Stat.ATK, pokemon.baseAtk, pokemon, 1, crit)
     pokemon.status.triggerConfusion(3000, pokemon, pokemon)
   }
 }
@@ -5849,7 +5849,7 @@ export class FakeOutStrategy extends AbilityStrategy {
     const damage = [50, 100, 150][pokemon.stars - 1] ?? 150
     if (pokemon.ap >= 0) target.status.triggerFlinch(3000, target)
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    pokemon.addAbilityPower(-30, pokemon, 0, false)
+    pokemon.applyStat(Stat.AP, -30, pokemon, 0, false)
   }
 }
 
@@ -5871,8 +5871,8 @@ export class FellStingerStrategy extends AbilityStrategy {
       crit
     )
     if (victim.death && !pokemon.isSpawn) {
-      pokemon.addAttack(1, pokemon, 0, false, true)
-      pokemon.addMaxHP(10, pokemon, 0, false, true)
+      pokemon.applyStat(Stat.ATK, 1, pokemon, 0, false, true)
+      pokemon.applyStat(Stat.HP, 10, pokemon, 0, false, true)
     }
   }
 }
@@ -5982,7 +5982,7 @@ export class MistBallStrategy extends AbilityStrategy {
           pokemon,
           crit
         )
-        cell.value.addAbilityPower(-30, pokemon, 0, false)
+        cell.value.applyStat(Stat.AP, -30, pokemon, 0, false)
       }
     })
 
@@ -5997,7 +5997,7 @@ export class MistBallStrategy extends AbilityStrategy {
               pokemon,
               crit
             )
-            cell.value.addAbilityPower(-30, pokemon, 0, false)
+            cell.value.applyStat(Stat.AP, -30, pokemon, 0, false)
           }
         })
       }, 1000)
@@ -6034,7 +6034,7 @@ export class LusterPurgeStrategy extends AbilityStrategy {
           pokemon,
           crit
         )
-        cell.value.addSpecialDefense(-5, pokemon, 0, false)
+        cell.value.applyStat(Stat.SPE_DEF, -5, pokemon, 0, false)
       }
     })
 
@@ -6049,7 +6049,7 @@ export class LusterPurgeStrategy extends AbilityStrategy {
               pokemon,
               crit
             )
-            cell.value.addSpecialDefense(-3, pokemon, 0, false)
+            cell.value.applyStat(Stat.SPE_DEF, -3, pokemon, 0, false)
           }
         })
       }, 1000)
@@ -6205,11 +6205,11 @@ export class ShellSmashStrategy extends AbilityStrategy {
         )
       }
     })
-    pokemon.addAbilityPower(20, pokemon, 0, false)
-    pokemon.addAttack(2, pokemon, 0, false)
-    pokemon.addSpeed(20, pokemon, 0, false)
-    pokemon.addDefense(-2, pokemon, 0, false)
-    pokemon.addSpecialDefense(-2, pokemon, 0, false)
+    pokemon.applyStat(Stat.AP, 20, pokemon, 0, false)
+    pokemon.applyStat(Stat.ATK, 2, pokemon, 0, false)
+    pokemon.applyStat(Stat.SPEED, 20, pokemon, 0, false)
+    pokemon.applyStat(Stat.DEF, -2, pokemon, 0, false)
+    pokemon.applyStat(Stat.SPE_DEF, -2, pokemon, 0, false)
   }
 }
 
@@ -6474,7 +6474,7 @@ export class ShelterStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const defGain = [5, 10, 15][pokemon.stars - 1] ?? 15
-    pokemon.addDefense(defGain, pokemon, 1, crit)
+    pokemon.applyStat(Stat.DEF, defGain, pokemon, 1, crit)
     const cells = board.getCellsInFront(pokemon, target)
     cells.forEach((cell) => {
       board.addBoardEffect(cell.x, cell.y, Effect.SMOKE, pokemon.simulation)
@@ -6650,7 +6650,7 @@ export class TeeterDanceStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, state, board, target, crit)
-    pokemon.addSpeed(20, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPEED, 20, pokemon, 1, crit)
     board.cells
       .filter((v) => v !== undefined)
       .forEach((v) => v && v.status.triggerConfusion(3000, v, pokemon))
@@ -6666,8 +6666,8 @@ export class CloseCombatStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, state, board, target, crit)
-    pokemon.addDefense(-2, pokemon, 0, false)
-    pokemon.addSpecialDefense(-2, pokemon, 0, false)
+    pokemon.applyStat(Stat.DEF, -2, pokemon, 0, false)
+    pokemon.applyStat(Stat.SPE_DEF, -2, pokemon, 0, false)
     target.handleSpecialDamage(130, board, AttackType.SPECIAL, pokemon, crit)
   }
 }
@@ -6826,7 +6826,7 @@ export class LungeStrategy extends AbilityStrategy {
     if (cellToGo) {
       pokemon.moveTo(cellToGo.x, cellToGo.y, board)
       if (enemy) {
-        enemy.addAttack(-5, pokemon, 1, crit)
+        enemy.applyStat(Stat.ATK, -5, pokemon, 1, crit)
         enemy.handleSpecialDamage(
           50,
           board,
@@ -7053,7 +7053,7 @@ export class StruggleBugStrategy extends AbilityStrategy {
 
     cells.forEach((cell) => {
       if (cell.value && cell.value.team !== pokemon.team) {
-        cell.value.addAbilityPower(-50, pokemon, 0, false)
+        cell.value.applyStat(Stat.AP, -50, pokemon, 0, false)
         cell.value.handleSpecialDamage(
           30,
           board,
@@ -7075,10 +7075,10 @@ export class QuiverDanceStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, state, board, target, crit)
-    pokemon.addAttack(5, pokemon, 1, crit)
-    pokemon.addSpecialDefense(5, pokemon, 1, crit)
-    pokemon.addSpeed(10, pokemon, 1, crit)
-    pokemon.addAbilityPower(20, pokemon, 0, false)
+    pokemon.applyStat(Stat.ATK, 5, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPE_DEF, 5, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPEED, 10, pokemon, 1, crit)
+    pokemon.applyStat(Stat.AP, 20, pokemon, 0, false)
   }
 }
 
@@ -7094,7 +7094,7 @@ export class TailGlowStrategy extends AbilityStrategy {
 
     const cells = board.getAdjacentCells(pokemon.positionX, pokemon.positionY)
 
-    pokemon.addAbilityPower(50, pokemon, 0, false)
+    pokemon.applyStat(Stat.AP, 50, pokemon, 0, false)
     cells.forEach((cell) => {
       if (cell.value && cell.value.team !== pokemon.team) {
         cell.value.handleSpecialDamage(
@@ -7264,7 +7264,7 @@ export class ScreechStrategy extends AbilityStrategy {
     )
     cells.forEach((cell) => {
       if (cell.value && cell.value.team !== pokemon.team) {
-        cell.value.addDefense(debuff, pokemon, 1, crit)
+        cell.value.applyStat(Stat.DEF, debuff, pokemon, 1, crit)
         broadcastAbility(pokemon, { targetX: cell.x, targetY: cell.y })
       }
     })
@@ -7341,7 +7341,7 @@ export class AcidSprayStrategy extends AbilityStrategy {
           targetX: tg.positionX,
           targetY: tg.positionY
         })
-        tg.addSpecialDefense(-5, pokemon, 0, false)
+        tg.applyStat(Stat.SPE_DEF, -5, pokemon, 0, false)
         tg.handleSpecialDamage(33, board, AttackType.SPECIAL, pokemon, crit)
         affectedTargetsIds.push(tg.id)
         const cells = board.getAdjacentCells(tg.positionX, tg.positionY)
@@ -7371,8 +7371,8 @@ export class UnboundStrategy extends AbilityStrategy {
     super.process(pokemon, state, board, target, crit)
     pokemon.index = PkmIndex[Pkm.HOOPA_UNBOUND]
     pokemon.skill = Ability.HYPERSPACE_FURY
-    pokemon.addAttack(10, pokemon, 0, false)
-    pokemon.addMaxHP(100, pokemon, 0, false)
+    pokemon.applyStat(Stat.ATK, 10, pokemon, 0, false)
+    pokemon.applyStat(Stat.HP, 100, pokemon, 0, false)
     pokemon.toMovingState()
   }
 }
@@ -7388,8 +7388,8 @@ export class HyperspaceFuryStrategy extends AbilityStrategy {
     super.process(pokemon, state, board, target, crit, true)
     const nbHits = 4 * (1 + pokemon.ap / 100) * (crit ? pokemon.critPower : 1)
     for (let i = 0; i < nbHits; i++) {
-      target.addDefense(-1, pokemon, 0, false)
-      target.addSpecialDefense(-1, pokemon, 0, false)
+      target.applyStat(Stat.DEF, -1, pokemon, 0, false)
+      target.applyStat(Stat.SPE_DEF, -1, pokemon, 0, false)
       target.handleSpecialDamage(
         15,
         board,
@@ -7848,7 +7848,7 @@ export class DoomDesireStrategy extends AbilityStrategy {
             true
           )
         } else {
-          pokemon.addPP(60, pokemon, 0, false)
+          pokemon.applyStat(Stat.PP, 60, pokemon, 0, false)
         }
       }, 2000)
     )
@@ -8328,7 +8328,7 @@ export class AuraWheelStrategy extends AbilityStrategy {
       pokemon.name = Pkm.MORPEKO
       pokemon.index = PkmIndex[Pkm.MORPEKO]
     }
-    pokemon.addSpeed(10, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPEED, 10, pokemon, 1, crit)
 
     target.handleSpecialDamage(
       60,
@@ -8419,8 +8419,8 @@ export class TickleStrategy extends AbilityStrategy {
           nbEnemiesHit < nbMaxEnemiesHit
         ) {
           nbEnemiesHit++
-          cell.value.addAttack(-attackLost, pokemon, 1, true)
-          cell.value.addDefense(-defLost, pokemon, 1, true)
+          cell.value.applyStat(Stat.ATK, -attackLost, pokemon, 1, true)
+          cell.value.applyStat(Stat.DEF, -defLost, pokemon, 1, true)
         }
       })
   }
@@ -8578,7 +8578,7 @@ export class PetalBlizzardStrategy extends AbilityStrategy {
           )
         }
       })
-    pokemon.addAbilityPower(10, pokemon, 0, false)
+    pokemon.applyStat(Stat.AP, 10, pokemon, 0, false)
   }
 }
 
@@ -8754,7 +8754,7 @@ export class SpiritBreakStrategy extends AbilityStrategy {
       true
     )
     const apDebuff = -20
-    target.addAbilityPower(apDebuff, pokemon, 1, crit)
+    target.applyStat(Stat.AP, apDebuff, pokemon, 1, crit)
   }
 }
 
@@ -8926,7 +8926,7 @@ export class PsychoBoostStrategy extends AbilityStrategy {
             true
           )
 
-          pokemon.addAbilityPower(-20, pokemon, 0, false)
+          pokemon.applyStat(Stat.AP, -20, pokemon, 0, false)
         }
       }
     )
@@ -9242,7 +9242,7 @@ export class TailWhipStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const defLoss = -0.3 * target.def
-    target.addDefense(defLoss, pokemon, 1, crit)
+    target.applyStat(Stat.DEF, defLoss, pokemon, 1, crit)
   }
 }
 
@@ -9319,7 +9319,7 @@ export class TorchSongStrategy extends AbilityStrategy {
             targetX: randomTarget.positionX,
             targetY: randomTarget.positionY
           })
-          pokemon.addAbilityPower(apGainPerFlame, pokemon, 0, false)
+          pokemon.applyStat(Stat.AP, apGainPerFlame, pokemon, 0, false)
           if (randomTarget?.life > 0) {
             randomTarget.handleSpecialDamage(
               damagePerFlame,
@@ -9417,11 +9417,11 @@ export class StoneEdgeStrategy extends AbilityStrategy {
 
     pokemon.status.triggerSilence(duration, pokemon, pokemon)
     pokemon.effects.add(Effect.STONE_EDGE)
-    pokemon.addCritChance(20, pokemon, 1, false)
+    pokemon.applyStat(Stat.CRIT_CHANCE, 20, pokemon, 1, false)
     pokemon.range += 2
     pokemon.commands.push(
       new DelayedCommand(() => {
-        pokemon.addCritChance(-20, pokemon, 1, false)
+        pokemon.applyStat(Stat.CRIT_CHANCE, -20, pokemon, 1, false)
         pokemon.range = min(pokemon.baseRange)(pokemon.range - 2)
         pokemon.effects.delete(Effect.STONE_EDGE)
       }, duration)
@@ -9443,7 +9443,7 @@ export class PsyShockStrategy extends AbilityStrategy {
     const ppStolen = max(target.pp)(ppBurn)
     const extraPP = ppBurn - ppStolen
 
-    target.addPP(-ppStolen, pokemon, 0, crit)
+    target.applyStat(Stat.PP, -ppStolen, pokemon, 0, crit)
     pokemon.addShield(ppBurn, pokemon, 0, crit)
     if (extraPP > 0) {
       target.handleSpecialDamage(
@@ -9533,7 +9533,7 @@ export class BulldozeStrategy extends AbilityStrategy {
           cell.value.cooldown = 500
         }
 
-        cell.value.addSpeed(-speedReduction, pokemon, 0, crit)
+        cell.value.applyStat(Stat.SPEED, -speedReduction, pokemon, 0, crit)
 
         cell.value.handleSpecialDamage(
           damage,
@@ -9561,8 +9561,8 @@ export class RapidSpinStrategy extends AbilityStrategy {
 
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
 
-    pokemon.addDefense(buffAmount, pokemon, 1, true)
-    pokemon.addSpecialDefense(buffAmount, pokemon, 1, true)
+    pokemon.applyStat(Stat.DEF, buffAmount, pokemon, 1, true)
+    pokemon.applyStat(Stat.SPE_DEF, buffAmount, pokemon, 1, true)
   }
 }
 
@@ -9638,7 +9638,7 @@ export class AncientPowerStrategy extends AbilityStrategy {
     super.process(pokemon, state, board, target, crit)
     const damage = [40, 80, 120][pokemon.stars - 1] ?? 120
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    pokemon.addAbilityPower(25, pokemon, 0, false)
+    pokemon.applyStat(Stat.AP, 25, pokemon, 0, false)
   }
 }
 
@@ -9796,7 +9796,7 @@ export class CrushClawStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const defLoss = [-5, -10][pokemon.stars - 1] ?? -6
-    target.addDefense(defLoss, pokemon, 0, false)
+    target.applyStat(Stat.DEF, defLoss, pokemon, 0, false)
     for (let i = 0; i < 2; i++) {
       target.handleSpecialDamage(
         pokemon.atk,
@@ -10114,7 +10114,7 @@ export class CharmStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const attackReduce = [2, 3, 4][pokemon.stars - 1] ?? 4
-    target.addAttack(-attackReduce, pokemon, 1, crit)
+    target.applyStat(Stat.ATK, -attackReduce, pokemon, 1, crit)
     target.status.triggerCharm(3000, target, pokemon, false)
   }
 }
@@ -10129,7 +10129,7 @@ export class EntrainmentStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const ppGained = 10
-    pokemon.addPP(ppGained, pokemon, 1, crit)
+    pokemon.applyStat(Stat.PP, ppGained, pokemon, 1, crit)
     if (target.skill !== Ability.ENTRAINMENT) {
       target.skill = Ability.ENTRAINMENT
     } else {
@@ -10394,7 +10394,7 @@ export class IvyCudgelStrategy extends AbilityStrategy {
         .getAdjacentCells(pokemon.positionX, pokemon.positionY, true)
         .forEach((cell) => {
           if (cell.value && cell.value.team === pokemon.team) {
-            cell.value.addPP(20, pokemon, 1, crit)
+            cell.value.applyStat(Stat.PP, 20, pokemon, 1, crit)
           }
         })
     } else if (pokemon.passive === Passive.OGERPON_HEARTHFLAME) {
@@ -10469,8 +10469,8 @@ export class SteelWingStrategy extends AbilityStrategy {
       cells.forEach((cell) => {
         if (cell.value && cell.value.team != pokemon.team) {
           broadcastAbility(pokemon, { positionX: cell.x, positionY: cell.y })
-          pokemon.addDefense(1, pokemon, 0, false)
-          cell.value.addDefense(-1, pokemon, 0, false)
+          pokemon.applyStat(Stat.DEF, 1, pokemon, 0, false)
+          cell.value.applyStat(Stat.DEF, -1, pokemon, 0, false)
           cell.value.handleSpecialDamage(
             damage,
             board,
@@ -10543,7 +10543,7 @@ export class YawnStrategy extends AbilityStrategy {
 
     opponentsTargetingMe.forEach((opponent) => {
       opponent.status.triggerFatigue(3000, pokemon)
-      opponent.addAbilityPower(-20, pokemon, 0, false)
+      opponent.applyStat(Stat.AP, -20, pokemon, 0, false)
     })
 
     const shield = [10, 20, 40][pokemon.stars - 1] ?? 40
@@ -10758,7 +10758,7 @@ export class ThunderousKickStrategy extends AbilityStrategy {
     const damage = [20, 40, 60][pokemon.stars - 1] ?? 60
 
     target.status.triggerFlinch(4000, pokemon)
-    target.addDefense(-10, pokemon, 1, crit)
+    target.applyStat(Stat.DEF, -10, pokemon, 1, crit)
     target.handleSpecialDamage(
       damage,
       board,
@@ -10771,7 +10771,7 @@ export class ThunderousKickStrategy extends AbilityStrategy {
       if (cell.value != null && target.id !== cell.value.id) {
         if (cell.value.team !== pokemon.team) {
           cell.value.status.triggerFlinch(4000, pokemon)
-          cell.value.addDefense(-5, pokemon, 1, crit)
+          cell.value.applyStat(Stat.DEF, -5, pokemon, 1, crit)
           cell.value.handleSpecialDamage(
             damage,
             board,
@@ -10847,12 +10847,12 @@ export class ViseGripStrategy extends AbilityStrategy {
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
     const defGain = target.def * 1
     const spedefGain = target.speDef * 1
-    pokemon.addDefense(defGain, pokemon, 1, crit)
-    pokemon.addSpecialDefense(spedefGain, pokemon, 1, crit)
+    pokemon.applyStat(Stat.DEF, defGain, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPE_DEF, spedefGain, pokemon, 1, crit)
     pokemon.commands.push(
       new DelayedCommand(() => {
-        pokemon.addDefense(-defGain, pokemon, 1, crit)
-        pokemon.addSpecialDefense(-spedefGain, pokemon, 1, crit)
+        pokemon.applyStat(Stat.DEF, -defGain, pokemon, 1, crit)
+        pokemon.applyStat(Stat.SPE_DEF, -spedefGain, pokemon, 1, crit)
       }, 4000)
     )
   }
@@ -10884,8 +10884,8 @@ export class LandsWrathStrategy extends AbilityStrategy {
           crit,
           false
         )
-        cell.value.addDefense(-8, pokemon, 0.5, crit)
-        cell.value.addSpecialDefense(-8, pokemon, 0.5, crit)
+        cell.value.applyStat(Stat.DEF, -8, pokemon, 0.5, crit)
+        cell.value.applyStat(Stat.SPE_DEF, -8, pokemon, 0.5, crit)
         broadcastAbility(pokemon, {
           skill: "LANDS_WRATH/hit",
           positionX: cell.x,
@@ -11070,7 +11070,7 @@ export class MetalClawStrategy extends AbilityStrategy {
     const damage = [10, 20, 40][pokemon.stars - 1] ?? 40
     const atkBuff = [2, 4, 6][pokemon.stars - 1] ?? 6
     target.handleSpecialDamage(damage, board, AttackType.TRUE, pokemon, crit)
-    pokemon.addAttack(atkBuff, pokemon, 1, crit)
+    pokemon.applyStat(Stat.ATK, atkBuff, pokemon, 1, crit)
   }
 }
 
@@ -11102,7 +11102,7 @@ export class FirestarterStrategy extends AbilityStrategy {
         ) {
           pokemon.commands.push(
             new DelayedCommand(() => {
-              pokemon.addSpeed(speedBuff, pokemon, 1, crit)
+              pokemon.applyStat(Stat.SPEED, speedBuff, pokemon, 1, crit)
             }, 500)
           )
         } else {
@@ -11181,8 +11181,8 @@ export class BoneArmorStrategy extends AbilityStrategy {
         pokemon.handleHeal(attack.takenDamage, pokemon, 1, crit)
       }
       if (attack.death) {
-        pokemon.addDefense(defBuff, pokemon, 0, false)
-        pokemon.addSpecialDefense(defBuff, pokemon, 0, false)
+        pokemon.applyStat(Stat.DEF, defBuff, pokemon, 0, false)
+        pokemon.applyStat(Stat.SPE_DEF, defBuff, pokemon, 0, false)
       }
     }
   }
@@ -11209,18 +11209,18 @@ export class TopsyTurvyStrategy extends AbilityStrategy {
         )
         if (target.atk > target.baseAtk) {
           const d = target.atk - target.baseAtk
-          target.addAttack(-2 * d, pokemon, 0, false)
+          target.applyStat(Stat.ATK, -2 * d, pokemon, 0, false)
         }
         if (target.ap > 0) {
-          target.addAbilityPower(-2 * target.ap, pokemon, 0, false)
+          target.applyStat(Stat.AP, -2 * target.ap, pokemon, 0, false)
         }
         if (target.def > target.baseDef) {
           const d = target.def - target.baseDef
-          target.addDefense(-2 * d, pokemon, 0, false)
+          target.applyStat(Stat.DEF, -2 * d, pokemon, 0, false)
         }
         if (target.speDef > target.baseSpeDef) {
           const d = target.speDef - target.baseSpeDef
-          target.addSpecialDefense(-2 * d, pokemon, 0, false)
+          target.applyStat(Stat.SPE_DEF, -2 * d, pokemon, 0, false)
         }
       }, 500)
     )
@@ -11243,7 +11243,7 @@ export class RageStrategy extends AbilityStrategy {
     const missingHp = pokemon.hp - pokemon.life
     const atkBoost =
       pokemon.baseAtk * 0.1 * Math.floor(missingHp / (pokemon.hp / 10))
-    pokemon.addAttack(atkBoost, pokemon, 1, true)
+    pokemon.applyStat(Stat.ATK, atkBoost, pokemon, 1, true)
   }
 }
 
@@ -11310,8 +11310,8 @@ export class BulkUpStrategy extends AbilityStrategy {
     // Increase base Attack and base Defense by 40%
     const atkBoost = Math.ceil(0.5 * pokemon.baseAtk)
     const defBoost = Math.ceil(0.5 * pokemon.baseDef)
-    pokemon.addAttack(atkBoost, pokemon, 1, crit)
-    pokemon.addDefense(defBoost, pokemon, 1, crit)
+    pokemon.applyStat(Stat.ATK, atkBoost, pokemon, 1, crit)
+    pokemon.applyStat(Stat.DEF, defBoost, pokemon, 1, crit)
   }
 }
 
@@ -11472,7 +11472,7 @@ export class HardenStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     const defGain = [4, 8, 12][pokemon.stars - 1] ?? 12
-    pokemon.addDefense(defGain, pokemon, 1, crit)
+    pokemon.applyStat(Stat.DEF, defGain, pokemon, 1, crit)
   }
 }
 
@@ -11650,11 +11650,11 @@ export class DarkLariatStrategy extends AbilityStrategy {
                 crit
               )
               if (pokemon.effects.has(Effect.VICTORY_STAR)) {
-                pokemon.addAttack(1, pokemon, 0, false)
+                pokemon.applyStat(Stat.ATK, 1, pokemon, 0, false)
               } else if (pokemon.effects.has(Effect.DROUGHT)) {
-                pokemon.addAttack(2, pokemon, 0, false)
+                pokemon.applyStat(Stat.ATK, 2, pokemon, 0, false)
               } else if (pokemon.effects.has(Effect.DESOLATE_LAND)) {
-                pokemon.addAttack(3, pokemon, 0, false)
+                pokemon.applyStat(Stat.ATK, 3, pokemon, 0, false)
               }
             }
           },
@@ -11982,7 +11982,7 @@ export class SweetScentStrategy extends AbilityStrategy {
         if (chance(0.3, pokemon)) {
           cell.value.status.triggerCharm(1000, cell.value, pokemon, false)
         }
-        cell.value.addSpecialDefense(-6, pokemon, 1, crit)
+        cell.value.applyStat(Stat.SPE_DEF, -6, pokemon, 1, crit)
         cell.value.addDodgeChance(-cell.value.dodge, pokemon, 0, false)
       }
     })
@@ -12024,8 +12024,8 @@ export class SwallowStrategy extends AbilityStrategy {
       broadcastAbility(pokemon, { skill: Ability.SWALLOW })
       pokemon.count.ult = 0
     } else {
-      pokemon.addDefense(3, pokemon, 0, false)
-      pokemon.addSpecialDefense(3, pokemon, 0, false)
+      pokemon.applyStat(Stat.DEF, 3, pokemon, 0, false)
+      pokemon.applyStat(Stat.SPE_DEF, 3, pokemon, 0, false)
     }
   }
 }
@@ -12047,29 +12047,29 @@ export class DecorateStrategy extends AbilityStrategy {
         targetX: nearestAlly.positionX,
         targetY: nearestAlly.positionY
       })
-      nearestAlly.addAttack(atkBoost, pokemon, 1, crit)
-      nearestAlly.addAbilityPower(apBoost, pokemon, 1, crit)
+      nearestAlly.applyStat(Stat.ATK, atkBoost, pokemon, 1, crit)
+      nearestAlly.applyStat(Stat.AP, apBoost, pokemon, 1, crit)
 
       if (pokemon.name === Pkm.ALCREMIE_VANILLA) {
         nearestAlly.addShield(60, pokemon, 1, crit)
       } else if (pokemon.name === Pkm.ALCREMIE_RUBY) {
-        nearestAlly.addSpeed(30, pokemon, 1, crit)
+        nearestAlly.applyStat(Stat.SPEED, 30, pokemon, 1, crit)
       } else if (pokemon.name === Pkm.ALCREMIE_MATCHA) {
-        nearestAlly.addMaxHP(40, pokemon, 1, crit)
+        nearestAlly.applyStat(Stat.HP, 40, pokemon, 1, crit)
       } else if (pokemon.name === Pkm.ALCREMIE_MINT) {
         nearestAlly.handleHeal(40, pokemon, 0, crit)
-        nearestAlly.addSpecialDefense(15, pokemon, 0, crit)
+        nearestAlly.applyStat(Stat.SPE_DEF, 15, pokemon, 0, crit)
       } else if (pokemon.name === Pkm.ALCREMIE_LEMON) {
-        nearestAlly.addCritChance(40, pokemon, 0, crit)
+        nearestAlly.applyStat(Stat.CRIT_CHANCE, 40, pokemon, 0, crit)
       } else if (pokemon.name === Pkm.ALCREMIE_SALTED) {
         nearestAlly.handleHeal(40, pokemon, 1, crit)
-        nearestAlly.addDefense(15, pokemon, 0, crit)
+        nearestAlly.applyStat(Stat.DEF, 15, pokemon, 0, crit)
       } else if (pokemon.items.has(Item.RUBY_SWIRL_FLAVOR)) {
-        nearestAlly.addAttack(8, pokemon, 1, crit)
+        nearestAlly.applyStat(Stat.ATK, 8, pokemon, 1, crit)
       } else if (pokemon.items.has(Item.CARAMEL_SWIRL_FLAVOR)) {
-        nearestAlly.addCritPower(80, pokemon, 1, crit)
+        nearestAlly.applyStat(Stat.CRIT_POWER, 80, pokemon, 1, crit)
       } else if (pokemon.name === Pkm.ALCREMIE_RAINBOW_SWIRL) {
-        nearestAlly.addAbilityPower(60, pokemon, 1, crit)
+        nearestAlly.applyStat(Stat.AP, 60, pokemon, 1, crit)
       }
     }
   }
@@ -12145,7 +12145,7 @@ export class MudShotStrategy extends AbilityStrategy {
     const damage = [25, 50, 75][pokemon.stars - 1] ?? 75
     const speedDebuff = [10, 20, 30][pokemon.stars - 1] ?? 30
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    target.addSpeed(-speedDebuff, pokemon, 1, crit)
+    target.applyStat(Stat.SPEED, -speedDebuff, pokemon, 1, crit)
   }
 }
 
@@ -12190,8 +12190,8 @@ export class FilletAwayStrategy extends AbilityStrategy {
       false,
       false
     )
-    pokemon.addAttack(10, pokemon, 1, crit)
-    pokemon.addSpeed(20, pokemon, 1, crit)
+    pokemon.applyStat(Stat.ATK, 10, pokemon, 1, crit)
+    pokemon.applyStat(Stat.SPEED, 20, pokemon, 1, crit)
     pokemon.status.triggerProtect(400)
     // move to backline
     const corner = board.getTeleportationCell(
@@ -12254,7 +12254,7 @@ export class ElectroShotStrategy extends AbilityStrategy {
         () => {
           const damage = [80, 90, 100][pokemon.stars - 1] ?? 100
           const apBoost = 40
-          pokemon.addAbilityPower(apBoost, pokemon, 0, crit)
+          pokemon.applyStat(Stat.AP, apBoost, pokemon, 0, crit)
           broadcastAbility(pokemon, {
             skill: Ability.ELECTRO_SHOT,
             targetX: target.positionX,

--- a/app/core/abilities/ability-strategy.ts
+++ b/app/core/abilities/ability-strategy.ts
@@ -12,6 +12,7 @@ import { AbilityStrategies } from "./abilities"
 import { min } from "../../utils/number"
 import { OnAbilityCastEffect } from "../effect"
 import { DelayedCommand } from "../simulation-command"
+import { Stat } from "../../types/enum/Game"
 
 export class AbilityStrategy {
   copyable = true // if true, can be copied by mimic, metronome...
@@ -45,7 +46,7 @@ export class AbilityStrategy {
     })
 
     if (pokemon.items.has(Item.AQUA_EGG)) {
-      pokemon.addPP(20, pokemon, 0, false)
+      pokemon.applyStat(Stat.PP, 20)
     }
 
     if (pokemon.items.has(Item.STAR_DUST)) {
@@ -60,7 +61,7 @@ export class AbilityStrategy {
     if (pokemon.items.has(Item.MAX_ELIXIR) && pokemon.count.ult === 1) {
       pokemon.commands.push(
         new DelayedCommand(() => {
-          pokemon.addPP(pokemon.maxPP, pokemon, 0, false)
+          pokemon.applyStat(Stat.PP, pokemon.maxPP, pokemon, 0, false)
           pokemon.removeItem(Item.MAX_ELIXIR, false)
         }, 1000)
       )
@@ -78,8 +79,8 @@ export class AbilityStrategy {
     }
 
     if (pokemon.passive === Passive.SLOW_START && pokemon.count.ult === 1) {
-      pokemon.addSpeed(30, pokemon, 0, false)
-      pokemon.addAttack(10, pokemon, 0, false)
+      pokemon.applyStat(Stat.SPEED, 30)
+      pokemon.applyStat(Stat.SPEED, 10)
     }
   }
 }

--- a/app/core/dishes.ts
+++ b/app/core/dishes.ts
@@ -1,4 +1,5 @@
 import { Effect as EffectEnum } from "../types/enum/Effect"
+import { Stat } from "../types/enum/Game"
 import { Berries, Dishes, Item } from "../types/enum/Item"
 import { Pkm } from "../types/enum/Pokemon"
 import { Synergy } from "../types/enum/Synergy"
@@ -117,39 +118,39 @@ export const DishEffects: Record<(typeof Dishes)[number], Effect[]> = {
   ],
   FRUIT_JUICE: [
     new OnSpawnEffect((entity) => {
-      entity.addSpeed(50, entity, 0, false)
+      entity.applyStat(Stat.SPEED, 50)
     })
   ],
   HEARTY_STEW: [
     new OnSpawnEffect((entity) => {
-      entity.addMaxHP(0.3 * entity.baseHP, entity, 0, false)
+      entity.applyStat(Stat.HP, 0.3 * entity.baseHP)
     })
   ],
   HONEY: [],
   LARGE_LEEK: [
     new OnSpawnEffect((entity) => {
       entity.effects.add(EffectEnum.ABILITY_CRIT)
-      entity.addCritPower(100, entity, 0, false)
+      entity.applyStat(Stat.CRIT_POWER, 100)
     })
   ],
   LEEK: [
     new OnSpawnEffect((entity) => {
       entity.effects.add(EffectEnum.ABILITY_CRIT)
-      entity.addCritChance(50, entity, 0, false)
+      entity.applyStat(Stat.CRIT_CHANCE, 50)
     })
   ],
   LEFTOVERS: [],
   MOOMOO_MILK: [
     new OnSpawnEffect((entity) => {
-      entity.addMaxHP(10, entity, 0, false, true)
+      entity.applyStat(Stat.HP, 10, entity, 0, false, true)
     })
   ],
   NUTRITIOUS_EGG: [
     new OnSpawnEffect((entity) => {
       // Start the next fight with +30% base ATK, DEF, SPE_DEF and AP
-      entity.addAttack(0.3 * entity.baseAtk, entity, 0, false)
-      entity.addDefense(0.3 * entity.baseDef, entity, 0, false)
-      entity.addSpecialDefense(0.3 * entity.baseSpeDef, entity, 0, false)
+      entity.applyStat(Stat.ATK, 0.3 * entity.baseAtk)
+      entity.applyStat(Stat.DEF, 0.3 * entity.baseDef)
+      entity.applyStat(Stat.SPE_DEF, 0.3 * entity.baseSpeDef)
     })
   ],
   POFFIN: [
@@ -164,7 +165,7 @@ export const DishEffects: Record<(typeof Dishes)[number], Effect[]> = {
   ],
   RAGE_CANDY_BAR: [
     new OnSpawnEffect((entity) => {
-      entity.addAttack(10, entity, 0, false)
+      entity.applyStat(Stat.ATK, 10)
     })
   ],
   ROCK_SALT: [
@@ -181,7 +182,7 @@ export const DishEffects: Record<(typeof Dishes)[number], Effect[]> = {
           case Synergy.GOURMET:
           case Synergy.BUG:
           case Synergy.AMORPHOUS:
-            entity.addMaxHP(20, entity, 0, false)
+            entity.applyStat(Stat.HP, 20)
             break
           case Synergy.NORMAL:
           case Synergy.ARTIFICIAL:
@@ -192,7 +193,7 @@ export const DishEffects: Record<(typeof Dishes)[number], Effect[]> = {
           case Synergy.FIRE:
           case Synergy.STEEL:
           case Synergy.FOSSIL:
-            entity.addAttack(5, entity, 0, false)
+            entity.applyStat(Stat.ATK, 5)
             break
           case Synergy.FLYING:
           case Synergy.GHOST:
@@ -201,31 +202,31 @@ export const DishEffects: Record<(typeof Dishes)[number], Effect[]> = {
           case Synergy.ELECTRIC:
           case Synergy.FIELD:
           case Synergy.WILD:
-            entity.addSpeed(10, entity, 0, false)
+            entity.applyStat(Stat.SPEED, 10)
             break
           case Synergy.ICE:
           case Synergy.AQUATIC:
           case Synergy.FLORA:
-            entity.addSpecialDefense(5, entity, 0, false)
+            entity.applyStat(Stat.SPE_DEF, 5)
             break
           case Synergy.GROUND:
           case Synergy.FIGHTING:
           case Synergy.ROCK:    
-            entity.addDefense(5, entity, 0, false)
+            entity.applyStat(Stat.DEF, 5)
             break
           case Synergy.PSYCHIC:
           case Synergy.HUMAN:
           case Synergy.LIGHT:
-            entity.addAbilityPower(20, entity, 0, false)
+            entity.applyStat(Stat.AP, 20)
             break
           case Synergy.FAIRY:
           case Synergy.DARK:
-            entity.addCritChance(5, entity, 0, false)
-            entity.addCritPower(10, entity, 0, false)
+            entity.applyStat(Stat.CRIT_CHANCE, 5)
+            entity.applyStat(Stat.CRIT_POWER, 10)
             break
           case Synergy.WATER:
           case Synergy.SOUND:
-            entity.addPP(20, entity, 0, false)
+            entity.applyStat(Stat.PP, 20)
             break
         }
       })
@@ -233,21 +234,21 @@ export const DishEffects: Record<(typeof Dishes)[number], Effect[]> = {
   ],
   SMOKED_FILET: [
     new OnSpawnEffect((entity) => {
-      entity.addMaxHP(-10, entity, 0, false, true)
-      entity.addAttack(3, entity, 0, false, true)
-      entity.addAbilityPower(5, entity, 0, false, true)
+      entity.applyStat(Stat.HP, -10, entity, 0, false, true)
+      entity.applyStat(Stat.ATK, 3, entity, 0, false, true)
+      entity.applyStat(Stat.AP, 5, entity, 0, false, true)
     })
   ],
   SPINDA_COCKTAIL: [
     new OnSpawnEffect((entity) => {
       if (chance(0.8, entity)) {
-        entity.addAttack(5, entity, 0, false)
+        entity.applyStat(Stat.ATK, 5)
       }
       if (chance(0.8, entity)) {
-        entity.addSpeed(25, entity, 0, false)
+        entity.applyStat(Stat.SPEED, 25)
       }
       if (chance(0.8, entity)) {
-        entity.addAbilityPower(25, entity, 0, false)
+        entity.applyStat(Stat.AP, 25)
       }
       if (chance(0.8, entity)) {
         entity.addShield(50, entity, 0, false)
@@ -271,22 +272,22 @@ export const DishEffects: Record<(typeof Dishes)[number], Effect[]> = {
   ],
   SWEET_APPLE: [
     new OnHitEffect((entity, target, board) => {
-      target.addSpecialDefense(-2, entity, 0, false)
+      target.applyStat(Stat.SPE_DEF, -2)
     })
   ],
   TART_APPLE: [
     new OnHitEffect((entity, target, board) => {
-      target.addDefense(-2, entity, 0, false)
+      target.applyStat(Stat.DEF, -2)
     })
   ],
   SWEET_HERB: [
     new OnSpawnEffect((entity) => {
-      entity.addAbilityPower(80, entity, 0, false)
+      entity.applyStat(Stat.AP, 80)
     })
   ],
   TEA: [
     new OnSpawnEffect((entity) => {
-      entity.addPP(80, entity, 0, false)
+      entity.applyStat(Stat.PP, 80)
     })
   ],
   WHIPPED_DREAM: [
@@ -303,37 +304,37 @@ export const DishEffects: Record<(typeof Dishes)[number], Effect[]> = {
   SWEETS: [],
   STRAWBERRY_SWEET: [
     new OnSpawnEffect((entity) => {
-      entity.addAttack(3, entity, 0, false, true)
+      entity.applyStat(Stat.ATK, 3, entity, 0, false, true)
     })
   ],
   LOVE_SWEET: [
     new OnSpawnEffect((entity) => {
-      entity.addDefense(3, entity, 0, false, true)
+      entity.applyStat(Stat.DEF, 3, entity, 0, false, true)
     })
   ],
   BERRY_SWEET: [
     new OnSpawnEffect((entity) => {
-      entity.addMaxHP(10, entity, 0, false, true)
+      entity.applyStat(Stat.HP, 10, entity, 0, false, true)
     })
   ],
   CLOVER_SWEET: [
     new OnSpawnEffect((entity) => {
-      entity.addLuck(10, entity, 0, false, true)
+      entity.applyStat(Stat.LUCK, 10, entity, 0, false, true)
     })
   ],
   FLOWER_SWEET: [
     new OnSpawnEffect((entity) => {
-      entity.addSpeed(5, entity, 0, false, true)
+      entity.applyStat(Stat.SPEED, 5, entity, 0, false, true)
     })
   ],
   STAR_SWEET: [
     new OnSpawnEffect((entity) => {
-      entity.addAbilityPower(5, entity, 0, false, true)
+      entity.applyStat(Stat.AP, 5, entity, 0, false, true)
     })
   ],
   RIBBON_SWEET: [
     new OnSpawnEffect((entity) => {
-      entity.addSpecialDefense(3, entity, 0, false, true)
+      entity.applyStat(Stat.SPE_DEF, 3, entity, 0, false, true)
     })
   ]
 }

--- a/app/core/effect.ts
+++ b/app/core/effect.ts
@@ -7,7 +7,7 @@ import PokemonState from "./pokemon-state"
 import { Passive } from "../types/enum/Passive"
 import { Ability } from "../types/enum/Ability"
 import { SynergyEffects } from "../models/effects"
-import { AttackType } from "../types/enum/Game"
+import { AttackType, Stat } from "../types/enum/Game"
 import { chance } from "../utils/random"
 
 type EffectOrigin = EffectEnum | Item | Passive | Ability
@@ -139,9 +139,9 @@ export class MonsterKillEffect extends OnKillEffect {
     const apBoost = [10, 20, 30, 30][this.synergyLevel] ?? 30
     const hpGain = [0.2, 0.4, 0.6, 0.6][this.synergyLevel] ?? 0.6
     const lifeBoost = hpGain * target.hp
-    pokemon.addAttack(attackBoost, pokemon, 0, false)
-    pokemon.addAbilityPower(apBoost, pokemon, 0, false)
-    pokemon.addMaxHP(lifeBoost, pokemon, 0, false)
+    pokemon.applyStat(Stat.ATK, attackBoost)
+    pokemon.applyStat(Stat.AP, apBoost)
+    pokemon.applyStat(Stat.HP, lifeBoost)
     this.hpBoosted += lifeBoost
     this.count += 1
   }
@@ -155,9 +155,9 @@ export class GrowGroundEffect extends PeriodicEffect {
         if (this.count > 5) {
           return
         }
-        pokemon.addDefense(this.synergyLevel * 2, pokemon, 0, false)
-        pokemon.addSpecialDefense(this.synergyLevel * 2, pokemon, 0, false)
-        pokemon.addAttack(this.synergyLevel, pokemon, 0, false)
+        pokemon.applyStat(Stat.DEF, this.synergyLevel * 2)
+        pokemon.applyStat(Stat.SPE_DEF, this.synergyLevel * 2)
+        pokemon.applyStat(Stat.ATK, this.synergyLevel)
         pokemon.transferAbility("GROUND_GROW")
         if (
           pokemon.items.has(Item.BIG_NUGGET) &&
@@ -179,7 +179,7 @@ export class ClearWingEffect extends PeriodicEffect {
   constructor() {
     super(
       (pokemon) => {
-        pokemon.addSpeed(2, pokemon, 0, false)
+        pokemon.applyStat(Stat.SPEED, 2)
       },
       Passive.CLEAR_WING,
       1000
@@ -306,7 +306,7 @@ export class FireHitEffect extends OnAttackEffect {
   }
 
   apply(pokemon, target, board) {
-    pokemon.addAttack(this.synergyLevel, pokemon, 0, false)
+    pokemon.applyStat(Stat.ATK, this.synergyLevel)
     this.count += 1
   }
 }
@@ -336,9 +336,9 @@ export class SoundCryEffect extends OnAbilityCastEffect {
     board.cells.forEach((ally) => {
       if (ally?.team === pokemon.team) {
         ally.status.sleep = false
-        ally.addAttack(attackBoost * scale, pokemon, 0, false)
-        ally.addSpeed(speedBoost * scale, pokemon, 0, false)
-        ally.addPP(manaBoost * scale, pokemon, 0, false)
+        ally.applyStat(Stat.ATK, attackBoost * scale)
+        ally.applyStat(Stat.SPEED, speedBoost * scale)
+        ally.applyStat(Stat.PP, manaBoost * scale)
         ally.count.soundCryCount += scale
       }
     })
@@ -349,7 +349,7 @@ export class WaterSpringEffect extends OnAbilityCastEffect {
   apply(pokemon) {
     pokemon.simulation.board.forEach((x, y, pkm) => {
       if (pkm?.passive === Passive.WATER_SPRING && pkm.team !== pokemon.team) {
-        pkm.addPP(5, pkm, 0, false)
+        pkm.applyStat(Stat.PP, 5)
         pkm.transferAbility(pkm.skill)
       }
     })

--- a/app/core/items.ts
+++ b/app/core/items.ts
@@ -126,10 +126,10 @@ export const ItemStats: { [item in Item]?: { [stat in Stat]?: number } } = {
 export const ItemEffects: { [i in Item]?: Effect[] } = {
   [Item.RUSTED_SWORD]: [
     new OnItemGainedEffect((pokemon) => {
-      pokemon.addAttack(pokemon.baseAtk * 0.5, pokemon, 0, false)
+      pokemon.applyStat(Stat.ATK, pokemon.baseAtk * 0.5)
     }),
     new OnItemRemovedEffect((pokemon) => {
-      pokemon.addAttack(-pokemon.baseAtk * 0.5, pokemon, 0, false)
+      pokemon.applyStat(Stat.ATK, -pokemon.baseAtk * 0.5)
     })
   ],
   [Item.SOUL_DEW]: [
@@ -139,7 +139,7 @@ export const ItemEffects: { [i in Item]?: Effect[] } = {
     new OnItemRemovedEffect((pokemon) => {
       for (const effect of pokemon.effectsSet) {
         if (effect instanceof SoulDewEffect) {
-          pokemon.addAbilityPower(-10 * effect.count, pokemon, 0, false)
+          pokemon.applyStat(Stat.AP, -10 * effect.count)
           pokemon.effectsSet.delete(effect)
           pokemon.count.soulDewCount = 0
           break
@@ -177,7 +177,7 @@ export const ItemEffects: { [i in Item]?: Effect[] } = {
 
   [Item.FLAME_ORB]: [
     new OnItemGainedEffect((pokemon) => {
-      pokemon.addAttack(pokemon.baseAtk, pokemon, 0, false)
+      pokemon.applyStat(Stat.ATK, pokemon.baseAtk)
       pokemon.status.triggerBurn(
         60000,
         pokemon as PokemonEntity,
@@ -185,14 +185,14 @@ export const ItemEffects: { [i in Item]?: Effect[] } = {
       )
     }),
     new OnItemRemovedEffect((pokemon) => {
-      pokemon.addAttack(-pokemon.baseAtk, pokemon, 0, false)
+      pokemon.applyStat(Stat.ATK, -pokemon.baseAtk)
       pokemon.status.burnCooldown = 0
     })
   ],
 
   [Item.TOXIC_ORB]: [
     new OnItemGainedEffect((pokemon) => {
-      pokemon.addAttack(pokemon.baseAtk, pokemon, 0, false)
+      pokemon.applyStat(Stat.ATK, pokemon.baseAtk)
       pokemon.status.triggerPoison(
         60000,
         pokemon as PokemonEntity,
@@ -200,7 +200,7 @@ export const ItemEffects: { [i in Item]?: Effect[] } = {
       )
     }),
     new OnItemRemovedEffect((pokemon) => {
-      pokemon.addAttack(-pokemon.baseAtk, pokemon, 0, false)
+      pokemon.applyStat(Stat.ATK, -pokemon.baseAtk)
       pokemon.status.poisonCooldown = 0
     })
   ],
@@ -232,21 +232,21 @@ export const ItemEffects: { [i in Item]?: Effect[] } = {
 
   [Item.DYNAMAX_BAND]: [
     new OnItemGainedEffect((pokemon) => {
-      pokemon.addMaxHP(2 * pokemon.baseHP, pokemon, 0, false)
+      pokemon.applyStat(Stat.HP, 2 * pokemon.baseHP)
     }),
     new OnItemRemovedEffect((pokemon) => {
-      pokemon.addMaxHP(-2 * pokemon.baseHP, pokemon, 0, false)
+      pokemon.applyStat(Stat.HP, -2 * pokemon.baseHP)
     })
   ],
 
   [Item.GOLD_BOTTLE_CAP]: [
     new OnItemGainedEffect((pokemon) => {
-      pokemon.addCritChance(pokemon.player?.money ?? 0, pokemon, 0, false)
-      pokemon.addCritPower(pokemon.player?.money ?? 0, pokemon, 0, false)
+      pokemon.applyStat(Stat.CRIT_CHANCE, pokemon.player?.money ?? 0)
+      pokemon.applyStat(Stat.CRIT_POWER, pokemon.player?.money ?? 0)
     }),
     new OnItemRemovedEffect((pokemon) => {
-      pokemon.addCritChance(-(pokemon.player?.money ?? 0), pokemon, 0, false)
-      pokemon.addCritPower(-(pokemon.player?.money ?? 0), pokemon, 0, false)
+      pokemon.applyStat(Stat.CRIT_CHANCE, -(pokemon.player?.money ?? 0))
+      pokemon.applyStat(Stat.CRIT_POWER, -(pokemon.player?.money ?? 0))
     }),
     new OnKillEffect((pokemon, target, board) => {
       if (pokemon.player) {
@@ -276,18 +276,16 @@ export const ItemEffects: { [i in Item]?: Effect[] } = {
         0,
         false
       )
-      pokemon.addSpeed(
+      pokemon.applyStat(
+        Stat.SPEED, 
         Math.floor(
           ((pokemon.player?.rerollCount ?? 0) + pokemon.simulation.stageLevel) /
             2
-        ),
-        pokemon,
-        0,
-        false
+        )
       )
     }),
     new OnItemRemovedEffect((pokemon) => {
-      pokemon.addAbilityPower(
+      pokemon.applyStat(Stat.AP, 
         -Math.floor(
           ((pokemon.player?.rerollCount ?? 0) + pokemon.simulation.stageLevel) /
             2
@@ -310,7 +308,7 @@ export const ItemEffects: { [i in Item]?: Effect[] } = {
 
   [Item.UPGRADE]: [
     new OnItemRemovedEffect((pokemon) => {
-      pokemon.addSpeed(-5 * pokemon.count.upgradeCount, pokemon, 0, false)
+      pokemon.applyStat(Stat.SPEED, -5 * pokemon.count.upgradeCount)
       pokemon.count.upgradeCount = 0
     })
   ],
@@ -318,9 +316,9 @@ export const ItemEffects: { [i in Item]?: Effect[] } = {
   [Item.DEFENSIVE_RIBBON]: [
     new OnItemRemovedEffect((pokemon) => {
       const stacks = Math.floor(pokemon.count.defensiveRibbonCount / 2)
-      pokemon.addAttack(-stacks, pokemon, 0, false)
-      pokemon.addDefense(-2 * stacks, pokemon, 0, false)
-      pokemon.addSpeed(-5 * stacks, pokemon, 0, false)
+      pokemon.applyStat(Stat.ATK, -stacks)
+      pokemon.applyStat(Stat.DEF, -2 * stacks)
+      pokemon.applyStat(Stat.SPEED, -5 * stacks)
       pokemon.count.defensiveRibbonCount = 0
     })
   ],
@@ -338,27 +336,27 @@ export const ItemEffects: { [i in Item]?: Effect[] } = {
   [Item.COMFEY]: [
     new OnItemGainedEffect((pokemon) => {
       const comfey = PokemonFactory.createPokemonFromName(Pkm.COMFEY)
-      pokemon.addAbilityPower(comfey.ap, pokemon, 0, false)
-      pokemon.addAttack(comfey.atk, pokemon, 0, false)
-      pokemon.addSpeed(comfey.speed - DEFAULT_SPEED, pokemon, 0, false)
-      pokemon.addMaxHP(comfey.hp, pokemon, 0, false)
-      pokemon.addDefense(comfey.def, pokemon, 0, false)
-      pokemon.addSpecialDefense(comfey.speDef, pokemon, 0, false)
+      pokemon.applyStat(Stat.AP, comfey.ap)
+      pokemon.applyStat(Stat.ATK, comfey.atk)
+      pokemon.applyStat(Stat.SPEED, comfey.speed - DEFAULT_SPEED)
+      pokemon.applyStat(Stat.HP, comfey.hp)
+      pokemon.applyStat(Stat.DEF, comfey.def)
+      pokemon.applyStat(Stat.SPE_DEF, comfey.speDef)
     }),
     new OnItemRemovedEffect((pokemon) => {
       const comfey = PokemonFactory.createPokemonFromName(Pkm.COMFEY)
-      pokemon.addAbilityPower(-comfey.ap, pokemon, 0, false)
-      pokemon.addAttack(-comfey.atk, pokemon, 0, false)
-      pokemon.addSpeed(-(comfey.speed - DEFAULT_SPEED), pokemon, 0, false)
-      pokemon.addMaxHP(-comfey.hp, pokemon, 0, false)
-      pokemon.addDefense(-comfey.def, pokemon, 0, false)
-      pokemon.addSpecialDefense(-comfey.speDef, pokemon, 0, false)
+      pokemon.applyStat(Stat.AP, -comfey.ap)
+      pokemon.applyStat(Stat.ATK, -comfey.atk)
+      pokemon.applyStat(Stat.SPEED, -(comfey.speed - DEFAULT_SPEED))
+      pokemon.applyStat(Stat.HP, -comfey.hp)
+      pokemon.applyStat(Stat.DEF, -comfey.def)
+      pokemon.applyStat(Stat.SPE_DEF, -comfey.speDef)
     })
   ],
 
   [Item.MAGMARIZER]: [
     new OnItemRemovedEffect((pokemon) => {
-      pokemon.addAttack(-pokemon.count.magmarizerCount, pokemon, 0, false)
+      pokemon.applyStat(Stat.ATK, -pokemon.count.magmarizerCount)
       pokemon.count.magmarizerCount = 0
     })
   ],
@@ -377,7 +375,7 @@ export class SoulDewEffect extends PeriodicEffect {
   constructor() {
     super(
       (pokemon) => {
-        pokemon.addAbilityPower(10, pokemon, 0, false)
+        pokemon.applyStat(Stat.AP, 10)
         pokemon.count.soulDewCount++
       },
       Item.SOUL_DEW,

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -121,6 +121,9 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   baseSpeDef: number
   baseRange: number
   baseHP: number
+  baseAP: number
+  baseSpeed: number
+  baseLuck: number
   dodge: number
   physicalDamage: number
   specialDamage: number
@@ -170,6 +173,10 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     this.baseSpeDef = pokemon.speDef
     this.baseRange = pokemon.range
     this.baseHP = pokemon.hp
+    this.baseAP = pokemon.baseAP
+    this.baseSpeed = pokemon.baseSpeed
+    this.baseHP = pokemon.baseHP
+    this.baseLuck = pokemon.baseLuck
     this.atk = pokemon.atk
     this.def = pokemon.def
     this.speDef = pokemon.speDef
@@ -187,7 +194,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     this.shiny = pokemon.shiny
     this.emotion = pokemon.emotion
     this.ap = pokemon.ap
-    this.luck = pokemon.permanentLuck
+    this.luck = pokemon.baseLuck
     this.dodge = 0
     this.physicalDamage = 0
     this.specialDamage = 0

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -503,7 +503,7 @@ export default abstract class PokemonState {
       // logger.debug(`${pokemon.name} took ${damage} and has now ${pokemon.life} life shield ${pokemon.shield}`);
 
       if (shouldTargetGainMana) {
-        pokemon.addPP(Math.ceil(residualDamage / 10), pokemon, 0, false)
+        pokemon.applyStat(Stat.PP, Math.ceil(residualDamage / 10))
       }
 
       if (takenDamage > 0) {
@@ -554,7 +554,7 @@ export default abstract class PokemonState {
               ? 0.6
               : 0.3
           pokemon.life = pokemon.hp * healBonus
-          pokemon.addAttack(pokemon.baseAtk * attackBonus, pokemon, 0, false)
+          pokemon.applyStat(Stat.ATK, pokemon.baseAtk * attackBonus)
           SynergyEffects[Synergy.FOSSIL].forEach((e) =>
             pokemon.effects.delete(e)
           )
@@ -576,7 +576,7 @@ export default abstract class PokemonState {
         }
 
         if (pokemon.passive === Passive.PRIMEAPE) {
-          pokemon.applyStat(Stat.ATK, 1, true)
+          pokemon.applyStat(Stat.ATK, 1, pokemon, 0, false, true)
         }
       }
 
@@ -698,7 +698,7 @@ export default abstract class PokemonState {
         const nbSmoothRocks = player ? count(player.items, Item.SMOOTH_ROCK) : 0
         if (nbSmoothRocks > 0) {
           sandstormDamage -= nbSmoothRocks
-          pokemon.addSpeed(nbSmoothRocks, pokemon, 0, false)
+          pokemon.applyStat(Stat.SPEED, nbSmoothRocks)
         }
         if (pokemon.types.has(Synergy.GROUND) === false) {
           pokemon.handleDamage({
@@ -741,30 +741,30 @@ export default abstract class PokemonState {
   }
 
   updateEachSecond(pokemon: PokemonEntity, board: Board) {
-    pokemon.addPP(10, pokemon, 0, false)
+    pokemon.applyStat(Stat.PP, 10)
     if (pokemon.effects.has(Effect.RAIN_DANCE)) {
-      pokemon.addPP(4, pokemon, 0, false)
+      pokemon.applyStat(Stat.PP, 4)
     }
     if (pokemon.effects.has(Effect.DRIZZLE)) {
-      pokemon.addPP(8, pokemon, 0, false)
+      pokemon.applyStat(Stat.PP, 8)
     }
     if (pokemon.effects.has(Effect.PRIMORDIAL_SEA)) {
-      pokemon.addPP(12, pokemon, 0, false)
+      pokemon.applyStat(Stat.PP, 12)
     }
     if (pokemon.simulation.weather === Weather.RAIN) {
-      pokemon.addPP(3, pokemon, 0, false)
+      pokemon.applyStat(Stat.PP, 3)
       const nbDampRocks = pokemon.player
         ? count(pokemon.player.items, Item.DAMP_ROCK)
         : 0
       if (nbDampRocks > 0) {
-        pokemon.addPP(2 * nbDampRocks, pokemon, 0, false)
+        pokemon.applyStat(Stat.PP, 2 * nbDampRocks)
       }
     }
 
     if (pokemon.passive === Passive.ILLUMISE_VOLBEAT) {
       board.forEach((x, y, p) => {
         if (p && p.passive === Passive.ILLUMISE_VOLBEAT && p !== pokemon) {
-          pokemon.addPP(5, pokemon, 0, false)
+          pokemon.applyStat(Stat.PP, 5)
         }
       })
     }
@@ -774,11 +774,11 @@ export default abstract class PokemonState {
       pokemon.effects.has(Effect.ETERNAL_LIGHT) ||
       pokemon.effects.has(Effect.MAX_ILLUMINATION)
     ) {
-      pokemon.addPP(8, pokemon, 0, false)
+      pokemon.applyStat(Stat.PP, 8)
     }
 
     if (pokemon.items.has(Item.METRONOME)) {
-      pokemon.addPP(5, pokemon, 0, false)
+      pokemon.applyStat(Stat.PP, 5)
     }
 
     if (pokemon.items.has(Item.GREEN_ORB)) {
@@ -867,9 +867,9 @@ export default abstract class PokemonState {
         pokemon.pp = 0
         pokemon.status.tree = false
         pokemon.toMovingState()
-        pokemon.addAttack(10, pokemon, 0, false)
-        pokemon.addDefense(-5, pokemon, 0, false)
-        pokemon.addSpecialDefense(-5, pokemon, 0, false)
+        pokemon.applyStat(Stat.ATK, 10)
+        pokemon.applyStat(Stat.DEF, -5)
+        pokemon.applyStat(Stat.SPE_DEF, -5)
       }
     }
   }

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -448,7 +448,7 @@ export default class Simulation extends Schema implements ISimulation {
     dishEffects.forEach((effect) => pokemon.effectsSet.add(effect))
 
     if (pokemon.passive === Passive.GLUTTON) {
-      pokemon.addMaxHP(20, pokemon, 0, false, true)
+      pokemon.applyStat(Stat.HP, 20, pokemon, 0, false, true)
       if (pokemon.player && pokemon.hp > 750) {
         pokemon.player.titles.add(Title.GLUTTON)
       }
@@ -529,15 +529,10 @@ export default class Simulation extends Schema implements ISimulation {
               (p) => p.refToBoardPokemon.id === pokemonCloned.id
             )
             if (clonedEntity) {
-              clonedEntity.addMaxHP(
-                -0.5 * pokemonCloned.hp,
-                clonedEntity,
-                0,
-                false
-              )
+              clonedEntity.applyStat(Stat.HP, -0.5 * pokemonCloned.hp)
             }
 
-            cloneEntity.addMaxHP(-0.5 * bug.hp, cloneEntity, 0, false)
+            cloneEntity.applyStat(Stat.HP, -0.5 * bug.hp)
           }
         }
       }
@@ -636,8 +631,8 @@ export default class Simulation extends Schema implements ISimulation {
           pokemon.addShield(dragonLevel * 5, pokemon, 0, false)
         }
         if (pokemon.effects.has(Effect.DRAGON_DANCE)) {
-          pokemon.addAbilityPower(dragonLevel, pokemon, 0, false)
-          pokemon.addSpeed(dragonLevel, pokemon, 0, false)
+          pokemon.applyStat(Stat.AP, dragonLevel)
+          pokemon.applyStat(Stat.SPEED, dragonLevel)
         }
         let shieldBonus = 0
         if (pokemon.effects.has(Effect.STAMINA)) {
@@ -691,7 +686,7 @@ export default class Simulation extends Schema implements ISimulation {
               pokemon.positionY
             )
             if (value) {
-              value.addSpeed(20, pokemon, 0, false)
+              value.applyStat(Stat.SPEED, 20)
             }
           })
         }
@@ -841,24 +836,24 @@ export default class Simulation extends Schema implements ISimulation {
     switch (effect) {
       case Effect.HONE_CLAWS:
         if (types.has(Synergy.DARK)) {
-          pokemon.addCritChance(30, pokemon, 0, false)
-          pokemon.addCritPower(30, pokemon, 0, false)
+          pokemon.applyStat(Stat.CRIT_CHANCE, 30)
+          pokemon.applyStat(Stat.CRIT_POWER, 30)
           pokemon.effects.add(Effect.HONE_CLAWS)
         }
         break
 
       case Effect.ASSURANCE:
         if (types.has(Synergy.DARK)) {
-          pokemon.addCritChance(40, pokemon, 0, false)
-          pokemon.addCritPower(60, pokemon, 0, false)
+          pokemon.applyStat(Stat.CRIT_CHANCE, 40)
+          pokemon.applyStat(Stat.CRIT_POWER, 60)
           pokemon.effects.add(Effect.ASSURANCE)
         }
         break
 
       case Effect.BEAT_UP:
         if (types.has(Synergy.DARK)) {
-          pokemon.addCritChance(50, pokemon, 0, false)
-          pokemon.addCritPower(100, pokemon, 0, false)
+          pokemon.applyStat(Stat.CRIT_CHANCE, 50)
+          pokemon.applyStat(Stat.CRIT_POWER, 100)
           pokemon.effects.add(Effect.BEAT_UP)
         }
         break
@@ -988,21 +983,21 @@ export default class Simulation extends Schema implements ISimulation {
       case Effect.AMNESIA:
         if (types.has(Synergy.PSYCHIC)) {
           pokemon.effects.add(Effect.AMNESIA)
-          pokemon.addAbilityPower(50, pokemon, 0, false)
+          pokemon.applyStat(Stat.AP, 50)
         }
         break
 
       case Effect.LIGHT_SCREEN:
         if (types.has(Synergy.PSYCHIC)) {
           pokemon.effects.add(Effect.LIGHT_SCREEN)
-          pokemon.addAbilityPower(100, pokemon, 0, false)
+          pokemon.applyStat(Stat.AP, 100)
         }
         break
 
       case Effect.EERIE_SPELL:
         if (types.has(Synergy.PSYCHIC)) {
           pokemon.effects.add(Effect.EERIE_SPELL)
-          pokemon.addAbilityPower(150, pokemon, 0, false)
+          pokemon.applyStat(Stat.AP, 150)
         }
         break
 
@@ -1060,21 +1055,21 @@ export default class Simulation extends Schema implements ISimulation {
 
       case Effect.BATTLE_ARMOR:
         if (types.has(Synergy.ROCK)) {
-          pokemon.addDefense(10, pokemon, 0, false)
+          pokemon.applyStat(Stat.DEF, 10)
           pokemon.effects.add(Effect.BATTLE_ARMOR)
         }
         break
 
       case Effect.MOUTAIN_RESISTANCE:
         if (types.has(Synergy.ROCK)) {
-          pokemon.addDefense(30, pokemon, 0, false)
+          pokemon.applyStat(Stat.DEF, 30)
           pokemon.effects.add(Effect.MOUTAIN_RESISTANCE)
         }
         break
 
       case Effect.DIAMOND_STORM:
         if (types.has(Synergy.ROCK)) {
-          pokemon.addDefense(60, pokemon, 0, false)
+          pokemon.applyStat(Stat.DEF, 60)
           pokemon.effects.add(Effect.DIAMOND_STORM)
         }
         break
@@ -1098,22 +1093,22 @@ export default class Simulation extends Schema implements ISimulation {
 
       case Effect.CHILLY:
         pokemon.effects.add(Effect.CHILLY)
-        pokemon.addSpecialDefense(4, pokemon, 0, false)
+        pokemon.applyStat(Stat.SPE_DEF, 4)
         break
 
       case Effect.FROSTY:
         pokemon.effects.add(Effect.FROSTY)
-        pokemon.addSpecialDefense(12, pokemon, 0, false)
+        pokemon.applyStat(Stat.SPE_DEF, 12)
         break
 
       case Effect.FREEZING:
         pokemon.effects.add(Effect.FREEZING)
-        pokemon.addSpecialDefense(40, pokemon, 0, false)
+        pokemon.applyStat(Stat.SPE_DEF, 40)
         break
 
       case Effect.SHEER_COLD:
         pokemon.effects.add(Effect.SHEER_COLD)
-        pokemon.addSpecialDefense(60, pokemon, 0, false)
+        pokemon.applyStat(Stat.SPE_DEF, 60)
         break
 
       case Effect.POISONOUS:
@@ -1174,8 +1169,8 @@ export default class Simulation extends Schema implements ISimulation {
             [Effect.LINK_CABLE]: (6 / 100) * pokemon.hp,
             [Effect.GOOGLE_SPECS]: (12 / 100) * pokemon.hp
           }[effect]
-          pokemon.addAttack(attackBoost * nbItems, pokemon, 0, false)
-          pokemon.addAbilityPower(apBoost * nbItems, pokemon, 0, false)
+          pokemon.applyStat(Stat.ATK, attackBoost * nbItems)
+          pokemon.applyStat(Stat.AP, apBoost * nbItems)
           pokemon.addShield(shieldBoost * nbItems, pokemon, 0, false)
           pokemon.effects.add(effect)
         }
@@ -1213,8 +1208,8 @@ export default class Simulation extends Schema implements ISimulation {
         if (pokemon.inSpotlight) {
           pokemon.status.light = true
           pokemon.effects.add(Effect.SHINING_RAY)
-          pokemon.addAttack(Math.ceil(pokemon.atk * 0.2), pokemon, 0, false)
-          pokemon.addAbilityPower(20, pokemon, 0, false)
+          pokemon.applyStat(Stat.ATK, Math.ceil(pokemon.atk * 0.2))
+          pokemon.applyStat(Stat.AP, 20)
         }
         break
 
@@ -1222,8 +1217,8 @@ export default class Simulation extends Schema implements ISimulation {
         if (pokemon.inSpotlight) {
           pokemon.status.light = true
           pokemon.effects.add(Effect.LIGHT_PULSE)
-          pokemon.addAttack(Math.ceil(pokemon.atk * 0.2), pokemon, 0, false)
-          pokemon.addAbilityPower(20, pokemon, 0, false)
+          pokemon.applyStat(Stat.ATK, Math.ceil(pokemon.atk * 0.2))
+          pokemon.applyStat(Stat.AP, 20)
         }
         break
 
@@ -1231,11 +1226,11 @@ export default class Simulation extends Schema implements ISimulation {
         if (pokemon.inSpotlight) {
           pokemon.status.light = true
           pokemon.effects.add(Effect.ETERNAL_LIGHT)
-          pokemon.addAttack(Math.ceil(pokemon.atk * 0.2), pokemon, 0, false)
-          pokemon.addAbilityPower(20, pokemon, 0, false)
+          pokemon.applyStat(Stat.ATK, Math.ceil(pokemon.atk * 0.2))
+          pokemon.applyStat(Stat.AP, 20)
           pokemon.status.triggerRuneProtect(8000)
-          pokemon.addDefense(0.5 * pokemon.baseDef, pokemon, 0, false)
-          pokemon.addSpecialDefense(0.5 * pokemon.baseSpeDef, pokemon, 0, false)
+          pokemon.applyStat(Stat.DEF, 0.5 * pokemon.baseDef)
+          pokemon.applyStat(Stat.SPE_DEF, 0.5 * pokemon.baseSpeDef)
         }
         break
 
@@ -1243,11 +1238,11 @@ export default class Simulation extends Schema implements ISimulation {
         if (pokemon.inSpotlight) {
           pokemon.status.light = true
           pokemon.effects.add(Effect.MAX_ILLUMINATION)
-          pokemon.addAttack(Math.ceil(pokemon.atk * 0.2), pokemon, 0, false)
-          pokemon.addAbilityPower(20, pokemon, 0, false)
+          pokemon.applyStat(Stat.ATK, Math.ceil(pokemon.atk * 0.2))
+          pokemon.applyStat(Stat.AP, 20)
           pokemon.status.triggerRuneProtect(8000)
-          pokemon.addDefense(0.5 * pokemon.baseDef, pokemon, 0, false)
-          pokemon.addSpecialDefense(0.5 * pokemon.baseSpeDef, pokemon, 0, false)
+          pokemon.applyStat(Stat.DEF, 0.5 * pokemon.baseDef)
+          pokemon.applyStat(Stat.SPE_DEF, 0.5 * pokemon.baseSpeDef)
           pokemon.addShield(100, pokemon, 0, false)
           pokemon.status.addResurrection(pokemon)
         }
@@ -1256,52 +1251,52 @@ export default class Simulation extends Schema implements ISimulation {
       case Effect.QUICK_FEET:
         if (types.has(Synergy.WILD)) {
           pokemon.effects.add(Effect.QUICK_FEET)
-          pokemon.addSpeed(30, pokemon, 0, false)
+          pokemon.applyStat(Stat.SPEED, 30)
         }
         break
 
       case Effect.RUN_AWAY:
         if (types.has(Synergy.WILD)) {
           pokemon.effects.add(Effect.RUN_AWAY)
-          pokemon.addSpeed(50, pokemon, 0, false)
+          pokemon.applyStat(Stat.SPEED, 50)
         }
         break
 
       case Effect.HUSTLE:
         if (types.has(Synergy.WILD)) {
           pokemon.effects.add(Effect.HUSTLE)
-          pokemon.addAttack(Math.ceil(0.2 * pokemon.baseAtk), pokemon, 0, false)
-          pokemon.addSpeed(50, pokemon, 0, false)
+          pokemon.applyStat(Stat.ATK, Math.ceil(0.2 * pokemon.baseAtk))
+          pokemon.applyStat(Stat.SPEED, 50)
         }
         break
 
       case Effect.BERSERK:
         if (types.has(Synergy.WILD)) {
           pokemon.effects.add(Effect.BERSERK)
-          pokemon.addAttack(Math.ceil(0.4 * pokemon.baseAtk), pokemon, 0, false)
-          pokemon.addSpeed(50, pokemon, 0, false)
+          pokemon.applyStat(Stat.ATK, Math.ceil(0.4 * pokemon.baseAtk))
+          pokemon.applyStat(Stat.SPEED, 50)
           pokemon.status.enrageDelay -= 5000
         }
         break
 
       case Effect.FLUID: {
         pokemon.effects.add(Effect.FLUID)
-        pokemon.addSpeed(1 * activeSynergies, pokemon, 0, false)
-        pokemon.addMaxHP(3 * activeSynergies, pokemon, 0, false)
+        pokemon.applyStat(Stat.SPEED, 1 * activeSynergies)
+        pokemon.applyStat(Stat.HP, 3 * activeSynergies)
         break
       }
 
       case Effect.SHAPELESS: {
         pokemon.effects.add(Effect.SHAPELESS)
-        pokemon.addSpeed(3 * activeSynergies, pokemon, 0, false)
-        pokemon.addMaxHP(6 * activeSynergies, pokemon, 0, false)
+        pokemon.applyStat(Stat.SPEED, 3 * activeSynergies)
+        pokemon.applyStat(Stat.HP, 6 * activeSynergies)
         break
       }
 
       case Effect.ETHEREAL: {
         pokemon.effects.add(Effect.ETHEREAL)
-        pokemon.addSpeed(6 * activeSynergies, pokemon, 0, false)
-        pokemon.addMaxHP(12 * activeSynergies, pokemon, 0, false)
+        pokemon.applyStat(Stat.SPEED, 6 * activeSynergies)
+        pokemon.applyStat(Stat.HP, 12 * activeSynergies)
         break
       }
 
@@ -1322,13 +1317,13 @@ export default class Simulation extends Schema implements ISimulation {
 
       case Effect.GOOD_LUCK: {
         pokemon.effects.add(effect)
-        pokemon.addLuck(20, pokemon, 0, false)
+        pokemon.applyStat(Stat.LUCK, 20)
         break
       }
 
       case Effect.BAD_LUCK: {
         pokemon.effects.add(effect)
-        pokemon.addLuck(-20, pokemon, 0, false)
+        pokemon.applyStat(Stat.LUCK, -20)
         break
       }
 
@@ -1340,7 +1335,7 @@ export default class Simulation extends Schema implements ISimulation {
       case Effect.WINDY: {
         const player = pokemon.player
         const nbFloatStones = player ? count(player.items, Item.FLOAT_STONE) : 0
-        pokemon.addSpeed(
+        pokemon.applyStat(Stat.SPEED, 
           (pokemon.types.has(Synergy.FLYING) ? 20 : 10) + nbFloatStones * 5,
           pokemon,
           0,
@@ -1350,7 +1345,7 @@ export default class Simulation extends Schema implements ISimulation {
       }
 
       case Effect.SNOW:
-        pokemon.addSpeed(-20, pokemon, 0, false)
+        pokemon.applyStat(Stat.SPEED, -20)
         break
 
       case Effect.SMOG: {
@@ -1369,7 +1364,7 @@ export default class Simulation extends Schema implements ISimulation {
           ? count(player.items, Item.BLACK_AUGURITE)
           : 0
 
-        pokemon.addCritChance(10 + 5 * nbBlackAugurite, pokemon, 0, false)
+        pokemon.applyStat(Stat.CRIT_CHANCE, 10 + 5 * nbBlackAugurite)
         break
       }
 
@@ -1377,7 +1372,7 @@ export default class Simulation extends Schema implements ISimulation {
         const player = pokemon.player
         const nbMistStones = player ? count(player.items, Item.MIST_STONE) : 0
         if (nbMistStones > 0) {
-          pokemon.addSpecialDefense(3 * nbMistStones, pokemon, 0, false)
+          pokemon.applyStat(Stat.SPE_DEF, 3 * nbMistStones)
         }
         break
       }
@@ -1646,8 +1641,8 @@ export default class Simulation extends Schema implements ISimulation {
         opponentsCursable.filter((p) => p.def + p.speDef === highestDef)
       )
       if (enemyWithHighestDef) {
-        enemyWithHighestDef.addDefense(-5, enemyWithHighestDef, 0, false)
-        enemyWithHighestDef.addSpecialDefense(-5, enemyWithHighestDef, 0, false)
+        enemyWithHighestDef.applyStat(Stat.DEF, -5, enemyWithHighestDef, 0, false)
+        enemyWithHighestDef.applyStat(Stat.SPE_DEF, -5, enemyWithHighestDef, 0, false)
         enemyWithHighestDef.status.curseVulnerability = true
         enemyWithHighestDef.status.triggerFlinch(
           30000,
@@ -1663,7 +1658,7 @@ export default class Simulation extends Schema implements ISimulation {
         opponentsCursable.filter((p) => p.atk === highestAtk)
       )
       if (enemyWithHighestAtk) {
-        enemyWithHighestAtk.addAttack(
+        enemyWithHighestAtk.applyStat(Stat.ATK, 
           Math.round(-0.3 * enemyWithHighestAtk.atk),
           enemyWithHighestAtk,
           0,
@@ -1684,7 +1679,7 @@ export default class Simulation extends Schema implements ISimulation {
         opponentsCursable.filter((p) => p.ap === highestAP)
       )
       if (enemyWithHighestAP) {
-        enemyWithHighestAP.addAbilityPower(-50, enemyWithHighestAP, 0, false)
+        enemyWithHighestAP.applyStat(Stat.AP, -50, enemyWithHighestAP, 0, false)
         enemyWithHighestAP.status.curseTorment = true
         enemyWithHighestAP.status.triggerFatigue(30000, enemyWithHighestAP)
       }

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -196,6 +196,12 @@ export class Pokemon extends Schema implements IPokemon {
     context: Pokemon | IPokemonEntity = this,
     base = false
   ) {
+    // temporary implementation to handle permanent stat applications
+    if (base) {
+      this.applyStat(stat, value)
+      return
+    }
+
     switch (stat) {
       case Stat.ATK:
         this.addAttack(value, context, base)
@@ -218,11 +224,6 @@ export class Pokemon extends Schema implements IPokemon {
       case Stat.LUCK:
         this.addLuck(value, context, base)
         break
-    }
-
-    if (base && context == this) {
-      // recalculate items
-      // recalculate synergy stats
     }
   }
 

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -103,7 +103,13 @@ export class Pokemon extends Schema implements IPokemon {
   @type("boolean") shiny: boolean
   @type("string") emotion: Emotion
   @type("string") action: PokemonActionState = PokemonActionState.IDLE
-  permanentLuck: number = 0
+  baseAtk: number
+  baseDef: number
+  baseSpeDef: number
+  baseAP: number
+  baseSpeed: number
+  baseHP: number
+  baseLuck: number
   deathCount: number = 0
   evolutions: Pkm[] = []
   evolutionRule: EvolutionRule = new CountEvolutionRule(3)
@@ -125,6 +131,13 @@ export class Pokemon extends Schema implements IPokemon {
     this.index = PkmIndex[name]
     this.shiny = shiny
     this.emotion = emotion
+    this.baseAtk = this.atk
+    this.baseDef = this.def
+    this.baseSpeDef = this.speDef
+    this.baseAP = this.ap
+    this.baseSpeed = this.speed
+    this.baseHP = this.hp
+    this.baseLuck = this.luck
   }
 
   get final(): boolean {
@@ -166,7 +179,7 @@ export class Pokemon extends Schema implements IPokemon {
   }
 
   get luck(): number {
-    let luck = this.permanentLuck
+    let luck = this.baseLuck
     this.items.forEach((item) => {
       luck += ItemStats[item]?.[Stat.LUCK] ?? 0
     })
@@ -174,7 +187,7 @@ export class Pokemon extends Schema implements IPokemon {
   }
 
   set luck(value: number) {
-    this.permanentLuck = value
+    this.baseLuck = value
   }
 
   applyStat(
@@ -218,7 +231,7 @@ export class Pokemon extends Schema implements IPokemon {
     context: Pokemon | IPokemonEntity = this,
     base: boolean
   ) {
-    const property = base ? 'baseAtk' : 'atk'
+    const property: keyof Pokemon & keyof IPokemonEntity = base ? 'baseAtk' : 'atk'
     context[property] = min(1)(context[property] + value)
   }
 
@@ -227,7 +240,7 @@ export class Pokemon extends Schema implements IPokemon {
     context: Pokemon | IPokemonEntity = this,
     base: boolean
   ) {
-    const property = base ? 'baseDef' : 'def'
+    const property: keyof Pokemon & keyof IPokemonEntity = base ? 'baseDef' : 'def'
     context[property] = min(0)(context[property] + value)
   }
   
@@ -236,7 +249,7 @@ export class Pokemon extends Schema implements IPokemon {
     context: Pokemon | IPokemonEntity = this,
     base: boolean
   ) {
-    const property = base ? 'baseSpeDef' : 'speDef'
+    const property: keyof Pokemon & keyof IPokemonEntity = base ? 'baseSpeDef' : 'speDef'
     context[property] = min(0)(context[property] + value)
   }
 
@@ -245,7 +258,7 @@ export class Pokemon extends Schema implements IPokemon {
     context: Pokemon | IPokemonEntity = this,
     base: boolean
   ) {
-    const property = base ? 'baseAP' : 'ap'
+    const property: keyof Pokemon & keyof IPokemonEntity = base ? 'baseAP' : 'ap'
     context[property] = min(-100)(context[property] + value)
   }
   
@@ -254,7 +267,7 @@ export class Pokemon extends Schema implements IPokemon {
     context: Pokemon | IPokemonEntity = this,
     base: boolean
   ) {
-    const property = base ? 'baseSpeed' : 'speed'
+    const property: keyof Pokemon & keyof IPokemonEntity = base ? 'baseSpeed' : 'speed'
     context[property] = clamp(context[property] + value, 0, 300)
   }
   
@@ -263,7 +276,7 @@ export class Pokemon extends Schema implements IPokemon {
     context: Pokemon | IPokemonEntity = this,
     base: boolean
   ) {
-    const property = base ? 'baseHP' : 'hp'
+    const property: keyof Pokemon & keyof IPokemonEntity = base ? 'baseHP' : 'hp'
     context[property] = min(1)(context[property] + value)
   }
 
@@ -272,7 +285,7 @@ export class Pokemon extends Schema implements IPokemon {
     context: Pokemon | IPokemonEntity = this,
     base: boolean
   ) {
-    const property = base ? 'baseLuck' : 'luck'
+    const property: keyof Pokemon & keyof IPokemonEntity = base ? 'baseLuck' : 'luck'
     context[property] = min(-100)(context[property] + value)
   }
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -437,6 +437,12 @@ export interface IPokemon {
   canEat: boolean
   deathCount: number
   readonly hasEvolution: boolean
+  applyStat(
+    stat: Stat,
+    value: number,
+    context?: Pokemon | IPokemonEntity,
+    base?: boolean
+  ): void
 }
 
 export interface IExperienceManager {
@@ -494,20 +500,13 @@ export interface IPokemonEntity {
   simulation: ISimulation
   refToBoardPokemon: IPokemon
   get player(): IPlayer | undefined
-  applyStat(stat: Stat, value: number): void
-  addAbilityPower(
+  applyStat(
+    stat: Stat, 
     value: number,
-    caster: IPokemonEntity,
-    apBoost: number,
-    crit: boolean,
-    permanent?: boolean
-  ): void
-  addLuck(
-    value: number,
-    caster: IPokemonEntity,
-    apBoost: number,
-    crit: boolean,
-    permanent?: boolean
+    caster?: IPokemonEntity,
+    apBoost?: number,
+    crit?: boolean,
+    base?: boolean
   ): void
   addPP(
     value: number,
@@ -515,46 +514,11 @@ export interface IPokemonEntity {
     apBoost: number,
     crit: boolean
   ): void
-  addAttack(
-    value: number,
-    caster: IPokemonEntity,
-    apBoost: number,
-    crit: boolean,
-    permanent?: boolean
-  ): void
-  addSpeed(
-    value: number,
-    caster: IPokemonEntity,
-    apBoost: number,
-    crit: boolean,
-    permanent?: boolean
-  ): void
-  addMaxHP(
-    value: number,
-    caster: IPokemonEntity,
-    apBoost: number,
-    crit: boolean,
-    permanent?: boolean
-  ): void
   addShield(
     value: number,
     caster: IPokemonEntity,
     apBoost: number,
     crit: boolean
-  ): void
-  addDefense(
-    value: number,
-    caster: IPokemonEntity,
-    apBoost: number,
-    crit: boolean,
-    permanent?: boolean
-  ): void
-  addSpecialDefense(
-    value: number,
-    caster: IPokemonEntity,
-    apBoost: number,
-    crit: boolean,
-    permanent?: boolean
   ): void
   addCritChance(
     value: number,

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -419,7 +419,10 @@ export interface IPokemon {
   stars: number
   maxPP: number
   luck: number
-  permanentLuck: number
+  baseLuck: number
+  baseAP: number
+  baseSpeed: number
+  baseHP: number
   ap: number
   skill: Ability
   passive: Passive
@@ -568,6 +571,10 @@ export interface IPokemonEntity {
   baseAtk: number
   baseDef: number
   baseSpeDef: number
+  baseAP: number
+  baseSpeed: number
+  baseHP: number
+  baseLuck: number
   attackType: AttackType
   life: number
   shield: number


### PR DESCRIPTION
Refactor stat application methods (`PokemonEntity.add[stat]`) to route through `applyStat`.

This is needed to prevent logic duplication in my improvement project: allowing item and synergy stats to be calculated and displayed in the preparation phase. Has the added benefit of allowing individual stat application methods (see Melmetal).