### PR TITLE
Remove Wood Hammer Recoil AP Scaling

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -10432,7 +10432,8 @@ export class WoodHammerStrategy extends AbilityStrategy {
             board,
             AttackType.PHYSICAL,
             pokemon,
-            crit
+            crit,
+            false
           )
         }
       }, 500)

--- a/app/public/dist/client/changelog/patch-6.6.md
+++ b/app/public/dist/client/changelog/patch-6.6.md
@@ -50,6 +50,7 @@
 - Change Plasma Fist: 25% heal from damage before armor reduction -> 30% heal from damage dealt after armor reduction
 - Gholdengo passive is now active when player has reached its max interests, not necessarily 50 gold depending on Amulet coins and Ghimigoul coins
 - Change Frost Breath: Now deals [35, 70, 140] Special Damage
+- Change Wood Hammer: Recoil no longer scales on AP
 
 # Changes to Synergies
 


### PR DESCRIPTION
Disabled AP scaling on wood hammer's recoil damage, per curry's suggestion: https://discord.com/channels/737230355039387749/1423426603408425021/1423665071271444593

Sorry I should have caught this when I made the other Wood Hammer pull request and it slipped my mind