### PR TITLE
fix getClosestAvailablePlaceOnBoardToPokemon

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -231,10 +231,7 @@ export class BeatUpStrategy extends AbilityStrategy {
         Pkm.HOUNDOUR,
         pokemon.player
       )
-      const coord = pokemon.simulation.getClosestAvailablePlaceOnBoardToPokemon(
-        pokemon,
-        pokemon.team
-      )
+      const coord = pokemon.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(pokemon)
       const entity = pokemon.simulation.addPokemon(
         houndour,
         coord.x,
@@ -7919,10 +7916,7 @@ export class ShedTailStrategy extends AbilityStrategy {
         Pkm.SUBSTITUTE,
         pokemon.player
       )
-      const coord = pokemon.simulation.getClosestAvailablePlaceOnBoardToPokemon(
-        lowestHealthAlly,
-        lowestHealthAlly.team
-      )
+      const coord = pokemon.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(lowestHealthAlly)
       pokemon.moveTo(coord.x, coord.y, board)
       pokemon.simulation.addPokemon(substitute, x, y, pokemon.team, true)
     }
@@ -7946,7 +7940,7 @@ export class ShadowPunchStrategy extends AbilityStrategy {
     ).sort((a, b) => a.life / a.hp - b.life / b.hp)[0]
 
     if (lowestHealthEnemy) {
-      const coord = pokemon.simulation.getClosestAvailablePlaceOnBoardToPokemon(
+      const coord = pokemon.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(
         lowestHealthEnemy,
         (lowestHealthEnemy.team + 1) % 2
       )
@@ -10886,7 +10880,7 @@ export class BoneArmorStrategy extends AbilityStrategy {
     ).sort((a, b) => a.life / a.hp - b.life / b.hp)[0]
 
     if (lowestHealthEnemy) {
-      const coord = pokemon.simulation.getClosestAvailablePlaceOnBoardToPokemon(
+      const coord = pokemon.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(
         lowestHealthEnemy,
         (lowestHealthEnemy.team + 1) % 2
       )
@@ -11302,10 +11296,7 @@ export class ColumnCrushStrategy extends AbilityStrategy {
         pillarType,
         pokemon.player
       )
-      const coord = pokemon.simulation.getClosestAvailablePlaceOnBoardToPokemon(
-        pokemon,
-        pokemon.team
-      )
+      const coord = pokemon.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(pokemon)
       pokemon.simulation.addPokemon(
         pillar,
         coord.x,

--- a/app/core/abilities/hidden-power.ts
+++ b/app/core/abilities/hidden-power.ts
@@ -212,10 +212,7 @@ export class HiddenPowerJStrategy extends HiddenPowerStrategy {
     super.process(unown, board, target, crit)
     const numberToSpawn = 2
     for (let i = 0; i < numberToSpawn; i++) {
-      const coord = unown.simulation.getClosestAvailablePlaceOnBoardToPokemon(
-        unown,
-        unown.team
-      )
+      const coord = unown.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(unown)
       const sharpedo = unown.simulation.addPokemon(
         PokemonFactory.createPokemonFromName(Pkm.SHARPEDO, unown.player),
         coord.x,
@@ -236,10 +233,7 @@ export class HiddenPowerKStrategy extends HiddenPowerStrategy {
     crit: boolean
   ) {
     super.process(unown, board, target, crit)
-    const coord = unown.simulation.getClosestAvailablePlaceOnBoardToPokemon(
-      unown,
-      unown.team
-    )
+    const coord = unown.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(unown)
     const hitmonlee = unown.simulation.addPokemon(
       PokemonFactory.createPokemonFromName(Pkm.HITMONLEE, unown.player),
       coord.x,
@@ -377,10 +371,7 @@ export class HiddenPowerPStrategy extends HiddenPowerStrategy {
 
     for (let i = 0; i < numberToSpawn; i++) {
       const bug = randomWeighted(candidatesWeights) ?? Pkm.WEEDLE
-      const coord = unown.simulation.getClosestAvailablePlaceOnBoardToPokemon(
-        unown,
-        unown.team
-      )
+      const coord = unown.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(unown)
       unown.simulation.addPokemon(
         PokemonFactory.createPokemonFromName(bug, unown.player),
         coord.x,
@@ -460,10 +451,7 @@ export class HiddenPowerUStrategy extends HiddenPowerStrategy {
     crit: boolean
   ) {
     super.process(unown, board, target, crit)
-    const coord = unown.simulation.getClosestAvailablePlaceOnBoardToPokemon(
-      unown,
-      unown.team
-    )
+    const coord = unown.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(unown)
     const uxie = unown.simulation.addPokemon(
       PokemonFactory.createPokemonFromName(Pkm.UXIE, unown.player),
       coord.x,
@@ -576,10 +564,7 @@ export class HiddenPowerYStrategy extends HiddenPowerStrategy {
     super.process(unown, board, target, crit)
     const numberToSpawn = 2
     for (let i = 0; i < numberToSpawn; i++) {
-      const coord = unown.simulation.getClosestAvailablePlaceOnBoardToPokemon(
-        unown,
-        unown.team
-      )
+      const coord = unown.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(unown)
       const meditite = unown.simulation.addPokemon(
         PokemonFactory.createPokemonFromName(Pkm.MEDITITE, unown.player),
         coord.x,

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -1673,11 +1673,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
             emotion: spawn.emotion,
             shiny: spawn.shiny
           })
-          const coord =
-            this.simulation.getClosestAvailablePlaceOnBoardToPokemon(
-              this,
-              this.team
-            )
+          const coord = this.simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(this)
           const spawnedEntity = this.simulation.addPokemon(
             mon,
             coord.x,

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -358,7 +358,7 @@ export default class Simulation extends Schema implements ISimulation {
     ]
     for (const [dx, dy] of placesToConsiderByOrderOfPriority) {
       const x = positionX + dx
-      const y = positionY - 1 + dy * (team === Team.BLUE_TEAM ? 1 : -1)
+      const y = positionY + dy * (team === Team.BLUE_TEAM ? 1 : -1)
 
       if (
         x >= 0 &&
@@ -374,8 +374,23 @@ export default class Simulation extends Schema implements ISimulation {
   }
 
   getClosestAvailablePlaceOnBoardToPokemon(
-    pokemon: IPokemon | IPokemonEntity,
+    pokemon: IPokemon,
     team: Team
+  ): { x: number; y: number } {
+    const positionX = pokemon.positionX
+    const positionY = team === Team.BLUE_TEAM
+      ? pokemon.positionY - 1
+      : 5 - (pokemon.positionY - 1)
+    return this.getClosestAvailablePlaceOnBoardTo(
+      positionX,
+      positionY,
+      team
+    )
+  }
+
+  getClosestAvailablePlaceOnBoardToPokemonEntity(
+    pokemon: IPokemonEntity,
+    team: Team = pokemon.team
   ): { x: number; y: number } {
     return this.getClosestAvailablePlaceOnBoardTo(
       pokemon.positionX,

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -1906,7 +1906,7 @@ const conversionEffect = ({
       entity.name,
       player as Player
     )
-    const coord = simulation.getClosestAvailablePlaceOnBoardToPokemon(
+    const coord = simulation.getClosestAvailablePlaceOnBoardToPokemonEntity(
       entity,
       player.team
     )


### PR DESCRIPTION
This function was taking both Pokemon and PokemonEntity as a parameter, but the positionY compute is different based on the type of the argument. Replaced by two different functions for clarity

fix https://discord.com/channels/737230355039387749/1388821395042996316