### PR TITLE
hotfix duplicate lobby

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -27,9 +27,12 @@ Encoder.BUFFER_SIZE = 512 * 1024
 
 async function main() {
   if (process.env.NODE_APP_INSTANCE) {
+    const processNumber = Number(process.env.NODE_APP_INSTANCE ?? "0")
+    const port = (Number(process.env.PORT) ?? 2567) + processNumber
     initializeMetrics()
     await listen(app)
-    if (process.env.PORT && parseInt(process.env.PORT) === 2567) {
+    if (port === 2567) {
+      // only the first thread of the first instance will create the lobby and init cron jobs
       await matchMaker.createRoom("lobby", {})
       checkLobby()
       initCronJobs()


### PR DESCRIPTION
Only the first thread of the first instance will create the lobby and init cron jobs