### PR TITLE
refactor afterSimulationStart into onSimulationStartEffect

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -13013,9 +13013,7 @@ export class EncoreStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, board, target, crit)
-    const abilitiesCasted = (
-      pokemon.refToBoardPokemon as IPokemon & { abilitiesCasted?: Ability[] }
-    ).abilitiesCasted
+    const abilitiesCasted = pokemon.team === Team.BLUE_TEAM ? pokemon.simulation.blueAbilitiesCasted : pokemon.simulation.redAbilitiesCasted
     const lastAbilityUsed = abilitiesCasted?.findLast(
       (ability) =>
         ability !== Ability.ENCORE && AbilityStrategies[ability]?.copyable

--- a/app/core/abilities/ability-strategy.ts
+++ b/app/core/abilities/ability-strategy.ts
@@ -1,9 +1,7 @@
-import { Item } from "../../types/enum/Item"
+import { Team } from "../../types/enum/Game"
 import { min } from "../../utils/number"
-import { values } from "../../utils/schemas"
 import type { Board } from "../board"
 import { OnAbilityCastEffect } from "../effects/effect"
-import { ItemEffects } from "../effects/items"
 import { PokemonEntity } from "../pokemon-entity"
 
 export class AbilityStrategy {
@@ -30,5 +28,11 @@ export class AbilityStrategy {
     pokemon.getEffects(OnAbilityCastEffect).forEach((effect) => {
       effect.apply(pokemon, board, target, crit)
     })
+
+    if (pokemon.team === Team.BLUE_TEAM) {
+      pokemon.simulation.blueAbilitiesCasted.push(pokemon.skill)
+    } else if (pokemon.team === Team.RED_TEAM) {
+      pokemon.simulation.redAbilitiesCasted.push(pokemon.skill)
+    }
   }
 }

--- a/app/core/effects/effect.ts
+++ b/app/core/effects/effect.ts
@@ -1,6 +1,8 @@
+import { MapSchema } from "@colyseus/schema"
 import Player from "../../models/colyseus-models/player"
 import { Pokemon } from "../../models/colyseus-models/pokemon"
 import GameRoom from "../../rooms/game-room"
+import { IPokemonEntity } from "../../types"
 import { Ability } from "../../types/enum/Ability"
 import { EffectEnum } from "../../types/enum/Effect"
 import { AttackType } from "../../types/enum/Game"
@@ -8,6 +10,7 @@ import { Item } from "../../types/enum/Item"
 import { Passive } from "../../types/enum/Passive"
 import type { Board } from "../board"
 import { PokemonEntity } from "../pokemon-entity"
+import Simulation from "../simulation"
 
 type EffectOrigin = EffectEnum | Item | Passive | Ability
 
@@ -24,7 +27,9 @@ export abstract class Effect {
 
 // applied on fight start or when spawning
 export class OnSpawnEffect extends Effect {
-  constructor(effect?: (entity: PokemonEntity, player?: Player, isSpawn?: boolean) => void) {
+  constructor(
+    effect?: (entity: PokemonEntity, player?: Player, isSpawn?: boolean) => void
+  ) {
     super(effect)
   }
   override apply(entity: PokemonEntity, player?: Player, isSpawn?: boolean) { }
@@ -49,7 +54,6 @@ export class OnItemGainedEffect extends Effect { }
 
 export class OnItemRemovedEffect extends Effect { }
 
-
 interface OnStageStartEffectArgs {
   player: Player
   pokemon?: Pokemon
@@ -62,6 +66,21 @@ export class OnStageStartEffect extends Effect {
     super(effect)
   }
   apply(args: OnStageStartEffectArgs) { }
+}
+
+interface OnSimulationStartEffectArgs {
+  simulation: Simulation
+  player: Player
+  team: MapSchema<IPokemonEntity>
+  entity: IPokemonEntity
+}
+
+// applied after simulation started, when the board is fully set up
+export class OnSimulationStartEffect extends Effect {
+  constructor(effect?: (args: OnSimulationStartEffectArgs) => void) {
+    super(effect)
+  }
+  apply(args: OnSimulationStartEffectArgs) { }
 }
 
 interface OnItemDroppedEffectArgs {
@@ -148,8 +167,8 @@ export class PeriodicEffect extends Effect {
 }
 
 interface OnHitEffectArgs {
-  attacker: PokemonEntity,
-  target: PokemonEntity,
+  attacker: PokemonEntity
+  target: PokemonEntity
   board: Board
   totalTakenDamage: number
   physicalDamage: number
@@ -160,7 +179,10 @@ interface OnHitEffectArgs {
 // applied after every successful basic attack (not dodged or protected)
 export class OnHitEffect extends Effect {
   apply(params: OnHitEffectArgs) { }
-  constructor(effect?: (params: OnHitEffectArgs) => void, origin?: EffectOrigin) {
+  constructor(
+    effect?: (params: OnHitEffectArgs) => void,
+    origin?: EffectOrigin
+  ) {
     super(effect, origin)
   }
 }
@@ -270,7 +292,6 @@ export class OnMoveEffect extends Effect {
     super(effect, origin)
   }
 }
-
 
 // applied after taking a hit that removed all the remaining shield
 interface OnShieldDepletedEffectArgs {

--- a/app/core/effects/passives.ts
+++ b/app/core/effects/passives.ts
@@ -1,4 +1,5 @@
 import { PokemonClasses } from "../../models/colyseus-models/pokemon"
+import { SynergyEffects } from "../../models/effects"
 import PokemonFactory from "../../models/pokemon-factory"
 import { Transfer } from "../../types"
 import { BOARD_HEIGHT, BOARD_WIDTH } from "../../types/Config"
@@ -14,15 +15,16 @@ import {
 import { Passive } from "../../types/enum/Passive"
 import { Pkm, PkmIndex } from "../../types/enum/Pokemon"
 import { Synergy, SynergyArray } from "../../types/enum/Synergy"
+import { Weather } from "../../types/enum/Weather"
 import { removeInArray } from "../../utils/array"
 import { isOnBench } from "../../utils/board"
 import { distanceC } from "../../utils/distance"
 import { min } from "../../utils/number"
-import { chance } from "../../utils/random"
+import { chance, pickRandomIn } from "../../utils/random"
 import { values } from "../../utils/schemas"
 import { AbilityStrategies } from "../abilities/abilities"
 import { Board, Cell } from "../board"
-import { PokemonEntity } from "../pokemon-entity"
+import { getStrongestUnit, PokemonEntity } from "../pokemon-entity"
 import { DelayedCommand } from "../simulation-command"
 import {
   Effect,
@@ -34,6 +36,7 @@ import {
   OnKillEffect,
   OnMoveEffect,
   OnShieldDepletedEffect,
+  OnSimulationStartEffect,
   OnSpawnEffect,
   OnStageStartEffect,
   PeriodicEffect
@@ -397,7 +400,7 @@ const ToxicSpikesEffect = new OnDamageReceivedEffect(({ pokemon, board }) => {
             y: pokemon.positionY + y,
             value:
               board.cells[
-                board.columns * pokemon.positionY + y + pokemon.positionX + x
+              board.columns * pokemon.positionY + y + pokemon.positionX + x
               ]
           })
         }
@@ -647,6 +650,233 @@ const ogerponMaskDropEffect = (
     }
   }, mask)
 
+const PyukumukuExplodeOnDeathEffect = new OnDeathEffect(({ pokemon, board }) => {
+  pokemon.broadcastAbility({ skill: Ability.EXPLOSION })
+  const adjcells = board.getAdjacentCells(
+    pokemon.positionX,
+    pokemon.positionY
+  )
+  const damage = Math.round(0.5 * pokemon.hp)
+  adjcells.forEach((cell) => {
+    if (cell.value && pokemon.team != cell.value.team) {
+      cell.value.handleSpecialDamage(
+        damage,
+        board,
+        AttackType.SPECIAL,
+        pokemon,
+        false
+      )
+    }
+  })
+})
+
+const comfeyEquipOnSimulationStartEffect = new OnSimulationStartEffect(
+  ({ simulation, team, entity }) => {
+    const alliesWithFreeSlots = values(team).filter(
+      (p) =>
+        p.name !== Pkm.COMFEY &&
+        p.items.size < 3 &&
+        p.refToBoardPokemon.canHoldItems
+    )
+
+    if (alliesWithFreeSlots.length > 0) {
+      // Find the minimum distance to any ally with free slots
+      const minDistance = Math.min(
+        ...alliesWithFreeSlots.map((a) =>
+          distanceC(
+            a.positionX,
+            a.positionY,
+            entity.positionX,
+            entity.positionY
+          )
+        )
+      )
+      // Filter allies at the shortest distance
+      const nearestAllies = alliesWithFreeSlots.filter(
+        (a) =>
+          distanceC(
+            a.positionX,
+            a.positionY,
+            entity.positionX,
+            entity.positionY
+          ) === minDistance
+      )
+
+      const holder = getStrongestUnit(nearestAllies)
+
+      // delete comfey
+      team.delete(entity.id)
+      simulation.board.setEntityOnCell(
+        entity.positionX,
+        entity.positionY,
+        undefined
+      )
+      if (simulation.blueDpsMeter.has(entity.id)) {
+        simulation.blueDpsMeter.delete(entity.id)
+      }
+      if (simulation.redDpsMeter.has(entity.id)) {
+        simulation.redDpsMeter.delete(entity.id)
+      }
+
+      holder.addItem(Item.COMFEY)
+    }
+  }
+)
+
+const conversionEffect = new OnSimulationStartEffect(
+  ({ simulation, player, entity }) => {
+    const opponent =
+      simulation.bluePlayerId === player.id
+        ? simulation.redPlayer
+        : simulation.bluePlayer
+    if (!opponent) return
+    const synergyCopied = pickRandomIn(opponent.synergies.getTopSynergies())
+    if (entity.types.has(synergyCopied)) return // does not copy if already has the synergy
+    entity.types.add(synergyCopied)
+    const effect =
+      SynergyEffects[synergyCopied].find((effect) =>
+        opponent.effects.has(effect)
+      ) ?? SynergyEffects[synergyCopied][0]!
+
+    simulation.applyEffect(
+      entity,
+      entity.types,
+      effect,
+      player?.synergies.countActiveSynergies() || 0
+    )
+
+    // when converting to bug, get a clone
+    if (synergyCopied === Synergy.BUG) {
+      const coord = simulation.getClosestFreeCellToPokemonEntity(
+        entity,
+        player.team
+      )
+      if (coord) {
+        const bug = PokemonFactory.createPokemonFromName(
+          entity.name,
+          player
+        )
+        simulation.addPokemon(bug, coord.x, coord.y, player.team, true)
+      }
+    }
+
+    // when converting to dragon, no double synergy but gains the AP/AS/SHIELD based on opponent team
+    if (synergyCopied === Synergy.DRAGON) {
+      const opponentTeam = simulation.getOpponentTeam(player.id)!
+      const dragonLevel = values(opponentTeam).reduce(
+        (acc, p) => acc + (p.types.has(Synergy.DRAGON) ? p.stars : 0),
+        0
+      )
+      if (
+        effect === EffectEnum.DRAGON_SCALES ||
+        effect === EffectEnum.DRAGON_DANCE
+      ) {
+        entity.addShield(dragonLevel * 5, entity, 0, false)
+      }
+      if (effect === EffectEnum.DRAGON_DANCE) {
+        entity.addAbilityPower(dragonLevel, entity, 0, false)
+        entity.addSpeed(dragonLevel, entity, 0, false)
+      }
+    }
+
+    // when converting to ghost, get Dodge chance
+    if (synergyCopied === Synergy.GHOST) {
+      entity.addDodgeChance(0.15, entity, 0, false)
+    }
+
+    // when converting to gourmet, get a Chef hat. Useless but funny
+    if (synergyCopied === Synergy.GOURMET && entity.items.size < 3) {
+      entity.items.add(Item.CHEF_HAT)
+    }
+  }
+)
+
+const spawnPhioneFromAquaEggOnSimulationStartEffect = new OnSimulationStartEffect(
+  ({ entity, simulation, player }) => {
+    if (entity.items.has(Item.AQUA_EGG)) {
+      entity.items.delete(Item.AQUA_EGG)
+      const coord = simulation.getClosestFreeCellToPokemonEntity(
+        entity,
+        entity.team
+      )
+      if (coord) {
+        const phione = PokemonFactory.createPokemonFromName(Pkm.PHIONE, player)
+        simulation.addPokemon(phione, coord.x, coord.y, entity.team, true)
+      }
+    }
+  }
+)
+
+const stonjournerPowerSpotOnSimulationStartEffect = new OnSimulationStartEffect(({ entity, simulation }) => {
+  simulation.board
+    .getAdjacentCells(entity.positionX, entity.positionY)
+    .forEach((cell) => {
+      if (cell.value && cell.value.team === entity.team) {
+        cell.value.addAbilityPower(50, cell.value, 0, false)
+      }
+    })
+})
+
+const treeEffect = new OnSpawnEffect((entity) => {
+  entity.status.tree = true
+  entity.toIdleState()
+})
+
+const inanimateObjectEffect = new OnSpawnEffect((entity) => {
+  entity.status.tree = true
+  entity.status.triggerRuneProtect(30000)
+  entity.toIdleState()
+})
+
+const skarmorySpikesOnSimulationStartEffect = new OnSimulationStartEffect(({ simulation, entity }) => {
+  entity.commands.push(
+    new DelayedCommand(() => {
+      const board = simulation.board
+      const nbSpikes = 12
+      const positions = new Set<string>()
+      for (let i = 0; i < nbSpikes; i++) {
+        let x, y
+        do {
+          x = Math.floor(Math.random() * board.columns)
+          y =
+            Math.floor((Math.random() * board.rows) / 2) +
+            (entity.positionY < 3 ? 3 : 0)
+        } while (positions.has(`${x},${y}`))
+        positions.add(`${x},${y}`)
+
+        board.addBoardEffect(x, y, EffectEnum.SPIKES, simulation)
+        entity.broadcastAbility({
+          skill: Ability.SPIKES,
+          targetX: x,
+          targetY: y
+        })
+      }
+    }, 300)
+  )
+})
+
+class DrySkinPeriodicEffect extends PeriodicEffect {
+  constructor() {
+    super(
+      (pokemon) => {
+        pokemon.handleHeal(8, pokemon, 0, false)
+      },
+      Passive.DRY_SKIN,
+      1000
+    )
+  }
+}
+
+const drySkinOnSpawnEffect = new OnSpawnEffect((entity) => {
+  if (entity.simulation.weather === Weather.RAIN) {
+    entity.effectsSet.add(new DrySkinPeriodicEffect())
+  } else if (entity.simulation.weather === Weather.SANDSTORM) {
+    entity.addDodgeChance(0.25, entity, 0, false)
+  } else if (entity.simulation.weather === Weather.SUN) {
+    entity.addAbilityPower(50, entity, 0, false)
+  }
+})
+
 export const PassiveEffects: Partial<
   Record<Passive, (Effect | (() => Effect))[]>
 > = {
@@ -745,27 +975,7 @@ export const PassiveEffects: Partial<
       board.effects[oldY * board.columns + oldX] = EffectEnum.POISON_GAS
     })
   ],
-  [Passive.PYUKUMUKU]: [
-    new OnDeathEffect(({ pokemon, board }) => {
-      pokemon.broadcastAbility({ skill: Ability.EXPLOSION })
-      const adjcells = board.getAdjacentCells(
-        pokemon.positionX,
-        pokemon.positionY
-      )
-      const damage = Math.round(0.5 * pokemon.hp)
-      adjcells.forEach((cell) => {
-        if (cell.value && pokemon.team != cell.value.team) {
-          cell.value.handleSpecialDamage(
-            damage,
-            board,
-            AttackType.SPECIAL,
-            pokemon,
-            false
-          )
-        }
-      })
-    })
-  ],
+  [Passive.PYUKUMUKU]: [PyukumukuExplodeOnDeathEffect],
   [Passive.BEADS_OF_RUIN]: [
     new OnHitEffect(({ attacker, target }) => {
       target.addSpecialDefense(-1, attacker, 0, false)
@@ -773,5 +983,14 @@ export const PassiveEffects: Partial<
   ],
   [Passive.EMERGENCY_EXIT]: [
     new OnSpawnEffect((pkm) => pkm.addPP(pkm.maxPP, pkm, 0, false))
-  ]
+  ],
+  [Passive.COMFEY]: [comfeyEquipOnSimulationStartEffect],
+  [Passive.CONVERSION]: [conversionEffect],
+  [Passive.MANAPHY]: [spawnPhioneFromAquaEggOnSimulationStartEffect],
+  [Passive.STONJOURNER]: [stonjournerPowerSpotOnSimulationStartEffect, treeEffect],
+  [Passive.WOBBUFFET]: [treeEffect],
+  [Passive.SUDOWOODO]: [treeEffect],
+  [Passive.INANIMATE]: [inanimateObjectEffect],
+  [Passive.SKARMORY]: [skarmorySpikesOnSimulationStartEffect],
+  [Passive.DRY_SKIN]: [drySkinOnSpawnEffect]
 }

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -1707,7 +1707,7 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
   }
 }
 
-export function getStrongestUnit<T extends Pokemon | PokemonEntity>(
+export function getStrongestUnit<T extends Pokemon | IPokemonEntity>(
   pokemons: T[]
 ): T {
   /*

--- a/app/public/dist/client/changelog/patch-6.6.md
+++ b/app/public/dist/client/changelog/patch-6.6.md
@@ -43,6 +43,7 @@
 - Buff Ogerpon WellSpring mask: upon casting, heal ~~40~~ 50 HP and restore ~~20~~ 25 PP to adjacent allies
 - Fix Egg Bomb damaging the same target instead of AoE ; damage 30/60/120 → 25/50/100
 - Teleport (Abra) and Shadow Punch (Golett) special damage is now properly considered as part of the attack damage, which better interacts with Choice Scarf
+- Comfey is now always held by the strongest ally among the nearest allies with a free item slot
 
 # Changes to Synergies
 

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -2813,7 +2813,7 @@
 		"DRIZZLE": "The Pokémon count as 3 for RAIN",
 		"WIND_POWER": "The Pokémon count as 3 for STORM",
 		"GLUTTON": "Permanently gains max HP when eating: 10 HP for each berry, 20 HP for each dish, 30 HP when cooking as a Chef",
-		"COMFEY": "Comfey cannot hold items. At the start of the fight, the nearest ally with a free item slot wears Comfey and gains all its base stats. Comfey casts it's ability at the same time as it's holder. When its holder is KO, Comfey fights on its own.",
+		"COMFEY": "Comfey cannot hold items. At the start of the fight, the STRONGEST nearest ally with a free item slot wears Comfey and gains all its base stats. Comfey casts its ability at the same time as its holder. When its holder is KO, Comfey fights on its own.",
 		"HISUIAN_TYPHLOSION": "The Pokémon inflicts 20% extra damage on a BURN or SILENCE target",
 		"PICKUP": "The Pokémon will start with a random item if it's not holding anything",
 		"CORSOLA": "$t(pkm.CORSOLA) evolves into $t(pkm.GALAR_CORSOLA) after being KO once",

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -374,8 +374,11 @@ export interface IExperienceManager {
 
 export interface ISimulation {
   room: GameRoom
+  board: Board
   id: string
   weather: Weather
+  bluePlayer: IPlayer | undefined
+  redPlayer: IPlayer | undefined
   blueEffects: Set<EffectEnum>
   redEffects: Set<EffectEnum>
   blueTeam: MapSchema<IPokemonEntity>


### PR DESCRIPTION
solves a lot of potential circular imports. The next refactors to come are onSpawn and beforeSimulationStart, then the pokemons.ts file will be clean of complex effects imports