### PR TITLE
Update French translations (Meltan Varoom line) + some fixes

### DIFF
--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -2620,7 +2620,7 @@
 		"TORNADUS": "Change weather to WINDY or SNOW based on your dominant synergy between FLYING and ICE",
 		"ENAMORUS": "Change weather to MISTY or WINDY based on your dominant synergy between FAIRY and FLYING",
 		"AIRLOCK": "Change weather to NEUTRAL",
-		"SHARED_VISION": "All Pokémon with $t(passive_description.SHARED_VISION) will attack the same target, if at range",
+		"SHARED_VISION": "Shared Vision: All Pokémon with Shared Vision will attack the same target, if at range",
 		"WATER_SPRING": "Whenever an enemy uses their ability, gain 5 PP",
 		"MAGIKARP": "8 Magikarp evolve in Gyarados",
 		"FEEBAS": "6 Feebas evolve in Milotic",

--- a/app/public/dist/client/locales/fr/translation.json
+++ b/app/public/dist/client/locales/fr/translation.json
@@ -487,7 +487,9 @@
 		"ENCORE": "Encore",
 		"STORED_POWER": "Force Ajoutée",
 		"MIND_BEND": "Contrôleur d'esprit",
-		"CHAIN_CRAZED": "Chaîne Frénétique"
+		"CHAIN_CRAZED": "Chaîne Frénétique",
+		"MAGNET_PULL": "Magnépiège",
+		"WILD_DRIFT": "Drift Sauvage"
 	},
 	"pkm": {
 		"DEFAULT": "MissingNo.",
@@ -1058,6 +1060,7 @@
 		"MR_MIME": "M. Mime",
 		"ORIGIN_GIRATINA": "Giratina (Originelle)",
 		"PIROUETTE_MELOETTA": "Meloetta (Danse)",
+		"MELTAN": "Meltan",
 		"MELMETAL": "Melmetal",
 		"HOOPA": "Hoopa",
 		"HOOPA_UNBOUND": "Hoopa (Déchaîné)",
@@ -1474,13 +1477,15 @@
 		"WYRDEER": "Cerbyllin",
 		"OKIDOGI": "Félicanis",
 		"MUNKIDORI": "Fortusimia",
-		"FEZANDIPITI": "Favianos"
+		"FEZANDIPITI": "Favianos",
+		"VAROOM": "Vrombi",
+		"REVAVROOM": "Vrombotor"
 	},
 	"ability_description": {
 		"SOFT_BOILED": "Soigne tous les effets de statut et octroie [20,40,80,SP] SHIELD à tous les alliés.",
 		"EARTHQUAKE": "Inflige [100,SP] SPECIAL à tous les ennemis présents sur la même rangée ou colonne que le lanceur.",
 		"SONG_OF_DESIRE": "Rend CHARM 2 adversaires dans la rangée du fond pendant 3 secondes, et réduit leur ATK de [3,SP].",
-		"CONFUSING_MIND": "Rend CONFUSION 2 adversaires dans la rangée du fond pendant 3 secondes.",
+		"CONFUSING_MIND": "Rend CONFUSION 2 adversaires dans la rangée arrière pendant 3 secondes.",
 		"KNOWLEDGE_THIEF": "Utilise la capacité de la cible. Le joueur gagne 1 XP.",
 		"KING_SHIELD": "PROTECT le lanceur pendant 1.5 secondes, gagne [10,20,30,SP] SHIELD et échange sa position avec l'ennemi le plus éloigné.",
 		"U_TURN": "Gagne [15,30,50,SP] SHIELD, échange sa position avec la cible qui est CHARM pendant 1 seconde.",
@@ -1506,7 +1511,7 @@
 		"NUZZLE": "Fonce vers l'ennemi le plus éloigné et lui inflige [20,40,80,SP] SPECIAL ainsi que PARALYSIS pendant 3 secondes.",
 		"LIQUIDATION": "Inflige [20,40,80,SP] SPECIAL et retire [4,8,16,SP] DEF de la cible.",
 		"TOXIC": "Inflige POISONNED aux [1,2,3] adversaires les plus proches pendant [3,6,9,SP=0.5] secondes.",
-		"SING": "Inflige SLEEP aux [1,2,3] Pokémon ennemis de la rangée de fond pendant [2,SP] secondes.",
+		"SING": "Inflige SLEEP aux [1,2,3] Pokémon ennemis de la rangée arrière pendant [2,SP] secondes.",
 		"PROTECT": "PROTECT le lanceur, devenant invulnérable pendant [1,3,5,SP=0.5] secondes.",
 		"OBSTRUCT": "PROTECT le lanceur, devenant invulnérable pendant [2,SP=0.5] secondes. Toute attaque reçue pendant ce délai réduit la DEF du lanceur de 2.",
 		"BLIZZARD": "FREEZE tous les Pokémon ennemis pendant 2 secondes et leur inflige [10,20,30,SP] SPECIAL. Dégâts doublés si l'ennemi est déjà FREEZE.",
@@ -1925,7 +1930,7 @@
 		"BEHEMOTH_BLADE": "Fonce derrière la cible et délivre un puissant coup d'estoc, infligeant [100,SP] + 1x ATK comme SPECIAL.",
 		"HEAT_CRASH": "S'écrase sur la cible, la fait reculer et lui inflige [40,60,80,SP] SPECIAL. Plus le lanceur a d'ATK par rapport à la cible, plus les dégâts seront importants.",
 		"LASER_BLADE": "Alterne entre :\n1. Fait tournoyer une Lame Laser qui peut se déplacer derrière sa cible, le lanceur gagne [25,SP] SHIELD et inflige [25,SP] SPECIAL à la cible et à tous les ennemis adjacents sur son chemin.\n2. Fait tournoyer une Lame Laser devant eux, infligeant 2 fois [25,SP] + ATK comme SPECIAL.",
-		"ICICLE_MISSILE": "Lance [1,2,3] stalactites sur les ennemis de la ranggée du fond, infligeant [50,SP] SPECIAL et FREEZE pendant 3 secondes.",
+		"ICICLE_MISSILE": "Lance [1,2,3] stalactites sur les ennemis de la ranggée arrière, infligeant [50,SP] SPECIAL et FREEZE pendant 3 secondes.",
 		"ARM_THRUST": "Attaque de [2,LK] à [5,LK] fois, infligeant [100,SP]% d'ATK comme PHYSICAL à chaque fois. Chaque coup indépendamment peut causer un coup critique par défaut basé sur la CRIT_CHANCE du lanceur.",
 		"DRUM_BEATING": "Boucle entre :\n1. Wood-block : donne [10,20,40,SP] SHIELD à toute votre équipe\n2. Roulement de tambours : inflige [10,20,40,SP] SPECIAL à tous les ennemis\n3. Accélère le rythme : donne [10,20,40,SP] SPEED à toute votre équipe.",
 		"PSYCHO_CUT": "3 épées psychiques qui coupent et percent tous les ennemis derrière la cible en ligne, chacune inflige [10,20,40,SP] SPECIAL à tous les ennemis touchés. Peut infliger un coup critique par défaut.",
@@ -1942,7 +1947,9 @@
 		"ENCORE": "Lance la dernière capacité utilisée par un allié.",
 		"STORED_POWER": "Inflige 20 SPECIAL à la cible. Plus les stats du lanceur ont été augmentées, plus les dégats seront importants (ATK, SPEED, DEF, SPE_DEF, AP).",
 		"MIND_BEND": "La cible est POSSESSED pendant [2,SP,ND=1] secondes. Si RUNE_PROTECT ou déjà POSSESSED, inflige [100,SP] SPECIAL à la place.",
-		"CHAIN_CRAZED": "S'auto-inflige POISON pendant 3 secondes et gagne [15,SP] ATK, [10,SP] DEF et 20 SPEED."
+		"CHAIN_CRAZED": "S'auto-inflige POISON pendant 3 secondes et gagne [15,SP] ATK, [10,SP] DEF et 20 SPEED.",
+		"MAGNET_PULL": "Tous les ennemis dans un rayon de 3 cases sont bloqués pendant [3,SP] secondes. Attire un Pokémon STEEL aléatoire sur le champ de bataille. Cliquez dessus pour l'ajouter à votre banc.",
+		"WILD_DRIFT": "Drift vers votre rangée arrière, infligeant [25,50,100,SP]% de la SPEED du lanceur en SPECIAL à la cible, la rendant BLINDED pendant 1 seconde. Le lanceur perd ensuite tous les bonus de SPEED liés à son passif Turbo."
 	},
 	"effect": {
 		"STAMINA": "Endurance",
@@ -2613,7 +2620,7 @@
 		"TORNADUS": "Change la météo en WINDY ou SNOW selon votre synergie dominante entre FLYING et ICE.",
 		"ENAMORUS": "Change la météo en MISTY ou WINDY selon votre synergie dominante entre FAIRY et FLYING.",
 		"AIRLOCK": "Neutralise tous les effets météorologiques, retourne à une météo NEUTRAL.",
-		"SHARED_VISION": "Tous les Pokémon avec $t(passive_description.SHARED_VISION) attaqueront la même cible, si elle est à portée.",
+		"SHARED_VISION": "Vision Partagée : Tous les Pokémon avec le passif Vision Partagée attaqueront la même cible, si elle est à portée.",
 		"WATER_SPRING": "À chaque fois qu'un ennemi utilise sa capacité, gagne 5 PP.",
 		"MAGIKARP": "8 $t(pkm.MAGIKARP) évoluent en Léviator.",
 		"FEEBAS": "6 $t(pkm.FEEBAS) évoluent en $t(pkm.MILOTIC).",
@@ -2705,7 +2712,7 @@
 		"APPLIN": "$t(pkm.APPLIN) cherche une SWEET_APPLE, une TART_APPLE ou une SIRUPY_APPLE.",
 		"DIPPLIN": "$t(pkm.DIPPLIN) cherche une SIRUPY_APPLE.",
 		"WELL_BAKED": "Le Pokémon ne souffre pas de BURN. Au contraire, il gagne 20 DEF lorsqu'il est affecté par BURN.",
-		"CONVERSION": "Le Pokémon récupère la plus haute synergie de votre adversaire et ses effets au début du combat.",
+		"CONVERSION": "Conversion : Le Pokémon récupère la plus haute synergie de votre adversaire et ses effets au début du combat.",
 		"CREAM": "$t(pkm.MILCERY) cherche une saveur délicieuse…",
 		"VANILLA_CREAM": "Au lancement de la capacité, la VANILLA_FLAVOR ajoute [80,SP] SHIELD à l'allié décoré.",
 		"RUBY_CREAM": "Au lancement de la capacité, la RUBY_FLAVOR ajoute [30,SP] SPEED à l'allié décoré.",
@@ -2728,7 +2735,8 @@
 		"STANTLER": "Évolue en $t(pkm.WYRDEER) en changeant de région.",
 		"PIKACHU_SURFER": "Pour chaque vague qui approche, $t(pkm.PIKACHU_SURFER) se sent motivé, ce qui remplit sa barre de PP.",
 		"ESPURR": "Évolue en $t(MEOWSTIC) Mâle ou Femelle en fonction de la synergie dominante entre PSYCHIC et FIELD.",
-		"FUR_COAT": "Sa fourrure pousse, donnant +2 DEF et -5 SPEED à chaque tour. Il peut être toiletté en passant un tour sur le banc, ce qui réinitialise ses statistiques de DEF et de SPEED."
+		"FUR_COAT": "Sa fourrure pousse, donnant +2 DEF et -5 SPEED à chaque tour. Il peut être toiletté en passant un tour sur le banc, ce qui réinitialise ses statistiques de DEF et de SPEED.",
+		"ACCELERATION": "Turbo : gagne 20 SPEED pour chaque case sur laquelle le Pokémon se déplace (les sauts et les sprints comptent pour une case)"
 	},
 	"stat": {
 		"ATK": "Attaque",
@@ -3200,9 +3208,11 @@
 	"minimum_rank": "Rang minimum",
 	"maximum_rank": "Rang max",
 	"ranked_match": "Match Classé",
+	"ranked_match_short": "Classé",
 	"ranked_match_description": "Pour les compétiteurs\n8 joueurs, Elo activé, restreint aux joueurs de votre rang actuel",
 	"ranked_game_hint": "Cette partie est restreinte aux joueurs de votre rang actuel",
 	"smeargle_scribble": "Gribouilles de Queulorior",
+	"smeargle_scribble_short": "Gribouilles",
 	"smeargle_scribble_description": "Jouez pour le fun, pas de gain/perte d'Elo !\nUne nouvelle règle spéciale est ajoutée à la partie.",
 	"smeargle_scribble_hint": "Queulorior gribouille une nouvelle règle aléatoire appliquée pendant toute la partie",
 	"no_rule": "Aucune règle spéciale",
@@ -3215,7 +3225,10 @@
 	"new_game": "Nouvelle partie",
 	"in_game": "En jeu",
 	"tournament": "Tournoi",
+	"events": "Événements",
+	"victory_road": "Route Victoire",
 	"custom_room": "Salon personnalisé",
+	"custom_room_short": "Personnalisé",
 	"custom_room_description": "Créer un salon privé avec vos règles",
 	"loading": "Connexion....",
 	"connecting": "Connexion...",
@@ -3881,6 +3894,10 @@
 		"itssolution": "C'est $t(pkm.{{pokemon}}) !",
 		"attempts": "Essais : {{count}}",
 		"guess": "Devine",
-		"reset": "Réinitialiser"
+		"reset": "Réinitialiser",
+		"difficulty": "Difficulté",
+		"easy": "Facile",
+		"normal": "Normal",
+		"hard": "Difficile"
 	}
 }

