### PR TITLE
Fix Power Lens reflected damage calculation

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -365,7 +365,8 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
         !attacker.items.has(Item.PROTECTIVE_PADS) &&
         attackType === AttackType.SPECIAL
       ) {
-        const damageAfterReduction = damage / (1 + ARMOR_FACTOR * this.speDef)
+        let speDef = this.status.armorReduction ? Math.round(this.speDef / 2) : this.speDef
+        const damageAfterReduction = specialDamage / (1 + ARMOR_FACTOR * speDef)
         const damageBlocked = min(0)(specialDamage - damageAfterReduction)
         attacker.handleDamage({
           damage: Math.round(damageBlocked),


### PR DESCRIPTION
Fix Power Lens reflected damage calculation by using specialDamage and accounting for armor break.

Previously damageAfterReduction was calculated using 'damage' which was not boosted by AP/critical/helping hand. This made damageAfterReduction lower than it should be, which made damageBlocked higher. 

It was also not checking if the holder had armor break for speDef calculation.