### PR TITLE
Fix for Useless conditional

### DIFF
--- a/edit/add-pokemon.ts
+++ b/edit/add-pokemon.ts
@@ -278,7 +278,7 @@ class SpriteSheetProcessor {
           (m) => m.Name === conf.attack
         )
         if (attackMetadata) {
-          if (attackMetadata && attackMetadata.CopyOf) {
+          if (attackMetadata.CopyOf) {
             attackMetadata =
               xmlData.AnimData.Anims.Anim.find(
                 (m) => m.Name == attackMetadata?.CopyOf


### PR DESCRIPTION
General fix: remove the redundant truthiness test in the nested `if`, keeping only the meaningful condition.

Best fix here: in `edit/add-pokemon.ts`, within `splitIndex(...)`, change:

- `if (attackMetadata && attackMetadata.CopyOf) {`

to:

- `if (attackMetadata.CopyOf) {`

This preserves functionality exactly, because the outer `if (attackMetadata)` already guarantees non-nullish `attackMetadata` in that scope. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._