### PR TITLE
consistent life drain behavior

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -4059,24 +4059,15 @@ export class LeechLifeStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, board, target, crit)
-    let damage = 0
-
-    switch (pokemon.stars) {
-      case 1:
-        damage = 20
-        break
-      case 2:
-        damage = 40
-        break
-      case 3:
-        damage = 80
-        break
-      default:
-        break
-    }
-
-    target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
-    pokemon.handleHeal(damage, pokemon, 1, crit)
+    const damage = [20, 40, 80][pokemon.stars - 1] ?? 80
+    const { takenDamage } = target.handleSpecialDamage(
+      damage,
+      board,
+      AttackType.SPECIAL,
+      pokemon,
+      crit
+    )
+    pokemon.handleHeal(takenDamage, pokemon, 1, crit)
   }
 }
 

--- a/app/core/effects/effect.ts
+++ b/app/core/effects/effect.ts
@@ -291,7 +291,7 @@ export class DarkHarvestEffect extends PeriodicEffect {
           .getAdjacentCells(pokemon.positionX, pokemon.positionY)
           .forEach((cell) => {
             if (cell.value && cell.value.team !== pokemon.team) {
-              cell.value.handleSpecialDamage(
+              const { takenDamage } = cell.value.handleSpecialDamage(
                 darkHarvestDamage,
                 board,
                 AttackType.SPECIAL,
@@ -300,7 +300,7 @@ export class DarkHarvestEffect extends PeriodicEffect {
                 true
               )
               pokemon.handleHeal(
-                Math.round(darkHarvestDamage * healFactor),
+                Math.round(takenDamage * healFactor),
                 pokemon,
                 0,
                 false


### PR DESCRIPTION
Most life-draining abilities in the game heal the user for a percentage of **actual** damage dealt (after all defensive calculations) as returned by `handleSpecialDamage`.

However, the code for two abilities, Leech Life and Dark Harvest, instead heal the user by a fixed amount, ignoring how much damage was actually dealt to the target.

This is despite their ability descriptions appearing very similar to other lifesteal abilities:

- Leech Life: `Deal 20/40/80 special damage to the target and heal the user for the same amount of HP.` (heals a fixed amount)

versus
 
- Dream Eater: `Jump next to an enemy suffering from Sleep, deal 45/90/150 special damage and heal for the same amount of HP. If no enemy Pokémon suffer from Sleep, put the target to Sleep for 3/4/5 seconds.` (heals based on actual damage dealt)

and

- Dark Harvest: `Teleport into the largest group of enemy Pokémon. Inflict the user with Silence for 3 seconds and drain the HP of adjacent enemy Pokémon, dealing 5/10/20 special damage per second and heal for 30% of the damage dealt.` (heals a fixed amount)

versus

- Bite: `Deal 40/80/120 special damage to the target and heal the user for 30% of the damage dealt. Cause the target to Flinch for 5 seconds.` (heals based on actual damage dealt)