### PR TITLE
Create DPS Status bars for dps meter

### DIFF
--- a/app/public/src/pages/component/game/game-dps-meter.css
+++ b/app/public/src/pages/component/game/game-dps-meter.css
@@ -94,3 +94,32 @@
   height: 2vw;
   width: 2vw;
 }
+
+.game-dps-meter-tab-list {
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+  margin-left: -54px;
+  margin-right: -8px;
+  margin-bottom: 0px;
+}
+
+.game-dps-meter-tab-list li {
+  background: none;
+  border: none;
+  padding: unset;
+  width: 100%;
+
+  height: 36px;
+  display: flex;
+  align-items: center;
+  border-radius: 0;
+}
+
+.game-dps-meter-tab-list li::after {
+  display: none;
+}
+
+.game-dps-meter-tab-list li[aria-selected="true"] {
+  background-color: var(--color-bg-secondary);
+}

--- a/app/public/src/pages/component/game/game-dps-meter.tsx
+++ b/app/public/src/pages/component/game/game-dps-meter.tsx
@@ -1,120 +1,169 @@
-import React from "react"
-import { useTranslation } from "react-i18next"
-import { Tab, TabList, TabPanel, Tabs } from "react-tabs"
-import { selectCurrentPlayer, useAppSelector } from "../../../hooks"
-import { usePreference, usePreferences } from "../../../preferences"
-import { getAvatarSrc } from "../../../../../utils/avatar"
-import GamePlayerDpsMeter from "./game-player-dps-meter"
-import GamePlayerDpsTakenMeter from "./game-player-dps-taken-meter"
-import GamePlayerHpsMeter from "./game-player-hps-meter"
-import { GamePhaseState, Team } from "../../../../../types/enum/Game"
-import { PVEStages } from "../../../../../models/pve-stages"
-import "./game-dps-meter.css"
-import { cc } from "../../utils/jsx"
-import PokemonPortrait from "../pokemon-portrait"
+import { useTranslation } from "react-i18next";
+import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
+import { PVEStages } from "../../../../../models/pve-stages";
+import { IDps, IPlayer } from "../../../../../types";
+import { GamePhaseState, Team } from "../../../../../types/enum/Game";
+import { selectCurrentPlayer, useAppSelector } from "../../../hooks";
+import { usePreference } from "../../../preferences";
+import PokemonPortrait from "../pokemon-portrait";
+import "./game-dps-meter.css";
+import { GameDpsStatus } from "./game-dps-status";
+import GamePlayerDpsMeter from "./game-player-dps-meter";
+import GamePlayerDpsTakenMeter from "./game-player-dps-taken-meter";
+import GamePlayerHpsMeter from "./game-player-hps-meter";
 
 export default function GameDpsMeter() {
-  const [{ antialiasing }] = usePreferences()
-  const { t } = useTranslation()
-  const currentPlayer = useAppSelector(selectCurrentPlayer)
-  const team = useAppSelector(
-    (state) => state.game.currentTeam
-  )
-  const stageLevel = useAppSelector((state) => state.game.stageLevel)
-  const phase = useAppSelector((state) => state.game.phase)
+  const currentPlayer = useAppSelector(selectCurrentPlayer);
+  const team = useAppSelector((state) => state.game.currentTeam);
+  const stageLevel = useAppSelector((state) => state.game.stageLevel);
+  const phase = useAppSelector((state) => state.game.phase);
 
-  const blueDpsMeter = useAppSelector((state) => state.game.blueDpsMeter)
-  const redDpsMeter = useAppSelector((state) => state.game.redDpsMeter)
-  const myDpsMeter = team === Team.BLUE_TEAM ? blueDpsMeter : redDpsMeter
-  const opponentDpsMeter = team === Team.BLUE_TEAM ? redDpsMeter : blueDpsMeter
+  const blueDpsMeter = useAppSelector((state) => state.game.blueDpsMeter);
+  const redDpsMeter = useAppSelector((state) => state.game.redDpsMeter);
+  const myDpsMeter = team === Team.BLUE_TEAM ? blueDpsMeter : redDpsMeter;
+  const opponentDpsMeter = team === Team.BLUE_TEAM ? redDpsMeter : blueDpsMeter;
 
-  const [isOpen, setOpen] = usePreference("showDpsMeter")
+  const [isOpen, setOpen] = usePreference("showDpsMeter");
 
-  if (!currentPlayer) return null
+  if (!currentPlayer) return null;
 
-  const isPVE = phase === GamePhaseState.FIGHT ? stageLevel in PVEStages : (stageLevel - 1) in PVEStages
+  return (
+    <GameDpsMeterBase
+      phase={phase}
+      stageLevel={stageLevel}
+      currentPlayer={currentPlayer}
+      myDpsMeter={myDpsMeter}
+      opponentDpsMeter={opponentDpsMeter}
+      isOpen={isOpen}
+      setOpen={setOpen}
+    />
+  );
+}
 
