### PR TITLE
Fix Heat Rock not adding burn chance

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -865,6 +865,11 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
 
     if (this.hasSynergyEffect(Synergy.FIRE)) {
       const burnChance = 0.3
+      const nbHeatRocks =
+        this.player && this.simulation.weather === Weather.SUN
+          ? count(this.player.items, Item.HEAT_ROCK)
+          : 0
+      burnChance += nbHeatRocks * 0.05
       if (chance(burnChance, this)) {
         target.status.triggerBurn(3000, target, this)
       }


### PR DESCRIPTION
Heat Rock was only reducing burn damage and not checked in onHit for burn chance.

Fixed so it is now properly adding 5% per rock to burnChance under zenith.