### PR TITLE
add decremental k factor for elo based on number of games played

### DIFF
--- a/app/core/elo-engine.ts
+++ b/app/core/elo-engine.ts
@@ -1,10 +1,18 @@
+import { min } from "../utils/number"
+
 export class EloEngine {
-  k = 32
+  K = 32
 
   getExpected(a: number, b: number) {
     return 1 / (1 + Math.pow(10, (b - a) / 400))
   }
-  updateRating(expected: number, actual: number, current: number) {
-    return Math.round(current + this.k * (actual - expected))
+  updateRating(expected: number, actual: number, current: number, nbGamesPlayed: number) {
+    /*
+    Adapt the K value based on the number of games played
+    as an attempt to reduce the annoyance of smurf accounts for other players in 1000-1100 elo range
+    The idea is that you can quickly have a good first impression of one player's skill level on their first games.
+    */
+    const dynamicK = min(this.K)(123 - 70 * Math.log(nbGamesPlayed))
+    return Math.round(current + dynamicK * (actual - expected))
   }
 }

--- a/app/core/elo.ts
+++ b/app/core/elo.ts
@@ -20,9 +20,9 @@ export function computeElo(
       const expectedScore = eloEngine.getExpected(previousElo, plyr.elo)
       //logger.debug("against ", plyr.name, "expected", expectedScoreA)
       if (rank < plyr.rank) {
-        eloGains.push(eloEngine.updateRating(expectedScore, 1, previousElo))
+        eloGains.push(eloEngine.updateRating(expectedScore, 1, previousElo, player.games))
       } else {
-        eloGains.push(eloEngine.updateRating(expectedScore, 0, previousElo))
+        eloGains.push(eloEngine.updateRating(expectedScore, 0, previousElo, player.games))
       }
     }
   })

--- a/app/models/colyseus-models/after-game-player.ts
+++ b/app/models/colyseus-models/after-game-player.ts
@@ -24,6 +24,7 @@ export default class AfterGamePlayer
   @type("uint8") rank: number
   @type([PokemonRecord]) pokemons = new ArraySchema<IPokemonRecord>()
   @type("uint16") elo: number