-  const name = currentPlayer.name
-  const avatar = currentPlayer.avatar
-  const opponentName = currentPlayer.opponentName
-  const opponentAvatar = currentPlayer.opponentAvatar
+export function GameDpsMeterBase({
+  phase,
+  stageLevel,
+  currentPlayer,
+  myDpsMeter,
+  opponentDpsMeter,
+  isOpen,
+  setOpen,
+}: {
+  phase: GamePhaseState;
+  stageLevel: number;
+  currentPlayer: Pick<
+    IPlayer,
+    "name" | "avatar" | "opponentName" | "opponentAvatar"
+  >;
+  myDpsMeter: IDps[];
+  opponentDpsMeter: IDps[];
+  isOpen: boolean;
+  setOpen: (set: boolean | ((old: boolean) => boolean)) => void;
+}) {
+  const { t } = useTranslation();
+
+  const isPVE =
+    phase === GamePhaseState.FIGHT
+      ? stageLevel in PVEStages
+      : stageLevel - 1 in PVEStages;
+
+  const name = currentPlayer.name;
+  const avatar = currentPlayer.avatar;
+  const opponentName = currentPlayer.opponentName;
+  const opponentAvatar = currentPlayer.opponentAvatar;
 
   function toggleOpen() {
-    setOpen((old) => !old)
+    setOpen((old) => !old);
   }
 
   if (opponentAvatar == "") {
-    return null
+    return null;
   }
 
   return (
     <>
       <div
-        id="game-dps-icon"
-        className="my-box clickable"
+        id='game-dps-icon'
+        className='my-box clickable'
         title={`${isOpen ? "Hide" : "Show"} battle stats`}
         onClick={toggleOpen}
       >
-        <img src="/assets/ui/dpsmeter.svg" />
+        <img src='/assets/ui/dpsmeter.svg' />
       </div>
-      {isOpen && <div
-        className="my-container hidden-scrollable game-dps-meter"
-      >
-        <header>
-          <div>
-            <PokemonPortrait avatar={avatar} />
-            <p>{name}</p>
-          </div>
-          <h2>vs</h2>
-          <div>
-            <PokemonPortrait avatar={opponentAvatar} />
-            <p>{isPVE ? t(opponentName) : opponentName}</p>
-          </div>
-        </header>
-        <Tabs>
-          <TabList>
-            <Tab key="damage_dealt">
-              <img
-                src="assets/icons/ATK.png"
-                title={t("damage_dealt")}
-                alt={t("damage_dealt")}
-              ></img>
-            </Tab>
-            <Tab key="damage_blocked">
-              <img
-                src="assets/icons/SHIELD.png"
-                title={t("damage_blocked")}
-                alt={t("damage_blocked")}
-              ></img>
-            </Tab>
-            <Tab key="heal">
-              <img
-                src="assets/icons/HP.png"
-                title={t("heal_shield")}
-                alt={t("heal_shield")}
-              ></img>
-            </Tab>
-          </TabList>
+      {isOpen && (
+        <div className='my-container hidden-scrollable game-dps-meter'>
+          <header>
+            <div>
+              <PokemonPortrait avatar={avatar} />
+              <p>{name}</p>
+            </div>
+            <h2>vs</h2>
+            <div>
+              <PokemonPortrait avatar={opponentAvatar} />
+              <p>{isPVE ? t(opponentName) : opponentName}</p>
+            </div>
+          </header>
+          <Tabs>
+            <TabList className='game-dps-meter-tab-list'>
+              <Tab
+                key='damage_dealt'
+                selectedClassName='game-dps-meter-tab-list-selected'
+              >
+                <GameDpsStatus
+                  myMeter={myDpsMeter}
+                  opponentMeter={opponentDpsMeter}
+                  attributes={["physicalDamage", "specialDamage", "trueDamage"]}
+                  icon='assets/icons/ATK.png'
+                  title={t("damage_dealt")}
+                  alt={t("damage_dealt")}
+                />
+              </Tab>
+              <Tab key='damage_blocked'>
+                <GameDpsStatus
+                  myMeter={myDpsMeter}
+                  opponentMeter={opponentDpsMeter}
+                  attributes={[
+                    "physicalDamageReduced",
+                    "specialDamageReduced",
+                    "shieldDamageTaken",
+                  ]}
+                  icon='assets/icons/SHIELD.png'
+                  title={t("damage_blocked")}
+                  alt={t("damage_blocked")}
+                />
+              </Tab>
+              <Tab key='heal'>
+                <GameDpsStatus
+                  myMeter={myDpsMeter}
+                  opponentMeter={opponentDpsMeter}
+                  attributes={["heal", "shield"]}
+                  icon='assets/icons/HP.png'
+                  title={t("heal_shield")}
+                  alt={t("heal_shield")}
+                />
+              </Tab>
+            </TabList>
 
-          <TabPanel>
-            <p>{t("damage_dealt")}</p>
-            <GamePlayerDpsMeter dpsMeter={myDpsMeter} />
-            <GamePlayerDpsMeter dpsMeter={opponentDpsMeter} />
-          </TabPanel>
+            <TabPanel>
+              <p>{t("damage_dealt")}</p>
+              <GamePlayerDpsMeter dpsMeter={myDpsMeter} />
+              <GamePlayerDpsMeter dpsMeter={opponentDpsMeter} />
+            </TabPanel>
 
-          <TabPanel>
-            <p>{t("damage_blocked")}</p>
-            <GamePlayerDpsTakenMeter dpsMeter={myDpsMeter} />
-            <GamePlayerDpsTakenMeter dpsMeter={opponentDpsMeter} />
-          </TabPanel>
+            <TabPanel>
+              <p>{t("damage_blocked")}</p>
+              <GamePlayerDpsTakenMeter dpsMeter={myDpsMeter} />
+              <GamePlayerDpsTakenMeter dpsMeter={opponentDpsMeter} />
+            </TabPanel>
 
-          <TabPanel>
-            <p>{t("heal_shield")}</p>
-            <GamePlayerHpsMeter dpsMeter={myDpsMeter} />
-            <GamePlayerHpsMeter dpsMeter={opponentDpsMeter} />
-          </TabPanel>
-        </Tabs>
-      </div>}
+            <TabPanel>
+              <p>{t("heal_shield")}</p>
+              <GamePlayerHpsMeter dpsMeter={myDpsMeter} />
+              <GamePlayerHpsMeter dpsMeter={opponentDpsMeter} />
+            </TabPanel>
+          </Tabs>
+        </div>
+      )}
     </>
-  )
+  );
 }

