### PR TITLE
Potential fix for code scanning alert no. 18: DOM text reinterpreted as HTML

### DIFF
--- a/app/public/src/game/components/item-detail.tsx
+++ b/app/public/src/game/components/item-detail.tsx
@@ -18,6 +18,9 @@ import { isIn } from "../../../../utils/array"
 import { addIconsToDescription } from "../../pages/utils/descriptions"
 import "./item-detail.css"
 
+const isValidItem = (value: unknown): value is Item =>
+  Object.values(Item).includes(value as Item)
+
 export function ItemDetailTooltipContent({
   item,
   showItemCombinationsTooltip = true
@@ -26,16 +29,17 @@ export function ItemDetailTooltipContent({
   showItemCombinationsTooltip?: boolean
 }) {
   const { t } = useTranslation()
+  const safeItem = isValidItem(item) ? item : ItemComponents[0]
   const recipes = useMemo(
     () =>
       ItemComponents.map((c) =>
         Object.entries(ItemRecipe).find(
           ([, recipe]) =>
-            (recipe[0] === item && recipe[1] === c) ||
-            (recipe[1] === item && recipe[0] === c)
+            (recipe[0] === safeItem && recipe[1] === c) ||
+            (recipe[1] === safeItem && recipe[0] === c)
         )
       ).filter((r) => r != null),
-    [item]
+    [safeItem]
   )
 
   const formatStat = (stat: Stat, value: number) => {
@@ -60,11 +64,14 @@ export function ItemDetailTooltipContent({
 
   return (
     <div className="game-item-detail">
-      <img className="game-item-detail-icon" src={`assets/item/${item}.png`} />
+      <img
+        className="game-item-detail-icon"
+        src={`assets/item/${safeItem}.png`}
+      />
       <div className="game-item-detail-name">
-        {ItemRecipe[item] && (
+        {ItemRecipe[safeItem] && (
           <div className="game-item-recipe">
-            {ItemRecipe[item]?.map((item, i) => (
+            {ItemRecipe[safeItem]?.map((item, i) => (
               <React.Fragment key={`component_${i}_${item}`}>
                 <img
                   className="game-item-detail-icon"
@@ -76,7 +83,7 @@ export function ItemDetailTooltipContent({
             ))}
           </div>
         )}
-        {t(`item.${item}`)}
+        {t(`item.${safeItem}`)}
       </div>
       <div className="game-item-detail-stats">
         {itemCategoryLabel && <i>{itemCategoryLabel}</i>}
@@ -92,12 +99,13 @@ export function ItemDetailTooltipContent({
         ))}
       </div>
       <p className="game-item-detail-description">
-        {addIconsToDescription(t(`item_description.${item}`))}
+        {addIconsToDescription(t(`item_description.${safeItem}`))}
       </p>
       {recipes.length > 0 && showItemCombinationsTooltip && (
         <div className="game-item-detail-combinations">
           {recipes.map(([result, recipe]) => {
-            const otherComponent = recipe[0] == item ? recipe[1] : recipe[0]
+            const otherComponent =
+              recipe[0] == safeItem ? recipe[1] : recipe[0]
             return (
               <div className="game-item-detail-combination" key={result}>
                 <p>+</p>


### PR DESCRIPTION
Potential fix for [https://github.com/keldaanCommunity/pokemonAutoChess/security/code-scanning/18](https://github.com/keldaanCommunity/pokemonAutoChess/security/code-scanning/18)

Best fix: enforce **runtime allowlist validation** for item values at the UI sink so only known `Item` enum entries are used in URLs/tooltip propagation. This preserves behavior for valid data and safely rejects malformed/untrusted values.

Concretely in `app/public/src/game/components/item-detail.tsx`:
- Add a small helper that validates an unknown value against `Object.values(Item)`.
- Derive a `safeItem` from incoming `item` using that helper, with a safe fallback (`ItemComponents[0]`).
- Use `safeItem` for all `assets/item/...` interpolations and for recipe comparisons where relevant.
- Keep existing functionality for valid enum inputs unchanged.

No import changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
