### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/keldaanCommunity/pokemonAutoChess/security/code-scanning/24](https://github.com/keldaanCommunity/pokemonAutoChess/security/code-scanning/24)

To fix this, add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to only what this workflow needs. The best minimal fix without changing functionality is to set:

- `permissions:`
  - `contents: read`

Place this at the workflow root (after `on:` block and before `jobs:`), so it applies to all jobs unless overridden. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