--- a/app/public/src/pages/component/game/game-dps-status.css
+++ b/app/public/src/pages/component/game/game-dps-status.css
@@ -1,0 +1,47 @@
+.game-dps-status-bar {
+  display: flex;
+  height: 24px;
+  width: 100%;
+  background: #222;
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 8px 0;
+  box-shadow: 0 1px 4px #0000001a;
+  border: 2px solid black;
+}
+.game-dps-status-bar-my {
+  background: #76c442;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding-left: 8px;
+  font-weight: bold;
+  transition: width 0.3s;
+  border-right: 2px solid var(--color-shadow);
+}
+
+.game-dps-status-bar-opponent {
+  background: #8d8d8d;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 8px;
+  font-weight: bold;
+  transition: width 0.3s;
+}
+
+.game-dps-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px;
+  gap: 8px;
+  height: 24px;
+  flex: 1;
+}
+
+.game-dps-status-bar-value {
+  z-index: 1;
+}

--- a/app/public/src/pages/component/game/game-dps-status.tsx
+++ b/app/public/src/pages/component/game/game-dps-status.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+
+import { IDps } from "../../../../../types";
+
+import "./game-dps-status.css";
+
+export const GameDpsStatus = ({
+  myMeter,
+  opponentMeter,
+  attributes,
+  icon,
+  title,
+  alt,
+}: {
+  myMeter: IDps[];
+  opponentMeter: IDps[];
+  attributes: (keyof IDps)[];
+  icon: string;
+  title: string;
+  alt: string;
+}) => {
+  const myValue = useMemo(() => getValue(myMeter, attributes), [myMeter]);
+  const opponentValue = useMemo(
+    () => getValue(opponentMeter, attributes),
+    [opponentMeter]
+  );
+
+  const totalValue = myValue + opponentValue;
+  const myValuePercent = totalValue === 0 ? 50 : (myValue / totalValue) * 100;
+  const opponentValuePercent =
+    totalValue === 0 ? 50 : (opponentValue / totalValue) * 100;
+
+  return (
+    <div className='game-dps-status'>
+      <img src={icon} title={title} alt={alt} />
+      <div className='game-dps-status-bar'>
+        <div
+          className='game-dps-status-bar-my'
+          style={{ width: `${myValuePercent}%` }}
+          title={`My ${title}: ${myValue}`}
+        >
+          {myValue > 0 && (
+            <span className='game-dps-status-bar-value'>{myValue}</span>
+          )}
+        </div>
+        <div
+          className='game-dps-status-bar-opponent'
+          style={{ width: `${opponentValuePercent}%` }}
+          title={`Opponent ${title}: ${opponentValue}`}
+        >
+          {opponentValue > 0 && (
+            <span className='game-dps-status-bar-value'>{opponentValue}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+function getValue(meter: IDps[], attributes: (keyof IDps)[]) {
+  return meter.reduce(
+    (acc, curr) =>
+      acc +
+      attributes
+        .filter((attribute) => curr[attribute])
+        .reduce((a, c) => a + Number(curr[c]), 0),
+    0
+  );
+}

--- a/app/public/src/pages/component/game/game-player-dps-meter.tsx
+++ b/app/public/src/pages/component/game/game-player-dps-meter.tsx
@@ -1,16 +1,14 @@
-import React, { useMemo } from "react"
-import { useTranslation } from "react-i18next"
-import { IDps } from "../../../../../types"
-import GameDps from "./game-dps"
+import { useMemo } from "react";
+import { IDps } from "../../../../../types";
+import GameDps from "./game-dps";
 
 type GamePlayerDpsMeterInput = {
-  dpsMeter: IDps[]
-}
+  dpsMeter: IDps[];
+};
 
 export default function GamePlayerDpsMeter({
-  dpsMeter = []
+  dpsMeter = [],
 }: GamePlayerDpsMeterInput) {
-  const { t } = useTranslation()
   const sortedDps = useMemo(
     () =>
       [...dpsMeter].sort((a, b) => {
@@ -19,40 +17,26 @@ export default function GamePlayerDpsMeter({
           b.specialDamage +
           b.trueDamage -
           (a.physicalDamage + a.specialDamage + a.trueDamage)
-        )
+        );
       }),
     [dpsMeter]
-  )
+  );
 
   const maxDamage = useMemo(() => {
-    const firstDps = sortedDps.at(0)
+    const firstDps = sortedDps.at(0);
     if (!firstDps) {
-      return 0
+      return 0;
     }
     return (
       firstDps.physicalDamage + firstDps.specialDamage + firstDps.trueDamage
-    )
-  }, [sortedDps])
-
-  const totalDamage = useMemo(
-    () =>
-      sortedDps.reduce((acc, dps) => {
-        acc += dps.physicalDamage + dps.specialDamage + dps.trueDamage
-        return acc
-      }, 0),
-    [sortedDps]
-  )
+    );
+  }, [sortedDps]);
 
   return (
     <div>
       {sortedDps.map((p) => {
-        return <GameDps key={p.id} dps={p} maxDamage={maxDamage} />
+        return <GameDps key={p.id} dps={p} maxDamage={maxDamage} />;
       })}
-      {sortedDps.length > 0 && (
-        <div>
-          {t("total")}: {totalDamage}
-        </div>
-      )}
     </div>
-  )
+  );
 }

