### PR TITLE
Fix Spicy Extract AP Scaling

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -11713,7 +11713,8 @@ export class SpicyExtractStrategy extends AbilityStrategy {
     super.process(pokemon, board, target, crit)
     //Make 1/2/3 closest allies RAGE for [2,SP] seconds
     const nbAllies = [1, 2, 3][pokemon.stars - 1] ?? 3
-    const rageDuration = 2000
+    const rageDuration = 2000 * (1 + pokemon.ap / 100) *
+          (crit ? 1 + (pokemon.critPower - 1) : 1)
     const allies = board.cells
       .filter<PokemonEntity>(
         (cell): cell is PokemonEntity =>

--- a/app/public/dist/client/changelog/patch-6.6.md
+++ b/app/public/dist/client/changelog/patch-6.6.md
@@ -90,6 +90,7 @@
 - Fix Brick Break description incorrectly not showing the ability inflicts Armor Break
 - Fix Metal Claw description not showing attack buff scaling on AP
 - Fix Salt Cure not scaling on AP
+- Fix Spicy Extract not scaling on AP
 
 # Misc
 


### PR DESCRIPTION
Fixed a bug where spicy extract did not account for AP or crits

https://discord.com/channels/737230355039387749/1423707916149457081

I wondered if you would want reduced AP scaling on this, but figured it would be best to allow you to decide that within the PR