### PR TITLE
Fix WoodHammer Recoil Desc

### DIFF
--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -1965,7 +1965,7 @@
 		"SHORE_UP": "Heal for [20,25,SP]% HP, +10% if the weather is SANDSTORM.",
 		"POISON_STING": "Inflict the target with [2,3,4] stacks of POISONNED. Every stack over the max immediately deals [25,50,100,SP] SPECIAL.",
 		"TRANSE": "Comes out of meditation, healing 30% of its max HP and returns to normal form.",
-		"WOOD_HAMMER": "Deal [400,SP]% of ATK as SPECIAL to the target and receive recoil damage equal to 25% of the damage done.",
+		"WOOD_HAMMER": "Deal [400,SP]% of ATK as SPECIAL to the target and receive recoil damage equal to 100% of ATK as PHYSICAL.",
 		"TRICK_OR_TREAT": "The target must give one of its held items to the user. If it has no held item, it is transformed into $t(pkm.MAGIKARP) for [3,SP,ND=1] seconds.",
 		"FREEZING_GLARE": "Deal [20,40,80,SP] SPECIAL to all enemies in a line, with a [50,LK]% chance to FREEZE for 3 seconds",
 		"THUNDEROUS_KICK": "Target is pushed away. It and all enemies on the path are FLINCH for 4 seconds, lose [10,SP] DEF and take [20,40,60,SP] PHYSICAL.",


### PR DESCRIPTION
Fixed a description error with wood hammer in which the recoil was listed as special damage and calculated on damage dealt rather than physical damage

https://discord.com/channels/737230355039387749/1423426603408425021