### PR TITLE
Potential fix for code scanning alert no. 20: Insecure randomness

### DIFF
--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -95,10 +95,10 @@ export default function PreparationMenu() {
   function togglePrivate() {
     if (password === null || password === undefined) {
       // generate a random password made of 4 characters
-      const newPassword = Math.random()
-        .toString(36)
-        .substring(2, 6)
-        .toUpperCase()
+      const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+      const randomBytes = new Uint8Array(4)
+      crypto.getRandomValues(randomBytes)
+      const newPassword = Array.from(randomBytes, (b) => chars[b % chars.length]).join("")
       changeRoomPassword(newPassword)
     } else {
       changeRoomPassword(null)


### PR DESCRIPTION
Potential fix for [https://github.com/keldaanCommunity/pokemonAutoChess/security/code-scanning/20](https://github.com/keldaanCommunity/pokemonAutoChess/security/code-scanning/20)

Use the browser’s cryptographically secure RNG (`crypto.getRandomValues`) instead of `Math.random()` when generating the 4-character room password.

Best fix (without changing existing functionality):
- In `app/public/src/pages/component/preparation/preparation-menu.tsx`, update `togglePrivate()` where `newPassword` is generated.
- Replace `Math.random().toString(36).substring(2, 6).toUpperCase()` with generation from a secure random `Uint8Array`, mapped to the same alphanumeric uppercase charset.
- Keep output length at 4 and keep `changeRoomPassword(newPassword)` unchanged.

No new imports are required since `crypto` is a browser global.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
