### PR TITLE
Fix multiple account creation

### DIFF
--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -442,7 +442,7 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
     }
   }
 
-  async onJoin(client: Client, options: any, auth: any) {
+  async onJoin(client: Client) {
     const user = await UserMetadata.findOne({ uid: client.auth.uid })
     try {
       if (user?.banned) {
@@ -472,9 +472,8 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
         throw new Error("consented leave")
       }
       await this.allowReconnection(client, 30)
-      // if reconnected, dispatch the same event as if the user had joined to send them the initial data
-      const user = this.users.get(client.auth.uid) ?? null
-      this.dispatcher.dispatch(new OnJoinCommand(), { client, user })
+      // if reconnected, trigger the onJoin logic again to send them the initial data
+      this.onJoin(client)
     } catch (error) {
       this.dispatcher.dispatch(new OnLeaveCommand(), { client })
     }


### PR DESCRIPTION
tryfix for https://discord.com/channels/737230355039387749/1407017100358189056

hypothesis: reconnection after lobby disconnect where user stored in memory is not found for some reason: https://github.com/keldaanCommunity/pokemonAutoChess/blob/0b6681b5cd10e249884ab5204ea939f55f5eae4c/app/rooms/custom-lobby-room.ts#L477 ; that cause UserMetadata.create to be called in onJoinCommand

I replaced it with a onJoin() call that fetch user from database instead from memory. This way, we ensure to not create another entry if a previous entry with that uid exists in database