### PR TITLE
Fix for Useless conditional

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -148,7 +148,7 @@ export default abstract class PokemonState {
       } else if (pokemon.effects.has(EffectEnum.MAX_MELTDOWN)) {
         trueDamagePart += 1.2
       }
-      if (pokemon.items.has(Item.RED_ORB) && target) {
+      if (pokemon.items.has(Item.RED_ORB)) {
         trueDamagePart += 0.25
       }
       if (pokemon.effects.has(EffectEnum.LOCK_ON) && target) {


### PR DESCRIPTION
The correct fix is to remove the redundant `&& target` from the condition at line 151.

- **General approach:** eliminate always-true/always-false subexpressions in conditionals.
- **Best specific fix here:** in `app/core/pokemon-state.ts`, change:
  - `if (pokemon.items.has(Item.RED_ORB) && target) {`
  - to `if (pokemon.items.has(Item.RED_ORB)) {`
- This preserves behavior (since `target` is always truthy at this point) while resolving the CodeQL finding and improving clarity.
- No new imports, methods, or variable definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._