### PR TITLE
Fix Last Respects timer and Jaw Lock Description

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -13743,7 +13743,7 @@ export class LastRespectsStrategy extends AbilityStrategy {
     // Calculate curse delay with AP and crit scaling
     // Base delays: 1★=8s, 2★=5s, 3★=3s, reduced by AP and crit power
     const curseDelay = min(0)(
-      ([8000, 5000, 3000][pokemon.stars - 1] ?? 3000) *
+      ([10000, 8000, 5000][pokemon.stars - 1] ?? 5000) *
         (1 - (factor * pokemon.ap) / 100) *
         (crit ? 1 - (pokemon.critPower - 1) * factor : 1)
     )

--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -2058,7 +2058,7 @@
 		"EXPANDING_FORCE": "The user gains PSYCHIC_FIELD, or spreads it to a nearby ally. Then its psychic energy reverbates on all allies in a PSYCHIC_FIELD, dealing [10,20,40,SP] SPECIAL to ADJACENT enemies.",
 		"SPITE": "Drains [20,40,60,SP] PP from target and redistributes [20,40,60,SP] PP to ADJACENT allies",
 		"GRUDGE": "SILENCE the target for 3 seconds, then deals [18,36,52,SP] SPECIAL to all enemies affected by SILENCE",
-		"JAW_LOCK": "Bites the target, inflicting LOCKED for 3 seconds and dealing 125% ATK + [10,15,20,SP] SPECIAL. If target is already bitten, also heals [25,50,100,SP] HP.",
+		"JAW_LOCK": "Bites the target, inflicting LOCKED for 3 seconds and dealing [125, SP]% of ATK + [10,15,20,SP] SPECIAL. If target is already bitten, also heals [25,50,100,SP] HP.",
 		"LAST_RESPECTS": "Deals [30,60,90,SP] SPECIAL and CURSE that will KO after [10,8,6,SP=-0.2] seconds. If the target has already CURSE, targets another ADJACENT enemy instead.",
 		"OCTOLOCK": "Deals [30,60,90,SP] SPECIAL. Inflict LOCKED and ARMOR_BREAK for 3 seconds.",
 		"BURNING_JEALOUSY": "Deals [30,50,70,SP] SPECIAL to the target and ADJACENT enemies. Enemies with ATK buffs lose them and suffer BURN for 5 seconds.",


### PR DESCRIPTION
Fix the timer for Last Respects to scale on [10/8/5] seconds instead of [8/5/3]. Jaw Lock now includes AP scaling on the damage from ATK in its description