--- a/app/public/src/pages/component/game/game-player-dps-taken-meter.tsx
+++ b/app/public/src/pages/component/game/game-player-dps-taken-meter.tsx
@@ -1,12 +1,12 @@
-import React, { useMemo } from "react"
-import { useTranslation } from "react-i18next"
-import { IDps } from "../../../../../types"
-import GameDpsTaken from "./game-dps-taken"
+import { useMemo } from "react";
+import { IDps } from "../../../../../types";
+import GameDpsTaken from "./game-dps-taken";
 
 export default function GamePlayerDpsTakenMeter({
-  dpsMeter = []
-}: { dpsMeter: IDps[] }) {
-  const { t } = useTranslation()
+  dpsMeter = [],
+}: {
+  dpsMeter: IDps[];
+}) {
   const sortedDamageTaken = useMemo(
     () =>
       [...dpsMeter].sort((a, b) => {
@@ -17,47 +17,30 @@ export default function GamePlayerDpsTakenMeter({
           (a.physicalDamageReduced +
             a.specialDamageReduced +
             a.shieldDamageTaken)
-        )
+        );
       }),
     [dpsMeter]
-  )
+  );
 
   const maxDamageTaken = useMemo(() => {
-    const firstDps = sortedDamageTaken.at(0)
+    const firstDps = sortedDamageTaken.at(0);
     if (!firstDps) {
-      return 0
+      return 0;
     }
     return (
       firstDps.physicalDamageReduced +
       firstDps.specialDamageReduced +
       firstDps.shieldDamageTaken
-    )
-  }, [sortedDamageTaken])
-
-  const totalDamageTaken = useMemo(
-    () =>
-      sortedDamageTaken.reduce((acc, dps) => {
-        acc +=
-          dps.physicalDamageReduced +
-          dps.specialDamageReduced +
-          dps.shieldDamageTaken
-        return acc
-      }, 0),
-    [sortedDamageTaken]
-  )
+    );
+  }, [sortedDamageTaken]);
 
   return (
     <div>
       {sortedDamageTaken.map((p) => {
         return (
           <GameDpsTaken key={p.id} dps={p} maxDamageTaken={maxDamageTaken} />
-        )
+        );
       })}
