### PR TITLE
Added Falinks to 6.5 News Poster

### DIFF
--- a/app/public/dist/client/changelog/summary/summary-6.5.md
+++ b/app/public/dist/client/changelog/summary/summary-6.5.md
@@ -32,6 +32,7 @@
 ![Orbeetle](https://raw.githubusercontent.com/PMDCollab/SpriteCollab/master/portrait/0826/Normal.png)
 ![Pachirisu](https://raw.githubusercontent.com/PMDCollab/SpriteCollab/master/portrait/0417/Normal.png)
 ![Buzzwole](https://raw.githubusercontent.com/PMDCollab/SpriteCollab/master/portrait/0794/Normal.png)
+![Falinks](https://raw.githubusercontent.com/PMDCollab/SpriteCollab/master/portrait/0870/Normal.png)
 
 
 ## Adjustments for ranked matches


### PR DESCRIPTION
Under News, Falinks was not listed as new pokemon added this patch. This commit simply adds him to the 6.5 description found within the game