### PR TITLE
rework luck formula

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -26,7 +26,6 @@ import {
 } from "../types/Config"
 import { Ability } from "../types/enum/Ability"
 import { EffectEnum } from "../types/enum/Effect"
-import { ItemEffects } from "./effects/items"
 import {
   AttackType,
   Orientation,
@@ -65,13 +64,14 @@ import {
   OnItemRemovedEffect,
   OnKillEffect
 } from "./effects/effect"
+import { ItemEffects } from "./effects/items"
+import { PassiveEffects } from "./effects/passives"
 import { IdleState } from "./idle-state"
 import { ItemStats } from "./items"
 import MovingState from "./moving-state"
 import PokemonState from "./pokemon-state"
 import Simulation from "./simulation"
 import { DelayedCommand, SimulationCommand } from "./simulation-command"
-import { PassiveEffects } from "./effects/passives"
 
 export class PokemonEntity extends Schema implements IPokemonEntity {
   @type("boolean") shiny: boolean
@@ -375,7 +375,9 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
         !attacker.items.has(Item.PROTECTIVE_PADS) &&
         attackType === AttackType.SPECIAL
       ) {
-        const speDef = this.status.armorReduction ? Math.round(this.speDef / 2) : this.speDef
+        const speDef = this.status.armorReduction
+          ? Math.round(this.speDef / 2)
+          : this.speDef
         const damageAfterReduction = specialDamage / (1 + ARMOR_FACTOR * speDef)
         const damageBlocked = min(0)(specialDamage - damageAfterReduction)
         attacker.handleDamage({
@@ -539,7 +541,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     value =
       value * (1 + (apBoost * caster.ap) / 100) * (crit ? caster.critPower : 1)
     const update = (target: { luck: number }) => {
-      target.luck = min(-100)(target.luck + value)
+      target.luck = clamp(target.luck + value, -100, +100)
     }
     update(this)
     if (permanent && !this.isGhostOpponent) {
@@ -1296,7 +1298,11 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     target,
     board,
     damage
-  }: { target: PokemonEntity; board: Board; damage: number }) {
+  }: {
+    target: PokemonEntity
+    board: Board
+    damage: number
+  }) {
     // proc fairy splash damage for both the attacker and the target
     if (target.fairySplashCooldown === 0 && target.types.has(Synergy.FAIRY)) {
       let shockDamageFactor = 0.3
@@ -1354,7 +1360,11 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     target,
     board,
     attackType
-  }: { target: PokemonEntity; board: Board; attackType: AttackType }) {
+  }: {
+    target: PokemonEntity
+    board: Board
+    attackType: AttackType
+  }) {
     const itemEffects: OnKillEffect[] = values(this.items)
       .flatMap((item) => ItemEffects[item] ?? [])
       .filter((effect) => effect instanceof OnKillEffect)

--- a/app/public/dist/client/changelog/patch-6.3.md
+++ b/app/public/dist/client/changelog/patch-6.3.md
@@ -127,6 +127,7 @@
 - Paralysis status effect has changed: -50 speed debuff -> speed stat is 50% less effective for move speed and attack speed calculations. In practice, Paralysis status is more impactful on fast Pokémon, and less impactful on slow Pokémon.
 - Small adjustment to Rage status: +100 → +80 speed, half sleep and freeze durations immediately if unit has the status when getting enraged. Fixed status description.
 - Every % of crit chance above 100% crit chance now gives +1% crit power instead of +2% crit power.
+- Change Luck formula: `chance^(1-luck/100)` instead of `chance*(1+luck/100)`. Luck is now more valuable for low base chance effects, and less valuable for high base chance effects. You always have a risk of missing unless you reach 100% luck, which is the new max cap for Luck.
 
 # UI
 

--- a/app/utils/random.ts
+++ b/app/utils/random.ts
@@ -7,7 +7,7 @@ export function chance(
   cap = 1
 ): boolean {
   return (
-    Math.random() < max(cap)(probability * (1 + (pokemon?.luck ?? 0) / 100))
+    Math.random() < max(cap)(Math.pow(probability, (1 - (pokemon?.luck ?? 0) / 100)))
   )
 }
 


### PR DESCRIPTION
Change Luck formula: `chance^(1-luck/100)` instead of `chance*(1+luck/100)`. Luck is now more valuable for low base chance effects, and less valuable for high base chance effects. You always have a risk of missing unless you reach 100% luck, which is the new max cap for Luck.

This removes the guaranteed 100% crit with lucky egg, and makes lucky egg less desirable on Dark comps compared to other crit items

This also favor low base chance effects like status on attack from synergies. So this change makes luck more differentiable from crit chance