### PR TITLE
Allow Gourmet pokemon to Dig

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1371,8 +1371,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
       player.board.forEach((pokemon, pokemonId) => {
         if (
           pokemon.types.has(Synergy.GROUND) &&
-          !isOnBench(pokemon) &&
-          pokemon.items.has(Item.CHEF_HAT) === false
+          !isOnBench(pokemon)
         ) {
           const index =
             (pokemon.positionY - 1) * BOARD_WIDTH + pokemon.positionX


### PR DESCRIPTION
At present, pokemon holding the chef's hat cannot dig. This means cooking pot ground pokemon or explorer kit gourmet pokemon cannot dig. I could not find an explanation for this, and doesn't seem to align with player expectations. 

If this is intended, I apologize but I assumed it was a relic of some previous implementation that should no longer be here.