### PR TITLE
Fix edge case for special damage calculation

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -156,7 +156,7 @@ export default abstract class PokemonState {
       }
 
       if (attackType === AttackType.SPECIAL) {
-        specialDamage = damage
+        specialDamage += damage
       } else {
         physicalDamage = damage
       }


### PR DESCRIPTION
Fix edge case where additional special damage would be overwritten if attackType is SPECIAL (fairy xurkitree/wonder room active). Changed to add the damage instead of overwriting.