### PR TITLE
Fix Side Arm to match Description

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -10476,7 +10476,7 @@ export class WoodHammerStrategy extends AbilityStrategy {
             board,
             AttackType.PHYSICAL,
             pokemon,
-            crit,
+            false,
             false
           )
         }
@@ -14095,7 +14095,9 @@ export class ShellSideArmStrategy extends AbilityStrategy {
   ) {
     super.process(pokemon, board, target, crit, true)
 
-    const poisonDuration = [2000, 3000][pokemon.stars - 1] ?? 3000
+    const poisonDuration = ([2000, 3000][pokemon.stars - 1] ?? 3000) * 
+    (1 + pokemon.ap / 100) * (crit ? pokemon.critPower : 1)
+    
     const apBoost = [10, 20][pokemon.stars - 1] ?? 20
     const visited = new Set<string>()
     let currentTarget: PokemonEntity | undefined = target
@@ -14120,7 +14122,7 @@ export class ShellSideArmStrategy extends AbilityStrategy {
 
         // Poison enemies, boost allies' AP
         if (currentTarget.team === pokemon.team) {
-          currentTarget.addAbilityPower(apBoost, pokemon, 1, crit)
+          currentTarget.addAbilityPower(apBoost, pokemon, 0, false)
         } else {
           currentTarget.status.triggerPoison(
             poisonDuration,


### PR DESCRIPTION
Changed Side arm so the AP Boost would not scale on user AP and the poison duration would. Also remove crit on wood hammer recoil