+  @type("uint16") games: number
   @type("string") title: string
   @type("string") role: Role
   @type([SampleSynergy]) synergies = new ArraySchema<{
@@ -46,6 +47,7 @@ export default class AfterGamePlayer
       | Array<{ name: Synergy; value: number }>
       | ArraySchema<{ name: Synergy; value: number }>,
     elo: number,
+    games: number,
     moneyEarned: number,
     playerDamageDealt: number,
     rerollCount: number
@@ -58,6 +60,7 @@ export default class AfterGamePlayer
     this.title = title
     this.role = role
     this.elo = elo
+    this.games = games
     this.moneyEarned = moneyEarned
     this.playerDamageDealt = playerDamageDealt
     this.rerollCount = rerollCount

--- a/app/models/colyseus-models/game-user.ts
+++ b/app/models/colyseus-models/game-user.ts
@@ -8,6 +8,7 @@ export interface IGameUser {
   ready: boolean
   isBot: boolean
   elo: number
+  games: number
   title: string
   role: Role
   anonymous: boolean
@@ -19,6 +20,7 @@ export class GameUser extends Schema implements IGameUser {
   @type("boolean") ready: boolean
   @type("boolean") isBot: boolean
   @type("uint16") elo: number
+  @type("uint16") games: number
   @type("string") title: string
   @type("string") role: Role
   @type("boolean") anonymous: boolean
@@ -27,6 +29,7 @@ export class GameUser extends Schema implements IGameUser {
     uid: string,
     name: string,
     elo: number,
+    games: number,
     avatar: string,
     isBot: boolean,
     ready: boolean,
@@ -41,6 +44,7 @@ export class GameUser extends Schema implements IGameUser {
     this.ready = ready
     this.isBot = isBot
     this.elo = elo
+    this.games = games
     this.title = title
     this.role = role
     this.anonymous = anonymous

--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -85,6 +85,7 @@ export default class Player extends Schema implements IPlayer {
   @type(["string"]) items = new ArraySchema<Item>()
   @type("uint8") rank: number
   @type("uint16") elo: number
+  @type("uint16") games: number // number of games played on this account
   @type("boolean") alive = true
   @type([HistoryItem]) history = new ArraySchema<HistoryItem>()
   @type({ map: "uint8" }) pokemonCustoms: PokemonCustoms =
@@ -137,6 +138,7 @@ export default class Player extends Schema implements IPlayer {
     id: string,
     name: string,
     elo: number,
+    games: number,
     avatar: string,
     isBot: boolean,
     rank: number,
@@ -150,6 +152,7 @@ export default class Player extends Schema implements IPlayer {
     this.spectatedPlayerId = id
     this.name = name
     this.elo = elo
+    this.games = games
     this.avatar = avatar
     this.isBot = isBot
     this.rank = rank

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -232,6 +232,7 @@ export default function Game() {
       room?.state.players.forEach((p) => {
         const afterPlayer: IAfterGamePlayer = {
           elo: p.elo,
+          games: p.games,
           name: p.name,
           id: p.id,
           rank: p.rank,

--- a/app/public/src/pages/utils/date.ts
+++ b/app/public/src/pages/utils/date.ts
@@ -24,7 +24,9 @@ export function formatDuration(seconds: number) {
   seconds -= hours * 3600
   const minutes = Math.floor(seconds / 60)
   seconds -= minutes * 60
+  //@ts-ignore: https://github.com/microsoft/TypeScript/issues/60608
   if (Intl && Intl.DurationFormat) {
+    //@ts-ignore: https://github.com/microsoft/TypeScript/issues/60608
     return new Intl.DurationFormat(i18n.language, { style: "long" }).format({ days, hours, minutes, seconds });
   }
   return `${days > 0 ? days + " days" : ""}${hours > 0 ? hours + " hours" : ""}${minutes > 0 ? minutes + " min" : ""}${seconds > 0 ? seconds + " s" : ""}`.trim()

--- a/app/rooms/after-game-room.ts
+++ b/app/rooms/after-game-room.ts
@@ -38,6 +38,7 @@ export default class AfterGameRoom extends Room<AfterGameState> {
           plyr.role,
           plyr.synergies,
           plyr.elo,
+          plyr.games,
           plyr.moneyEarned,
           plyr.playerDamageDealt,
           plyr.rerollCount

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -111,6 +111,7 @@ export class OnJoinCommand extends Command<
             u.uid,
             u.displayName,
             u.elo,
+            u.games,
             u.avatar,
             false,
             false,
@@ -689,6 +690,7 @@ export class InitializeBotsCommand extends Command<
                 bot.id,
                 bot.name,
                 bot.elo,
+                99, // arbitrary number of games played
                 bot.avatar,
                 true,
                 true,
@@ -787,6 +789,7 @@ export class OnAddBotCommand extends Command<PreparationRoom, OnAddBotPayload> {
             bot.id,
             bot.name,
             bot.elo,
+            99, // arbitrary number of games played
             bot.avatar,
             true,
             true,

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -201,6 +201,7 @@ export default class GameRoom extends Room<GameState> {
             user.uid,
             user.name,
             user.elo,
+            user.games + 1, // already counting this new game
             user.avatar,
             true,
             this.state.players.size + 1,
@@ -219,6 +220,7 @@ export default class GameRoom extends Room<GameState> {
               user.uid,
               user.displayName,
               user.elo,
+              user.games + 1, // already counting this new game
               user.avatar,
               false,
               this.state.players.size + 1,
@@ -985,6 +987,7 @@ export default class GameRoom extends Room<GameState> {
         inventory: Item[]
       }>(),
       elo: player.elo,
+      games: player.games,
       synergies: [],
       title: player.title,
       role: player.role

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -206,6 +206,7 @@ export interface IGameState extends Schema {
 
 export interface ISimplePlayer {
   elo: number
+  games: number
   name: string
   id: string
   rank: number

--- a/app/utils/orientation.ts
+++ b/app/utils/orientation.ts
@@ -1,4 +1,4 @@
-import Board, { Cell } from "../core/board"
+import { Board, Cell } from "../core/board"
 import { PokemonEntity } from "../core/pokemon-entity"
 import { Orientation } from "../types/enum/Game"
 

--- a/db-commands/test-elo.ts
+++ b/db-commands/test-elo.ts
@@ -1,4 +1,0 @@
-import { EloEngine } from "../app/core/elo-engine"
-
-const elo = new EloEngine()
-console.log(elo.updateRating(elo.getExpected(1000, 1468), 1, 1000))


### PR DESCRIPTION
The K-factor is the multiplier applied on elo formula that establish the amount of elo you win or lose in a single game. It is currently set as K=32, that is a maximum and minimum of 32 elo gained or lost per game.

As an attempt to reduce the annoyance of smurf accounts for other players in 1000-1100 elo range, I propose to change the factor so that elo gains are more important for the first ranked games of a fresh new account. The idea is that you can quickly have a good first impression of one player's skill level on their first games.

I propose this formula:
K = 123 - 70 * log(N) , down to a minimum of 32
N being the number of ranked games played

After 20 games, K will stay at 32, so it only impacts the first 20 ranked games of an account. 

https://discord.com/channels/737230355039387749/1404514365406969868