### PR TITLE
Fix Cut Damage

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -11111,8 +11111,8 @@ export class CutStrategy extends AbilityStrategy {
     crit: boolean
   ) {
     super.process(pokemon, board, target, crit)
-    //Deal [30,SP]% of target max HP as special damage. Inflicts WOUND for 5 seconds
-    const damage = 0.3 * target.hp
+    //Deal [40,SP]% of target max HP as special damage. Inflicts WOUND for 5 seconds
+    const damage = 0.4 * target.hp
     target.handleSpecialDamage(damage, board, AttackType.SPECIAL, pokemon, crit)
     target.status.triggerWound(5000, target, pokemon)
   }

--- a/app/public/dist/client/changelog/patch-6.6.md
+++ b/app/public/dist/client/changelog/patch-6.6.md
@@ -55,7 +55,7 @@
 
 # Gameplay
 
-- New weather Murky: reduce Luck by 30% (Ghost are immune), silence duration +30%. Triggered when 8 Ghost Pokémon are on board.
+- New weather Murky: reduce Luck by 30 (Ghost are immune), silence duration +30%. Triggered when 8 Ghost Pokémon are on board.
 
 # UI
 
@@ -80,5 +80,6 @@
 - Fix Thunderous Kick reducing half the intended defense of enemies in the path
 - Fix Force Palm always dealing the extra paralyze damage
 - Fix Vise Grip incorrect description
+- Fix HM Cut dealing reduced damage
 
 # Misc


### PR DESCRIPTION
Despite a buff back in 5.10, the cut damage value was never changed only the description was. Buff damage to 40% instead of 30%.


This is the most recent mention of Cut in patch notes:
https://discord.com/channels/737230355039387749/737230355039387752/1336380222475472946

This is the bug report