### PR TITLE
Potential fix for code scanning alert no. 16: Insecure randomness

### DIFF
--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -1,5 +1,6 @@
 import { Command } from "@colyseus/command"
 import { Client, matchMaker } from "colyseus"
+import { randomBytes } from "crypto"
 import { writeHeapSnapshot } from "v8"
 import {
   BoosterPriceByRarity,
@@ -1090,7 +1091,12 @@ export class OpenGameCommand extends Command<
       roomName = "Smeargle's Scribble"
     } else if (gameMode === GameMode.CUSTOM_LOBBY) {
       ownerId = user.uid
-      password = Math.random().toString(36).substring(2, 6).toUpperCase()
+      const secureCode = randomBytes(4)
+        .toString("base64url")
+        .replace(/[^a-zA-Z0-9]/g, "")
+      password = (secureCode + randomBytes(4).toString("hex"))
+        .substring(0, 4)
+        .toUpperCase()
     } else if (gameMode === GameMode.CLASSIC) {
       roomName = "Classic"
     }


### PR DESCRIPTION
Potential fix for [https://github.com/keldaanCommunity/pokemonAutoChess/security/code-scanning/16](https://github.com/keldaanCommunity/pokemonAutoChess/security/code-scanning/16)

Use Node.js `crypto` CSPRNG instead of `Math.random()` to generate the custom lobby password.

Best fix in this file:
- Add `randomBytes` import from Node `crypto`.
- Replace line 1093 password generation with a secure equivalent that still yields a 4-character uppercase alphanumeric code.

A good minimal-change approach is:
- `randomBytes(3).toString("base64url").replace(/[^a-zA-Z0-9]/g, "").substring(0, 4).toUpperCase()`
- plus a tiny fallback to ensure length is always 4 (in rare filtering cases), e.g. append another secure chunk before truncating.

This keeps functionality (short uppercase room code) while removing insecure randomness.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