-      {sortedDamageTaken.length > 0 && (
-        <div>
-          {t("total")}: {totalDamageTaken}
-        </div>
-      )}
     </div>
-  )
+  );
 }

--- a/app/public/src/pages/component/game/game-player-hps-meter.tsx
+++ b/app/public/src/pages/component/game/game-player-hps-meter.tsx
@@ -1,47 +1,33 @@
-import React, { useMemo } from "react"
-import { useTranslation } from "react-i18next"
-import { IDps } from "../../../../../types"
-import GameDpsHeal from "./game-dps-heal"
+import { useMemo } from "react";
+import { IDps } from "../../../../../types";
+import GameDpsHeal from "./game-dps-heal";
 
 export default function GamePlayerHpsMeter({
-  dpsMeter = []
-}: { dpsMeter: IDps[] }) {
-  const { t } = useTranslation()
+  dpsMeter = [],
+}: {
+  dpsMeter: IDps[];
+}) {
   const sortedHps = useMemo(
     () =>
       [...dpsMeter].sort((a, b) => {
-        return b.shield + b.heal - (a.shield + a.heal)
+        return b.shield + b.heal - (a.shield + a.heal);
       }),
     [dpsMeter]
-  )
+  );
 
   const maxHealAmount = useMemo(() => {
-    const topHeal = sortedHps.at(0)
+    const topHeal = sortedHps.at(0);
     if (!topHeal) {
-      return 0
+      return 0;
     }
-    return topHeal.shield + topHeal.heal
-  }, [sortedHps])
-
-  const totalHealAmount = useMemo(
-    () =>
-      sortedHps.reduce((acc, dps) => {
-        acc += dps.shield + dps.heal
-        return acc
-      }, 0),
-    [sortedHps]
-  )
+    return topHeal.shield + topHeal.heal;
+  }, [sortedHps]);
 
   return (
     <div>
       {sortedHps.map((p) => (
         <GameDpsHeal key={p.id} dpsMeter={p} maxHeal={maxHealAmount} />
       ))}
-      {sortedHps.length > 0 && (
-        <div>
-          {t("total")}: {totalHealAmount}
-        </div>
-      )}
     </div>
-  )
+  );
 }


### PR DESCRIPTION
Updates the tabs in the Game DPS Meter to render a progress bar, showing your total vs the opponent. You can still click on each row to select that tab.

This lets you see at a glance how you're stacking up without having to click into each tab. This also removes the "Total" underneath the list of stats since it's now in the progress bar.

I went back and forth on the colors a bit, this was the closest I could find to something I liked and didn't feel conflicting with the other bars (as much).

![image](https://github.com/user-attachments/assets/c3f41327-ee42-478c-8bfa-295672f896df)
