### PR TITLE
parse rotation as parameter minifix

### DIFF
--- a/app/public/src/game/components/abilities-animations.ts
+++ b/app/public/src/game/components/abilities-animations.ts
@@ -388,7 +388,7 @@ const staticAnimation: AbilityAnimationMaker<{ x: number; y: number }> =
           options.x + (options?.positionOffset?.[0] ?? 0),
           options.y + (options?.positionOffset?.[1] ?? 0)
         ],
-        options
+        {... options, rotation}
       )
     }, delay)
   }


### PR DESCRIPTION
only adding the rotation parameter so functions like `onCaster` run properly again

https://github.com/user-attachments/assets/02510bf7-69bd-44c7-830e-726026177563

