### PR TITLE
Fix TerrainPulse helping enemy team too

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -14158,6 +14158,7 @@ export class TerrainPulseStrategy extends AbilityStrategy {
     // 1. collect adjacent fields
     board.forEach((x, y, entity) => {
       if (!entity) return
+      if (entity.team !== pokemon.team) return
       const activeField = getFieldEffect(entity)
       if (activeField) {
         pokemonsWithField.set(entity, activeField)


### PR DESCRIPTION
Early exit when traversing the board to get units with field effects if entity is not from the same team as the caster

Bug posted on discord : https://discord.com/channels/737230355039387749/1509966513745170802