### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/app/utils/avatar.ts
+++ b/app/utils/avatar.ts
@@ -29,7 +29,11 @@ export function getPkmFromPortraitSrc(src: string): PkmWithCustom | null {
 }
 
 export function getAvatarSrc(avatar: string) {
-  return `/assets/portraits/${avatar.replace(/(\d+)\-/g, "$1/")}.png`
+  const defaultAvatar = `${PkmIndex[Pkm.MAGIKARP]}/${Emotion.NORMAL}`
+  const normalizedAvatar = avatar.replace(/(\d+)\-/g, "$1/")
+  const isValidAvatarPath = /^\d+(?:\/\d+)*(?:\/[A-Z_]+)?$/.test(normalizedAvatar)
+  const safeAvatar = isValidAvatarPath ? normalizedAvatar : defaultAvatar
+  return `/assets/portraits/${safeAvatar}.png`
 }
 
 export function getAvatarString(


### PR DESCRIPTION
Potential fix for [https://github.com/keldaanCommunity/pokemonAutoChess/security/code-scanning/6](https://github.com/keldaanCommunity/pokemonAutoChess/security/code-scanning/6)

General fix: validate and normalize untrusted `avatar` values using a strict allowlist, and fall back to a safe default when invalid. Do this at the URL-construction utility (`getAvatarSrc`) so all call sites are protected without changing behavior elsewhere.

Best targeted fix:
- **File:** `app/utils/avatar.ts`
- **Region:** `getAvatarSrc` (lines around 31–33 in provided snippet)
- Add a small sanitizer that only permits the expected avatar token format (digits separated by `-` and optional `/` segments used by current avatar encoding), strips anything else by rejecting invalid inputs, and returns a known-safe default avatar string when invalid.
- Keep existing output shape (`/assets/portraits/...png`) to preserve functionality.

No new external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
