### PR TITLE
Fix Flying Press description grammar

### DIFF
--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -1687,7 +1687,7 @@
 		"MISTY_SURGE": "Restore [25,SP] HP and [25,SP] PP to all FAIRY allies except the user.",
 		"SKY_ATTACK": "Rise in the air and fall on the farthest target after 1 second, dealing [120,SP] SPECIAL.",
 		"SKY_ATTACK_SHADOW": "Rise in the air and fall on the farthest target after 1 second, dealing [120,SP] SPECIAL. Can crit by default.",
-		"FLYING_PRESS": "Dived down onto the farthest target from the sky, dealing [50,SP]% of the user's max HP as SPECIAL.",
+		"FLYING_PRESS": "Dives down onto the farthest target from the sky, dealing [50,SP]% of the user's max HP as SPECIAL.",
 		"ILLUSION": "The user recovers [30,50,70,SP=0.5] HP and copies the appearance, ATK, DEF, SPE_DEF and RANGE of the target.",
 		"SLUDGE": "Throw trash at the 3 enemy Pokémon in front of the user to inflict [2,3,4] stacks of POISONNED for [3,SP] seconds.",
 		"SLUDGE_WAVE": "Throw a spray of waste on the target and ADJACENT enemy Pokémon, dealing [10,20,40,SP] SPECIAL and inflict POISONNED for [2,3,4,SP] seconds.",


### PR DESCRIPTION
Fixed a grammatical error in which Hawlucha's Flying Press description read "dived down onto..." rather than "dives down onto"