### PR TITLE
Fix Spectral Thief using incorrect stats to calculate stolen buff

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -4190,7 +4190,7 @@ export class SpectralThiefStrategy extends AbilityStrategy {
       pokemon.moveTo(farthestCoordinate.x, farthestCoordinate.y, board)
       const boostAtk = min(0)(target.atk - target.baseAtk)
       const boostSpeed = min(0)(target.speed - DEFAULT_SPEED)
-      const boostDef = min(0)(target.def - target.baseSpeDef)
+      const boostDef = min(0)(target.def - target.baseDef)
       const boostSpeDef = min(0)(target.speDef - target.baseSpeDef)
       const boostAP = target.ap
 


### PR DESCRIPTION
Fix Spectral Thief using spDef to calculate defense buff.

There is also the issue of it not reducing AP and speed after stealing the buff. Should this be changed or is it intended to be like this?