### PR TITLE
Display pokemon names when hovering portraits/avatars

### DIFF
--- a/app/public/src/pages/component/pokemon-portrait.tsx
+++ b/app/public/src/pages/component/pokemon-portrait.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react"
 import { Emotion } from "../../../../types"
 import { getAvatarSrc, getPortraitSrc } from "../../../../utils/avatar"
 import { cc } from "../utils/jsx"
+import {  PkmByIndex } from "../../../../types/enum/Pokemon"
+import { useTranslation } from "react-i18next"
 
 interface PortraitOptions {
   index: string
@@ -16,7 +18,8 @@ type Props = (
   React.ImgHTMLAttributes<HTMLImageElement>
 
 export default function PokemonPortrait(props: Props) {
-  let src
+  const { t } = useTranslation()
+  let src: string
   if ("avatar" in props) {
     src = getAvatarSrc(props.avatar)
   } else {
@@ -44,9 +47,21 @@ export default function PokemonPortrait(props: Props) {
     }
   }
 
+  const pokemonName = () => {
+    if ("avatar" in props) {
+      return PkmByIndex[props.avatar]
+    }
+    const portrait = props.portrait
+    if (typeof portrait === "object") {
+      return PkmByIndex[portrait.index]
+    }
+    return PkmByIndex[portrait]
+  }
+  
   return (
     <img
       src={imgSrc}
+      title={t(`pkm.${pokemonName}`)}
       loading="lazy"
       className={cc("pokemon-portrait", className || "")}
       onError={handleError}


### PR DESCRIPTION
I've been missing this feature specially on the game history section, where I want to hover the pokemons from my team and see their names on the portraits, like the synergies.
<img width="1041" height="376" alt="image" src="https://github.com/user-attachments/assets/48780176-d4d9-405d-b161-9b3350cda7c9" />
