### PR TITLE
Fix Bone Armor heal AP scaling

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -10968,7 +10968,7 @@ export class BoneArmorStrategy extends AbilityStrategy {
         crit
       )
       if (attack.takenDamage > 0) {
-        pokemon.handleHeal(attack.takenDamage, pokemon, 1, crit)
+        pokemon.handleHeal(attack.takenDamage, pokemon, 0, false)
       }
       if (attack.death) {
         pokemon.addDefense(defBuff, pokemon, 0, false)

--- a/app/public/dist/client/changelog/patch-6.6.md
+++ b/app/public/dist/client/changelog/patch-6.6.md
@@ -80,5 +80,6 @@
 - Fix Thunderous Kick reducing half the intended defense of enemies in the path
 - Fix Force Palm always dealing the extra paralyze damage
 - Fix Vise Grip incorrect description
+- Fix Bone Armor heal scaling on AP twice
 
 # Misc


### PR DESCRIPTION
Fixed a bug in which bone armor heal would scale with AP on damage dealt and then scale again on the heal.