--- a/app/public/dist/client/locales/fr/translation.json
+++ b/app/public/dist/client/locales/fr/translation.json
@@ -1930,7 +1930,7 @@
 		"BEHEMOTH_BLADE": "Fonce derrière la cible et délivre un puissant coup d'estoc, infligeant [100,SP] + 1x ATK comme SPECIAL.",
 		"HEAT_CRASH": "S'écrase sur la cible, la fait reculer et lui inflige [40,60,80,SP] SPECIAL. Plus le lanceur a d'ATK par rapport à la cible, plus les dégâts seront importants.",
 		"LASER_BLADE": "Alterne entre :\n1. Fait tournoyer une Lame Laser qui peut se déplacer derrière sa cible, le lanceur gagne [25,SP] SHIELD et inflige [25,SP] SPECIAL à la cible et à tous les ennemis adjacents sur son chemin.\n2. Fait tournoyer une Lame Laser devant eux, infligeant 2 fois [25,SP] + ATK comme SPECIAL.",
-		"ICICLE_MISSILE": "Lance [1,2,3] stalactites sur les ennemis de la ranggée arrière, infligeant [50,SP] SPECIAL et FREEZE pendant 3 secondes.",
+		"ICICLE_MISSILE": "Lance [1,2,3] stalactites sur les ennemis de la rangée arrière, infligeant [50,SP] SPECIAL et FREEZE pendant 3 secondes.",
 		"ARM_THRUST": "Attaque de [2,LK] à [5,LK] fois, infligeant [100,SP]% d'ATK comme PHYSICAL à chaque fois. Chaque coup indépendamment peut causer un coup critique par défaut basé sur la CRIT_CHANCE du lanceur.",
 		"DRUM_BEATING": "Boucle entre :\n1. Wood-block : donne [10,20,40,SP] SHIELD à toute votre équipe\n2. Roulement de tambours : inflige [10,20,40,SP] SPECIAL à tous les ennemis\n3. Accélère le rythme : donne [10,20,40,SP] SPEED à toute votre équipe.",
 		"PSYCHO_CUT": "3 épées psychiques qui coupent et percent tous les ennemis derrière la cible en ligne, chacune inflige [10,20,40,SP] SPECIAL à tous les ennemis touchés. Peut infliger un coup critique par défaut.",


### PR DESCRIPTION
Updated from #3227, #3224 and #3218

### New Translations
New Pokémon translated : Meltan, Varoom and Revavroom
Translated new abilities, passives and their descriptions :
- Wild Drift -> Drift Sauvage 
https://www.pokepedia.fr/Vrombotor-ex_(%C3%89carlate_et_Violet_Flammes_Obsidiennes_216)
- Magnet Pull -> Magnépiège
https://www.pokepedia.fr/Magn%C3%A9pi%C3%A8ge
- Acceleration -> Turbo
Acceleration is the former name of the ability Speed Boost
https://bulbapedia.bulbagarden.net/wiki/Speed_Boost_(Ability)
https://bulbapedia.bulbagarden.net/w/index.php?title=Acceleration&redirect=no

### Fixes :
- Standardization of "backline"
"rangée du fond" -> "rangée arrière"
- Fix the description of SHARED_VISION in english and french