### PR TITLE
use addMaxHP instead of handleSpecialDamage for fillet away

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -12179,17 +12179,9 @@ export class FilletAwayStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, state, board, target, crit)
     // lose 50% of max HP and gain 10 attack and 20 speed
-    const newMaxHP = Math.ceil(pokemon.hp * 0.5)
-    const lostLife = min(0)(pokemon.life - newMaxHP)
-    pokemon.hp = newMaxHP
-    pokemon.handleSpecialDamage(
-      lostLife,
-      board,
-      AttackType.TRUE,
-      pokemon,
-      false,
-      false
-    )
+    const lostMaxHP = Math.floor(pokemon.hp * 0.5)
+    pokemon.addMaxHP(-lostMaxHP, pokemon, 0, false)
+    
     pokemon.addAttack(10, pokemon, 1, crit)
     pokemon.addSpeed(20, pokemon, 1, crit)
     pokemon.status.triggerProtect(400)


### PR DESCRIPTION
The fillet away ability currently works by setting Max HP to half, and then calculating lost life (if any), and then hitting itself with handleSpecialDamage using true damage. This is intended to clamp the current life, but creates a number of bugs:

- if user is enraged, or has boosts from terrain/sheer cold, it will deal extra damage to itself beyond the intended clamp
- if user has shield, it will hit the shield first, resulting in more current life than max HP
- if user is protected, it will not lose current life at all

using addMaxHP with a negative value avoids these bugs while taking advantage of the already existing clamping feature built into addMaxHP 