### PR TITLE
add profile endpoint

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -369,6 +369,19 @@ export default config({
       }
     }
 
+    app.get("/profile", async (req, res) => {
+      try {
+        const userAuth = await authUser(req, res)
+        if (!userAuth) return
+        const user = await UserMetadata.findOne({ uid: userAuth.uid })
+        if (!user) return res.status(404).send("User not found")
+        res.send(user)
+      } catch (error) {
+        logger.error("Error fetching profile", error)
+        res.status(500).send("Error fetching profile")
+      }
+    })
+
     app.post("/bots", async (req, res) => {
       try {
         const userAuth = await authUser(req, res)

--- a/app/public/src/game/lobby-logic.ts
+++ b/app/public/src/game/lobby-logic.ts
@@ -15,8 +15,8 @@ import { CloseCodes, CloseCodesMessages } from "../../../types/enum/CloseCodes"
 import { ConnectionStatus } from "../../../types/enum/ConnectionStatus"
 import type { NonFunctionPropNames } from "../../../types/HelperTypes"
 import { logger } from "../../../utils/logger"
+import { authenticateUser } from "../network"
 import { LocalStoreKeys, localStore } from "../pages/utils/store"
-import { FIREBASE_CONFIG } from "../pages/utils/utils"
 import store, { AppDispatch } from "../stores"
 import {
   addRoom,
@@ -38,7 +38,6 @@ import {
 } from "../stores/LobbyStore"
 import {
   joinLobby,
-  logIn,
   removeMessage,
   setConnectionStatus,
   setErrorAlertMessage,
@@ -60,14 +59,7 @@ export async function joinLobbyRoom(
         return resolve(lobby)
       }
 
-      if (!firebase.apps.length) {
-        firebase.initializeApp(FIREBASE_CONFIG)
-      }
-
-      firebase.auth().onAuthStateChanged(async (user) => {
-        if (!user) return reject(CloseCodes.USER_NOT_AUTHENTICATED)
-        dispatch(logIn(user))
-
+      authenticateUser().then(async (user) => {
         try {
           let room: Room<ICustomLobbyState> | undefined = undefined
 

--- a/app/public/src/network.ts
+++ b/app/public/src/network.ts
@@ -1,0 +1,38 @@
+import { User } from "@firebase/auth-types"
+import firebase from "firebase/compat/app"
+import { IUserMetadata } from "../../models/mongo-models/user-metadata"
+import { CloseCodes } from "../../types/enum/CloseCodes"
+import { FIREBASE_CONFIG } from "./pages/utils/utils"
+import store from "./stores"
+import { logIn, setProfile } from "./stores/NetworkStore"
+
+export function authenticateUser() {
+    if (!firebase.apps.length) {
+        firebase.initializeApp(FIREBASE_CONFIG)
+    }
+
+    return new Promise<User>((resolve, reject) => {
+        firebase.auth().onAuthStateChanged(async (user) => {
+            if (!user) return reject(CloseCodes.USER_NOT_AUTHENTICATED)
+            store.dispatch(logIn(user))
+            fetchProfile()
+            resolve(user)
+        })
+    })
+}
+
+export async function fetchProfile(forceRefresh: boolean = false): Promise<IUserMetadata> {
+    const profile = store.getState().network.profile;
+    const token = await firebase.auth().currentUser?.getIdToken()
+    if (!forceRefresh && profile) {
+        return Promise.resolve(profile);
+    }
+    return fetch("/profile", {
+        headers: {
+            Authorization: `Bearer ${token}`
+        }
+    }).then(res => res.json()).then((profile: IUserMetadata) => {
+        store.dispatch(setProfile(profile));
+        return profile;
+    });
+}

--- a/app/public/src/pages/after-game.tsx
+++ b/app/public/src/pages/after-game.tsx
@@ -1,9 +1,10 @@
 import { Client, Room } from "colyseus.js"
-import firebase from "firebase/compat/app"
 import React, { useEffect, useRef, useState } from "react"
 import { Navigate } from "react-router-dom"
 import AfterGameState from "../../../rooms/states/after-game-state"
+import { CloseCodes } from "../../../types/enum/CloseCodes"
 import { useAppDispatch, useAppSelector } from "../hooks"
+import { authenticateUser } from "../network"
 import { preference } from "../preferences"
 import {
   addPlayer,
@@ -12,11 +13,10 @@ import {
   setElligibilityToXP,
   setGameMode
 } from "../stores/AfterGameStore"
-import { joinAfter, logIn } from "../stores/NetworkStore"
+import { joinAfter } from "../stores/NetworkStore"
 import AfterMenu from "./component/after/after-menu"
 import { playSound, SOUNDS } from "./utils/audio"
 import { LocalStoreKeys, localStore } from "./utils/store"
-import { FIREBASE_CONFIG } from "./utils/utils"
 
 export default function AfterGame() {
   const dispatch = useAppDispatch()
@@ -32,12 +32,8 @@ export default function AfterGame() {
   useEffect(() => {
     const reconnect = async () => {
       initialized.current = true
-      if (!firebase.apps.length) {
-        firebase.initializeApp(FIREBASE_CONFIG)
-      }
-      firebase.auth().onAuthStateChanged(async (user) => {
-        if (user) {
-          dispatch(logIn(user))
+      authenticateUser()
+        .then(async () => {
           try {
             const cachedReconnectionToken = localStore.get(
               LocalStoreKeys.RECONNECTION_AFTER_GAME
@@ -67,10 +63,12 @@ export default function AfterGame() {
               }
             }, 1000)
           }
-        } else {
-          setToAuth(true)
-        }
-      })
+        })
+        .catch((err) => {
+          if (err === CloseCodes.USER_NOT_AUTHENTICATED) {
+            setToAuth(true)
+          }
+        })
     }
 
     const initialize = async (room: Room<AfterGameState>) => {

--- a/app/public/src/pages/component/booster/booster-card.tsx
+++ b/app/public/src/pages/component/booster/booster-card.tsx
@@ -1,13 +1,15 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { getPokemonData } from "../../../../../models/precomputed/precomputed-pokemon-data"
-import { DUST_PER_BOOSTER, DUST_PER_SHINY, RarityColor } from "../../../../../types/Config"
+import { BoosterCard } from "../../../../../types/Booster"
+import {
+  DUST_PER_BOOSTER,
+  DUST_PER_SHINY,
+  RarityColor
+} from "../../../../../types/Config"
 import { PkmIndex } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../../../utils/avatar"
 import { cc } from "../../utils/jsx"
-import { useAppSelector } from "../../../hooks"
-import { hasUnlocked } from "../../../../../core/collection"
-import { BoosterCard } from "../../../../../types/Booster"
 import PokemonPortrait from "../pokemon-portrait"
 import "./booster-card.css"
 
@@ -23,12 +25,6 @@ export function BoosterCard({ card, flipped, onFlip }: BoosterCardProps) {
   const style = {
     "--rarity-color": RarityColor[pokemonData.rarity]
   } as React.CSSProperties
-
-  const pokemonCollection = useAppSelector(
-    (state) => state.network.profile?.pokemonCollection
-  )
-  const hasUnlockedCard = pokemonCollection != null && hasUnlocked(pokemonCollection, card)
-
   return (
     <div
       className={cc(
@@ -43,14 +39,25 @@ export function BoosterCard({ card, flipped, onFlip }: BoosterCardProps) {
         <img src="/assets/ui/pokecard.png" />
       </div>
       <div className={cc("front", { shimmer: card.shiny })}>
-        <PokemonPortrait portrait={{ index: PkmIndex[card.name], shiny: card.shiny, emotion: card.emotion }} />
+        <PokemonPortrait
+          portrait={{
+            index: PkmIndex[card.name],
+            shiny: card.shiny,
+            emotion: card.emotion
+          }}
+        />
         <div className="front-text">
-          <p className="name">{t(`pkm.${card.name}`)}
-            <br /> <span style={{ fontWeight: 'normal' }}>{t(`emotion.${card.emotion}`)}</span>
+          <p className="name">
+            {t(`pkm.${card.name}`)}
+            <br />{" "}
+            <span style={{ fontWeight: "normal" }}>
+              {t(`emotion.${card.emotion}`)}
+            </span>
           </p>
-          {card.new
-            ? <p className={cc({ new: hasUnlockedCard })}>{t("new")}</p>
-            : <p className="dust">
+          {card.new ? (
+            <p className="new">{t("new")}</p>
+          ) : (
+            <p className="dust">
               +{card.shiny ? DUST_PER_SHINY : DUST_PER_BOOSTER} {t("shards")}{" "}
               <img
                 src={getPortraitSrc(PkmIndex[card.name])}
@@ -58,9 +65,9 @@ export function BoosterCard({ card, flipped, onFlip }: BoosterCardProps) {
                 alt="dust"
               />
             </p>
-          }
+          )}
         </div>
       </div>
-    </div >
+    </div>
   )
 }

--- a/app/public/src/pages/component/bot-builder/bot-manager-panel.tsx
+++ b/app/public/src/pages/component/bot-builder/bot-manager-panel.tsx
@@ -1,12 +1,10 @@
 import firebase from "firebase/compat/app"
-import React, { useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { IBotLight } from "../../../../../models/mongo-models/bot-v2"
-import { useAppDispatch } from "../../../hooks"
-import { logIn } from "../../../stores/NetworkStore"
+import { authenticateUser } from "../../../network"
 import { cc } from "../../utils/jsx"
-import { FIREBASE_CONFIG } from "../../utils/utils"
 import PokemonPortrait from "../pokemon-portrait"
 import "./bot-manager-panel.css"
 
@@ -57,22 +55,12 @@ export function BotManagerPanel() {
 function BotsList(props: { approved?: boolean }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const dispatch = useAppDispatch()
   const [bots, setBots] = useState<IBotLight[] | null>(null)
   const [sortColumn, setSortColumn] = useState<string>("")
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc")
 
   useEffect(() => {
-    // Initialize Firebase
-    if (!firebase.apps.length) {
-      firebase.initializeApp(FIREBASE_CONFIG)
-    }
-    firebase.auth().onAuthStateChanged((user) => {
-      if (user) {
-        dispatch(logIn(user))
-      }
-    })
-
+    authenticateUser()
     fetch(`/bots?t=${Date.now()}`)
       .then((res) => res.json())
       .then((data) => {

--- a/app/public/src/stores/NetworkStore.ts
+++ b/app/public/src/stores/NetworkStore.ts
@@ -1,5 +1,5 @@
 import { User } from "@firebase/auth-types"
-import { PayloadAction, createSlice } from "@reduxjs/toolkit"
+import { createSlice, PayloadAction } from "@reduxjs/toolkit"
 import { Client, Room } from "colyseus.js"
 import { IBot } from "../../../models/mongo-models/bot-v2"
 import { IUserMetadata } from "../../../models/mongo-models/user-metadata"
@@ -20,8 +20,8 @@ import { Item } from "../../../types/enum/Item"
 import { Language } from "../../../types/enum/Language"
 import { PkmProposition } from "../../../types/enum/Pokemon"
 import { SpecialGameRule } from "../../../types/enum/SpecialGameRule"
-import { logger } from "../../../utils/logger"
 import { getAvatarString } from "../../../utils/avatar"
+import { logger } from "../../../utils/logger"
 
 export interface INetwork {
   client: Client

--- a/app/rooms/after-game-room.ts
+++ b/app/rooms/after-game-room.ts
@@ -57,7 +57,6 @@ export default class AfterGameRoom extends Room<AfterGameState> {
       const token = await admin.auth().verifyIdToken(options.idToken)
       const user = await admin.auth().getUser(token.uid)
       const userProfile = await UserMetadata.findOne({ uid: user.uid })
-      client.send(Transfer.USER_PROFILE, userProfile)
 
       if (!user.displayName) {
         throw "No display name"

--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -75,7 +75,6 @@ export class OnJoinCommand extends Command<
       if (user) {
         // load existing account
         this.room.users.set(client.auth.uid, user)
-        client.send(Transfer.USER_PROFILE, user)
         const pendingGame = await getPendingGame(
           this.room.presence,
           client.auth.uid
@@ -115,7 +114,6 @@ export class OnJoinCommand extends Command<
           role: Role.BASIC
         }
         this.room.users.set(client.auth.uid, newUser)
-        client.send(Transfer.USER_PROFILE, newUser)
       }
     } catch (error) {
       logger.error(error)

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -562,7 +562,6 @@ export default class GameRoom extends Room<GameState> {
     if (userProfile?.banned) {
       throw "Account banned"
     }
-    client.send(Transfer.USER_PROFILE, userProfile)
     this.dispatcher.dispatch(new OnJoinCommand(), { client })
     const pendingGame = await getPendingGame(this.presence, client.auth.uid)
     if (pendingGame?.gameId === this.roomId) {
@@ -585,9 +584,8 @@ export default class GameRoom extends Room<GameState> {
       // allow disconnected client to reconnect into this room until 5 minutes
       setPendingGame(this.presence, client.auth.uid, this.roomId)
       await this.allowReconnection(client, ALLOWED_GAME_RECONNECTION_TIME)
+      // if the user reconnects, we clear the pending game and recall the OnJoinCommand
       clearPendingGame(this.presence, client.auth.uid)
-      const userProfile = await UserMetadata.findOne({ uid: client.auth.uid })
-      client.send(Transfer.USER_PROFILE, userProfile) // send profile info again after a /game page refresh
       this.dispatcher.dispatch(new OnJoinCommand(), { client })
     } catch (e) {
       if (client && client.auth && client.auth.displayName) {

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -340,7 +340,6 @@ export default class PreparationRoom extends Room<PreparationState> {
       const user = await admin.auth().getUser(token.uid)
       const userProfile = await UserMetadata.findOne({ uid: user.uid })
       const isAdmin = userProfile?.role === Role.ADMIN
-      client.send(Transfer.USER_PROFILE, userProfile)
 
       const isAlreadyInRoom = this.state.users.has(user.uid)
       const numberOfHumanPlayers = values(this.state.users).filter(


### PR DESCRIPTION
add /profile api endpoint to replace the sending of user profile over websocket every time a user joins the room.

Because the call is done client-side, this allows:
- to call the endpoint only when it is required (when no data available) to optimize unnecessary traffic over websocket
- to ensure the profile info is loaded when client is ready. We had some issues where profile was sometimes not properly loading after a while, forcing user to logout/login again to get their profile

see https://discord.com/channels/737230355039387749/1278509694058758144