### PR TITLE
Fix HeadSmash and CrabHammer not executing

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -676,7 +676,7 @@ export class CrabHammerStrategy extends AbilityStrategy {
     super.process(pokemon, board, target, crit)
     let attackType = AttackType.SPECIAL
     if (target.life / target.hp < 0.3) {
-      damage = target.life
+      damage = 9999
       attackType = AttackType.TRUE
     }
     target.handleSpecialDamage(damage, board, attackType, pokemon, crit)
@@ -1863,8 +1863,10 @@ export class HeadSmashStrategy extends AbilityStrategy {
     }
 
     if (target.status.sleep || target.status.freeze) {
+      damage = 9999
+      
       target.handleSpecialDamage(
-        target.life,
+        damage,
         board,
         AttackType.TRUE,
         pokemon,


### PR DESCRIPTION
Replaced the damage clause in Head Smash and Crab Hammer with the damage clause from Sheer Cold and Horn Drill. If an execute is to be triggered, set damage to 9999 rather than target life, to prevent edge cases where shield prevents execution. 

This is in relation to the bug report here: https://discord.com/channels/737230355039387749/1420560703965630594