### PR TITLE
Fix for Useless conditional

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -151,7 +151,7 @@ export default abstract class PokemonState {
       if (pokemon.items.has(Item.RED_ORB) && target) {
         trueDamagePart += 0.25
       }
-      if (pokemon.effects.has(EffectEnum.LOCK_ON) && target) {
+      if (pokemon.effects.has(EffectEnum.LOCK_ON)) {
         trueDamagePart += 2.0 * (1 + pokemon.ap / 100)
         pokemon.effects.delete(EffectEnum.LOCK_ON)
       }


### PR DESCRIPTION
The best fix is to simplify the conditional at line 154 by removing `&& target`, since `target` is already guaranteed to exist in this execution path. This keeps behavior unchanged while removing dead logic and satisfying CodeQL.

In `app/core/pokemon-state.ts`, update the `LOCK_ON` block:

- From: `if (pokemon.effects.has(EffectEnum.LOCK_ON) && target) {`
- To: `if (pokemon.effects.has(EffectEnum.LOCK_ON)) {`

No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._