### PR TITLE
Fix Crush Claw default value

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -9631,8 +9631,8 @@ export class CrushClawStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, board, target, crit)
-    const defLoss = [-5, -10][pokemon.stars - 1] ?? -6
-    target.addDefense(defLoss, pokemon, 0, false)
+    const defLoss = [5, 10][pokemon.stars - 1] ?? 10
+    target.addDefense(-defLoss, pokemon, 0, false)
     for (let i = 0; i < 2; i++) {
       target.handleSpecialDamage(
         pokemon.atk,


### PR DESCRIPTION
Fixed an edge case in which Crush Claw returned -6 def dropped on for 3 star casters instead of the max value of -10