### PR TITLE
Fix Syrup Bomb scaling twice on AP

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -3377,9 +3377,7 @@ export class SyrupBombStrategy extends AbilityStrategy {
     ).sort((a, b) => b.speed - a.speed)[0]
 
     if (highestSpeedEnemy) {
-      const speedDebuff = Math.round(
-        30 * (1 + pokemon.ap / 100) * (crit ? pokemon.critPower : 1)
-      )
+      const speedDebuff = 30
       highestSpeedEnemy.addSpeed(-speedDebuff, pokemon, 1, crit)
       highestSpeedEnemy.handleSpecialDamage(
         damage,


### PR DESCRIPTION
Fix a bug where Syrup Bomb would reduce speed with a value that scaled twice on AP. Now crit and AP only apply to the speed reduction once.