### PR TITLE
make speed influence projectile travel time

### DIFF
--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -1,6 +1,6 @@
 import Player from "../models/colyseus-models/player"
 import { IPokemonEntity } from "../types"
-import { PROJECTILE_SPEED } from "../types/Config"
+import { BASE_PROJECTILE_SPEED } from "../types/Config"
 import delays from "../types/delays.json"
 import { EffectEnum } from "../types/enum/Effect"
 import { PokemonActionState } from "../types/enum/Game"
@@ -136,6 +136,6 @@ export function getAttackTimings(pokemon: IPokemonEntity): {
     pokemon.positionX,
     pokemon.positionY
   )
-  const travelTime = (distance * 1000) / PROJECTILE_SPEED
+  const travelTime = (distance * 1000) / (BASE_PROJECTILE_SPEED * (1 + speed / 100))
   return { delayBeforeShoot, travelTime, attackDuration }
 }

--- a/app/public/dist/client/changelog/patch-6.5.md
+++ b/app/public/dist/client/changelog/patch-6.5.md
@@ -60,6 +60,7 @@
 
 # Gameplay
 
+- Speed stat now also influences projectile travel time for ranged attackers, from 3 tiles per second at 0 speed to 12 tiles per second at 300 speed.
 - Ranked matches elo ranges updated: 0-1100, 1050-1150, 1100-1250, 1200-1350, 1300+
 - Aquatic no longer increase Curse delay ; instead, when curse status is cleared, the remaining time + 1 second is stored in memory, and will be used if Curse status is reapplied again
 

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -2845,7 +2845,7 @@
 	},
 	"stat_description": {
 		"ATK": "Damage inflicted on each basic attack",
-		"SPEED": "Frequency of attacks, movement speed and cooldown times. Maximum 300.",
+		"SPEED": "Influences the frequency of attacks, projectiles travel time, movement speed and cooldown times. Maximum 300.",
 		"CRIT_CHANCE": "Critical hits deal 2x more damage. Abilities cannot crit by default. Crit chance over 100% is converted to Crit power.",
 		"CRIT_POWER": "Multiplier for critical hits damage, healing and buffs",
 		"DEF": "Reduces PHYSICAL received",

--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -121,12 +121,6 @@ export default class BattleManager {
   }
 
   clear() {
-    this.group.getChildren().forEach((p) => {
-      const pkm = p as PokemonSprite
-      if (pkm.projectile) {
-        pkm.projectile.destroy()
-      }
-    })
     this.group.clear(true, true)
     this.boardEventSprites = new Array(BOARD_WIDTH * BOARD_HEIGHT).fill(null)
     this.pokemonSprites.clear()

--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -90,7 +90,6 @@ export default class PokemonSprite extends DraggableObject {
   ap: number
   life: number | undefined
   shield: number | undefined
-  projectile: GameObjects.Sprite | undefined
   itemsContainer: ItemsContainer
   orientation: Orientation
   action: PokemonActionState

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -441,7 +441,7 @@ export const INACTIVITY_TIMEOUT = 60 * 1000 * 30 // 30 minutes
 export const DEFAULT_SPEED = 50
 export const DEFAULT_CRIT_CHANCE = 10
 export const DEFAULT_CRIT_POWER = 2
-export const PROJECTILE_SPEED = 4
+export const BASE_PROJECTILE_SPEED = 3
 
 export const StageDuration: Record<number | "DEFAULT", number> = {
   0: 23, // adjusted for treasure town theme


### PR DESCRIPTION
Speed stat now also influences projectile travel time for ranged attackers, from 3 tiles per second at 0 speed to 12 tiles per second at 300 speed.

idea from:
https://discord.com/channels/737230355039387749/1409159284238979095/1409258478479872111