### PR TITLE
Fix heal scaling on life drain abilities

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -3325,7 +3325,7 @@ export class BiteStrategy extends AbilityStrategy {
       pokemon,
       crit
     )
-    pokemon.handleHeal(Math.ceil(0.3 * takenDamage), pokemon, 1, crit)
+    pokemon.handleHeal(Math.ceil(0.3 * takenDamage), pokemon, 0, false)
     if (takenDamage > 0) target.status.triggerFlinch(5000, target, pokemon)
   }
 }
@@ -4068,7 +4068,7 @@ export class LeechLifeStrategy extends AbilityStrategy {
       pokemon,
       crit
     )
-    pokemon.handleHeal(takenDamage, pokemon, 1, crit)
+    pokemon.handleHeal(takenDamage, pokemon, 0, false)
   }
 }
 
@@ -8821,7 +8821,7 @@ export class DreamEaterStrategy extends AbilityStrategy {
         crit,
         true
       )
-      pokemon.handleHeal(takenDamage, pokemon, 1, crit)
+      pokemon.handleHeal(takenDamage, pokemon, 0, false)
     } else {
       const duration = Math.round(
         ([3000, 4000, 5000][pokemon.stars - 1] ?? 5000) * (1 + pokemon.ap / 100)


### PR DESCRIPTION
Some life drain abilities (Bite, leech life, dream eater) does not have heal % scaling on their description but do so in the code. This changes their effect to match the description.

If this is a description issue instead of effect issue, then ignore this change.