### PR TITLE
use texture cache when possible to load portraits ingame

### DIFF
--- a/app/public/dist/client/changelog/patch-6.2.md
+++ b/app/public/dist/client/changelog/patch-6.2.md
@@ -90,3 +90,4 @@
 - Shiny hunter scribble no longer gets shiny PvE encounters at stages where there's no shiny encounter possible in base rules
 - Bot manager submission process has been reworked to no longer rely on Pastebin service
 - New title: Picnicker: Make a picnic with 9 Pokémon
+- Performance improvement: improve use of texture cache for pokemon portraits, which should make them appear instantly when rolling shop

--- a/app/public/src/game/components/loading-manager.ts
+++ b/app/public/src/game/components/loading-manager.ts
@@ -13,6 +13,8 @@ import atlas from "../../assets/atlas.json"
 import { preloadMusic } from "../../pages/utils/audio"
 import { getPortraitSrc } from "../../../../utils/avatar"
 import GameScene from "../scenes/game-scene"
+import { getPkmWithCustom } from "../../../../models/colyseus-models/pokemon-customs"
+import type Player from "../../../../models/colyseus-models/player"
 
 export default class LoadingManager {
   scene: Phaser.Scene
@@ -120,15 +122,6 @@ export default class LoadingManager {
       }
     )
 
-    indexList.forEach((id) => {
-      scene.load.image(`portrait-${id}`, getPortraitSrc(id))
-      /*scene.load.multiatlas(
-        id,
-        `/assets/pokemons/${id}.json`,
-        "/assets/pokemons"
-      )*/
-    })
-
     if (scene instanceof GameScene) {
       const players = values(scene.room?.state.players!)
       const player = players.find((p) => p.id === scene.uid) ?? players[0]
@@ -138,6 +131,7 @@ export default class LoadingManager {
           .filter<DungeonPMDO>((map): map is DungeonPMDO => map !== "town")
       )
       preloadMusic(scene, DungeonDetails[player.map].music)
+      preloadPortraits(this.scene, player)
     }
 
     scene.load.image("town_tileset", "/assets/tilesets/Town/tileset.png")
@@ -171,7 +165,7 @@ export default class LoadingManager {
         endFrame: 23
       }
     })
