### PR TITLE
Fix Force Palm Additional Damage

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -10249,6 +10249,8 @@ export class ForcePalmStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, board, target, crit)
+    const additionalDamage = target.status.paralysis ? 40 : 0
+    const damage = Math.round(60 + target.hp * 0.1 + additionalDamage)
     if (target.status.paralysis) {
       let farthestEmptyCell: Cell | null = null
       effectInLine(board, pokemon, target, (cell) => {
@@ -10263,8 +10265,6 @@ export class ForcePalmStrategy extends AbilityStrategy {
     } else {
       target.status.triggerParalysis(6000, target, pokemon)
     }
-    const additionalDamage = target.status.paralysis ? 40 : 0
-    const damage = Math.round(60 + target.hp * 0.1 + additionalDamage)
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
   }
 }

--- a/app/public/dist/client/changelog/patch-6.6.md
+++ b/app/public/dist/client/changelog/patch-6.6.md
@@ -77,5 +77,6 @@
 - Fix unlocking in Pokédex for Hoopa unbound, Aegislash Blade form and unmasked forms of Ogerpon
 - Bide (Shuckle) now has proper targeting and no longer ignore damage healed
 - Fix Octazooka being unable to crit with reaper's cloth
+- Fix Force Palm always dealing the extra paralyze damage
 
 # Misc


### PR DESCRIPTION
Fixed a clause in which Force Palm always had additional damage because paralysis was given before the check