### PR TITLE
Hotfix error in gourmet dish priority

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1552,7 +1552,6 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
                       const pokemon = candidates[i] ?? chef
                       pokemon.meal = meal
                       pokemon.action = PokemonActionState.EAT
-                      removeInArray(candidates, pokemon)
                     }
                   })
                 }, 2000)


### PR DESCRIPTION
Fix leftover removeInArray from previous code causing the gourmet priority to skip every 2nd pokemon in dish candidate.

https://discord.com/channels/737230355039387749/1374532860467478599/1374532860467478599