### PR TITLE
ensure moving states on abilities that move enemies

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -8242,6 +8242,8 @@ export class SpacialRendStrategy extends AbilityStrategy {
     )
     const n = enemies.length
     for (let i = 0; i < Math.floor(n / 2); i++) {
+      enemies[i]!.toMovingState()
+      enemies[n - 1 - i]!.toMovingState()
       board.swapValue(
         enemies[i]!.positionX,
         enemies[i]!.positionY,

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -673,8 +673,11 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   }
 
   moveTo(x: number, y: number, board: Board) {
-    board.swapValue(this.positionX, this.positionY, x, y)
     this.toMovingState()
+    const target = board.getValue(x, y)
+    if (target) target.toMovingState()
+    
+    board.swapValue(this.positionX, this.positionY, x, y)
     this.cooldown = 100 // for faster retargeting
   }
 


### PR DESCRIPTION
fix Spacial rend does not create moving state on enemies. Poison jab, u-turn, and king's shield only create moving state on the user but not the enemy.