### PR TITLE
Add Moltres back as weather settler

### DIFF
--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -5431,6 +5431,7 @@ export class Moltres extends Pokemon {
   maxPP = 100
   range = 2
   skill = Ability.OVERHEAT
+  passive = Passive.SUN
 }
 
 export class GalarianMoltres extends Pokemon {

--- a/app/public/dist/client/changelog/patch-6.5.md
+++ b/app/public/dist/client/changelog/patch-6.5.md
@@ -19,6 +19,7 @@
 - Nerf Hitmonlee: Attack 28 → 26
 - Nerf Doduo line: PP 80 → 85
 - Nerf Bounce (Mantyke): damage 10/20/40 → 10/20/30
+- Moltres new passive: change weather to Zenith
 
 # Changes to Synergies
 

--- a/app/public/src/pages/component/wiki/wiki-weather.tsx
+++ b/app/public/src/pages/component/wiki/wiki-weather.tsx
@@ -71,7 +71,7 @@ export default function WikiWeather() {
 }
 
 const pokemonsInfluencingWeather = new Map([
-  [Weather.SUN, [Pkm.HO_OH, Pkm.SOLROCK, Pkm.CASTFORM_SUN]],
+  [Weather.SUN, [Pkm.HO_OH, Pkm.MOLTRES, Pkm.SOLROCK, Pkm.CASTFORM_SUN]],
   [Weather.NIGHT, [Pkm.LUNATONE, Pkm.SHADOW_LUGIA]],
   [Weather.WINDY, [Pkm.LUGIA, Pkm.LANDORUS, Pkm.THUNDURUS, Pkm.TORNADUS, Pkm.ENAMORUS]],
   [Weather.MISTY, [Pkm.ENAMORUS, Pkm.XERNEAS]],


### PR DESCRIPTION
Moltres new passive: change weather to Zenith

Just for the symetry with other Legendary bird trio. Zenith is overly represented in weather settlers but i think its okay