### PR TITLE
Fix Thunderous Kick Def drop

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -10548,9 +10548,10 @@ export class ThunderousKickStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, board, target, crit)
     const damage = [20, 40, 60][pokemon.stars - 1] ?? 60
+    const defenseDebuff = 10
 
     target.status.triggerFlinch(4000, pokemon)
-    target.addDefense(-10, pokemon, 1, crit)
+    target.addDefense(-defenseDebuff, pokemon, 1, crit)
     target.handleSpecialDamage(
       damage,
       board,
@@ -10563,7 +10564,7 @@ export class ThunderousKickStrategy extends AbilityStrategy {
       if (cell.value != null && target.id !== cell.value.id) {
         if (cell.value.team !== pokemon.team) {
           cell.value.status.triggerFlinch(4000, pokemon)
-          cell.value.addDefense(-5, pokemon, 1, crit)
+          cell.value.addDefense(-defenseDebuff, pokemon, 1, crit)
           cell.value.handleSpecialDamage(
             damage,
             board,

--- a/app/public/dist/client/changelog/patch-6.6.md
+++ b/app/public/dist/client/changelog/patch-6.6.md
@@ -77,5 +77,6 @@
 - Fix unlocking in Pokédex for Hoopa unbound, Aegislash Blade form and unmasked forms of Ogerpon
 - Bide (Shuckle) now has proper targeting and no longer ignore damage healed
 - Fix Octazooka being unable to crit with reaper's cloth
+- Fix Thunderous Kick reducing half the intended defense of enemies in the path
 
 # Misc


### PR DESCRIPTION
Fixed an issue where enemies within the path of the kick would lose 5 defense instead of the intended 10