### PR TITLE
Hotfix onDeath triggers with Possessed status

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -624,6 +624,8 @@ export default abstract class PokemonState {
       }
 
       if (death) {
+        const originalTeam = pokemon.status.possessed ? (pokemon.team === Team.BLUE_TEAM ? Team.RED_TEAM : Team.BLUE_TEAM) : pokemon.team
+        pokemon.team = originalTeam
         pokemon.onDeath({ board })
         board.setValue(pokemon.positionX, pokemon.positionY, undefined)
         if (attacker && pokemon !== attacker) {
@@ -662,7 +664,6 @@ export default abstract class PokemonState {
           effectsRemovedList.push(EffectEnum.MISTY_TERRAIN)
         }
 
-        const originalTeam = pokemon.status.possessed ? (pokemon.team === Team.BLUE_TEAM ? Team.RED_TEAM : Team.BLUE_TEAM) : pokemon.team
         if (originalTeam == Team.BLUE_TEAM) {
           effectsRemovedList.forEach((x) =>
             pokemon.simulation.blueEffects.delete(x)


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1389009126226526361

onDeath triggers are triggering for the wrong team while possessed. (Ghost curse spread, field boost, etc.)
Moved originalTeam logic up and changed pokemon.team to original to fix this.

Previous code using originalTeam below can be refactored but will leave that for another PR