### PR TITLE
frequency of zygarde passive - minifix

### DIFF
--- a/app/core/effects/passives.ts
+++ b/app/core/effects/passives.ts
@@ -568,7 +568,7 @@ class ZygardeCellsEffect extends PeriodicEffect {
         )
       },
       Passive.ZYGARDE,
-      1000
+      1800 // match frequency of the DelayedCommand
     )
   }
 }


### PR DESCRIPTION
The frequency of the passive is 1s.
The frequency of the `DelayedCommand` is 1.8s.
Since it uses the current `cellsCount`, the evolution is triggered earlier and the stat changes are applied twice.