-    
+
     scene.load.spritesheet({
       key: "board_cell",
       url: "/assets/ui/board_cell.png",
@@ -216,4 +210,14 @@ export function loadEnvironmentMultiAtlas(scene: Phaser.Scene) {
     "/assets/environment/berry_trees.json",
     "/assets/environment/"
   )
+}
+
+export function preloadPortraits(scene: Phaser.Scene, player: Player) {
+  indexList.forEach((index) => {
+    const pokemonCustom = getPkmWithCustom(index, player.pokemonCustoms)
+    scene.load.image(
+      `portrait-${index}`,
+      getPortraitSrc(index, pokemonCustom.shiny, pokemonCustom.emotion)
+    )
+  })
 }

--- a/app/public/src/game/game-container.ts
+++ b/app/public/src/game/game-container.ts
@@ -1,4 +1,5 @@
 import { getStateCallbacks, Room } from "colyseus.js"
+import { SchemaCallbackProxy } from "@colyseus/schema"
 import Phaser from "phaser"
 import MoveToPlugin from "phaser3-rex-plugins/plugins/moveto-plugin.js"
 import OutlinePlugin from "phaser3-rex-plugins/plugins/outlinepipeline-plugin.js"
@@ -41,14 +42,12 @@ import { transformBoardCoordinates } from "../pages/utils/utils"
 import { preference, subscribeToPreferences } from "../preferences"
 import store from "../stores"
 import { changePlayer, setPlayer, setSimulation } from "../stores/GameStore"
-import { getPortraitSrc } from "../../../utils/avatar"
 import { BoardMode } from "./components/board-manager"
 import GameScene from "./scenes/game-scene"
 import { t } from "i18next"
 import { values } from "../../../utils/schemas"
-import { SchemaCallbackProxy } from "@colyseus/schema"
-import { getPkmWithCustom } from "../../../models/colyseus-models/pokemon-customs"
 import { DEPTH } from "./depths"
+import { getCachedPortrait } from "../pages/component/game/game-pokemon-portrait"
 
 class GameContainer {
   room: Room<GameState>
@@ -450,11 +449,10 @@ class GameContainer {
 
     $player.board.onAdd((pokemon, key) => {
       if (pokemon.stars > 1) {
-        const custom = getPkmWithCustom(pokemon.index, player.pokemonCustoms)
         const i = React.createElement(
           "img",
           {
-            src: getPortraitSrc(pokemon.index, custom.shiny, custom.emotion)
+            src: getCachedPortrait(pokemon.index, player.pokemonCustoms)
           },
           null
         )

--- a/app/public/src/pages/component/game/game-additional-pokemons.tsx
+++ b/app/public/src/pages/component/game/game-additional-pokemons.tsx
@@ -5,9 +5,8 @@ import { getPokemonData } from "../../../../../models/precomputed/precomputed-po
 import { RarityColor } from "../../../../../types/Config"
 import { SpecialGameRule } from "../../../../../types/enum/SpecialGameRule"
 import { selectCurrentPlayer, useAppSelector } from "../../../hooks"
-import { getPortraitSrc } from "../../../../../utils/avatar"
 import SynergyIcon from "../icons/synergy-icon"
-import { getPkmWithCustom } from "../../../../../models/colyseus-models/pokemon-customs"
+import { getCachedPortrait } from "./game-pokemon-portrait"
 
 export function GameAdditionalPokemonsIcon() {
   return (
@@ -59,8 +58,6 @@ export function GameAdditionalPokemons() {
           {additionalPokemons.map((p, index) => {
             const pokemon = getPokemonData(p)
             const rarityColor = RarityColor[pokemon.rarity]
-            const custom = getPkmWithCustom(pokemon.index, currentPlayer?.pokemonCustoms)
-
             return (
               <div
                 className="my-box clickable game-pokemon-portrait"
@@ -68,7 +65,7 @@ export function GameAdditionalPokemons() {
                 style={{
                   backgroundColor: rarityColor,
                   borderColor: rarityColor,
-                  backgroundImage: `url("${getPortraitSrc(pokemon.index, custom.shiny, custom.emotion)}")`
+                  backgroundImage: `url("${getCachedPortrait(pokemon.index, currentPlayer?.pokemonCustoms)}")`
                 }}
               >
                 <ul className="game-pokemon-portrait-types">

--- a/app/public/src/pages/component/game/game-pokemon-duo-portrait.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-duo-portrait.tsx
@@ -4,11 +4,11 @@ import { getPokemonData } from "../../../../../models/precomputed/precomputed-po
 import { RarityColor } from "../../../../../types/Config"
 import { PkmDuo, PkmDuos } from "../../../../../types/enum/Pokemon"
 import { selectCurrentPlayer, useAppSelector } from "../../../hooks"
-import { getPortraitSrc } from "../../../../../utils/avatar"
 import { cc } from "../../utils/jsx"
 import SynergyIcon from "../icons/synergy-icon"
 import { GamePokemonDetail } from "./game-pokemon-detail"
 import { getPkmWithCustom } from "../../../../../models/colyseus-models/pokemon-customs"
+import { getCachedPortrait } from "./game-pokemon-portrait"
 import "./game-pokemon-portrait.css"
 
 export default function GamePokemonDuoPortrait(props: {
@@ -41,11 +41,7 @@ export default function GamePokemonDuoPortrait(props: {
             )}
             data-tooltip-id={`tooltip-${props.origin}-${props.index}-${p.index}`}
             style={{
-              backgroundImage: `url("${getPortraitSrc(
-                p.index,
-                duoCustom[i]?.shiny,
-                duoCustom[i]?.emotion
-              )}")`
+              backgroundImage: `url("${getCachedPortrait(p.index, currentPlayer?.pokemonCustoms)}")`
             }}
           ></div>
           <Tooltip

--- a/app/public/src/pages/component/game/game-pokemon-portrait.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-portrait.tsx
@@ -13,9 +13,19 @@ import { cc } from "../../utils/jsx"
 import { Money } from "../icons/money"
 import SynergyIcon from "../icons/synergy-icon"
 import { GamePokemonDetail } from "./game-pokemon-detail"
-import { usePreference } from "../../../preferences"
-import { getPkmWithCustom } from "../../../../../models/colyseus-models/pokemon-customs"
+import { getPkmWithCustom, PokemonCustoms } from "../../../../../models/colyseus-models/pokemon-customs"
+import { getGameScene } from "../../game"
 import "./game-pokemon-portrait.css"
+
+export function getCachedPortrait(index: string, customs?: PokemonCustoms): string {
+  const scene = getGameScene()
+  const pokemonCustom = getPkmWithCustom(index, customs)
+  return scene?.textures.getBase64(`portrait-${index}`) ?? getPortraitSrc(
+    index,
+    pokemonCustom.shiny,
+    pokemonCustom.emotion
+  )
+}
 
 export default function GamePokemonPortrait(props: {
   index: number
@@ -26,7 +36,6 @@ export default function GamePokemonPortrait(props: {
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>,
   inPlanner?: boolean
 }) {
-  const [antialiasing] = usePreference("antialiasing")
   const pokemon = useMemo(
     () =>
       typeof props.pokemon === "string"
@@ -82,7 +91,8 @@ export default function GamePokemonPortrait(props: {
     return <div className="game-pokemon-portrait my-box empty" />
   }
 
-  const pokemonCustom = getPkmWithCustom(pokemon.index, currentPlayer?.pokemonCustoms)
+  const customs = currentPlayer?.pokemonCustoms
+  const pokemonCustom = getPkmWithCustom(pokemon.index, customs)
   const rarityColor = RarityColor[pokemon.rarity]
 
   const evolutionName = currentPlayer
@@ -138,11 +148,7 @@ export default function GamePokemonPortrait(props: {
       style={{
         backgroundColor: rarityColor,
         borderColor: rarityColor,
-        backgroundImage: `url("${getPortraitSrc(
-          pokemonInPortrait.index,
-          pokemonCustom.shiny,
-          pokemonCustom.emotion
-        )}")`
+        backgroundImage: `url("${getCachedPortrait(pokemonInPortrait.index, customs)}")`
       }}
       onClick={(e) => {
         if (canBuy && props.click) props.click(e)
@@ -166,11 +172,7 @@ export default function GamePokemonPortrait(props: {
       {willEvolve && pokemonEvolution && (
         <div className="game-pokemon-portrait-evolution">
           <img
-            src={getPortraitSrc(
-              pokemon.index,
-              pokemonCustom.shiny,
-              pokemonCustom.emotion
-            )}
+            src={getCachedPortrait(pokemon.index, customs)}
             className="game-pokemon-portrait-evolution-portrait"
           />
           <img

--- a/app/public/src/pages/component/game/game-regional-pokemons.tsx
+++ b/app/public/src/pages/component/game/game-regional-pokemons.tsx
@@ -5,9 +5,8 @@ import { getPokemonData } from "../../../../../models/precomputed/precomputed-po
 import { RarityColor, RarityCost } from "../../../../../types/Config"
 import { Pkm } from "../../../../../types/enum/Pokemon"
 import { selectCurrentPlayer, useAppSelector } from "../../../hooks"
-import { getPortraitSrc } from "../../../../../utils/avatar"
 import SynergyIcon from "../icons/synergy-icon"
-import { getPkmWithCustom } from "../../../../../models/colyseus-models/pokemon-customs"
+import { getCachedPortrait } from "./game-pokemon-portrait"
 
 export function GameRegionalPokemonsIcon() {
   return (
@@ -50,7 +49,6 @@ export function GameRegionalPokemons() {
         <div className="grid">
           {regionalPokemons.map((p, index) => {
             const pokemon = getPokemonData(p)
-            const pokemonCustom = getPkmWithCustom(pokemon.index, currentPlayer?.pokemonCustoms)
             const rarityColor = RarityColor[pokemon.rarity]
 
             return (
@@ -60,11 +58,7 @@ export function GameRegionalPokemons() {
                 style={{
                   backgroundColor: rarityColor,
                   borderColor: rarityColor,
-                  backgroundImage: `url("${getPortraitSrc(
-                    pokemon.index,
-                    pokemonCustom.shiny,
-                    pokemonCustom.emotion
-                  )}")`
+                  backgroundImage: `url("${getCachedPortrait(pokemon.index, currentPlayer?.pokemonCustoms)}")`
                 }}
               >
                 <ul className="game-pokemon-portrait-types">

--- a/app/public/src/pages/component/synergy/synergy-detail-component.tsx
+++ b/app/public/src/pages/component/synergy/synergy-detail-component.tsx
@@ -17,11 +17,11 @@ import { IPokemonData } from "../../../../../types/interfaces/PokemonData"
 import { roundToNDigits } from "../../../../../utils/number"
 import { values } from "../../../../../utils/schemas"
 import { useAppSelector } from "../../../hooks"
-import { getPortraitSrc } from "../../../../../utils/avatar"
 import { addIconsToDescription } from "../../utils/descriptions"
 import { cc } from "../../utils/jsx"
 import SynergyIcon from "../icons/synergy-icon"
 import { EffectDescriptionComponent } from "./effect-description"
+import { getCachedPortrait } from "../game/game-pokemon-portrait"
 
 export default function SynergyDetailComponent(props: {
   type: Synergy
@@ -180,7 +180,7 @@ function PokemonPortrait(props: { p: IPokemonData, type: Synergy, player?: IPlay
       key={props.p.name}
       style={{ color: RarityColor[props.p.rarity], border: "3px solid " + RarityColor[props.p.rarity] }}
     >
-      <img src={getPortraitSrc(props.p.index)} />
+      <img src={getCachedPortrait(props.p.index, props.player?.pokemonCustoms)} />
     </div>
   )
 }


### PR DESCRIPTION
Use texture cache as base64 instead of HTTP request cache to load portraits ingame whenever possible. This should improve performance, for example when rolling shop a lot.