### PR TITLE
Handle Crit Reduction for Effect Abilities

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -91,6 +91,10 @@ export default abstract class PokemonState {
         }
       }
 
+      if (target.items.has(Item.ROCKY_HELMET) === true) {
+        reductionFactor = 0
+      }
+
       if (target.effects.has(EffectEnum.WONDER_ROOM)) {
         attackType = AttackType.SPECIAL
       }

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -61,12 +61,15 @@ export default abstract class PokemonState {
         )
         critChance += 0.01 * distance
       }
-      const crit = chance(critChance, pokemon)
-      //declare reduction factor outside for use in spell crit reduction later
-      let reductionFactor = 1.0
+      const crit = chance(critChance, pokemon)      
+
+      const nbBlackAugurite = target.player
+        ? count(target.player.items, Item.BLACK_AUGURITE)
+        : 0
 
       if (crit) {
         if (target.items.has(Item.ROCKY_HELMET) === false) {
+          let reductionFactor = 1.0
           if (target.effects.has(EffectEnum.BATTLE_ARMOR)) {
             reductionFactor -= 0.3
           } else if (target.effects.has(EffectEnum.MOUTAIN_RESISTANCE)) {
@@ -74,10 +77,8 @@ export default abstract class PokemonState {
           } else if (target.effects.has(EffectEnum.DIAMOND_STORM)) {
             reductionFactor -= 0.7
           }
-          const nbBlackAugurite = target.player
-            ? count(target.player.items, Item.BLACK_AUGURITE)
-            : 0
           reductionFactor -= 0.1 * nbBlackAugurite
+          
           const damageWithoutCrit = damage
           const damageAfterCrit = damage * pokemon.critPower
           const critPartOfTheDamage = damageAfterCrit - damageWithoutCrit
@@ -91,9 +92,11 @@ export default abstract class PokemonState {
         }
       }
 
+      
+      let reductionFactor = 1 - 0.1 * nbBlackAugurite
       if (target.items.has(Item.ROCKY_HELMET) === true) {
         reductionFactor = 0
-      }
+      } 
 
       if (target.effects.has(EffectEnum.WONDER_ROOM)) {
         attackType = AttackType.SPECIAL

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -62,10 +62,11 @@ export default abstract class PokemonState {
         critChance += 0.01 * distance
       }
       const crit = chance(critChance, pokemon)
+      //declare reduction factor outside for use in spell crit reduction later
+      let reductionFactor = 1.0
 
       if (crit) {
         if (target.items.has(Item.ROCKY_HELMET) === false) {
-          let reductionFactor = 1.0
           if (target.effects.has(EffectEnum.BATTLE_ARMOR)) {
             reductionFactor -= 0.3
           } else if (target.effects.has(EffectEnum.MOUTAIN_RESISTANCE)) {
@@ -169,11 +170,12 @@ export default abstract class PokemonState {
 
       if (pokemon.effects.has(EffectEnum.TELEPORT_NEXT_ATTACK)) {
         const abilityCrit = pokemon.effects.has(EffectEnum.ABILITY_CRIT) && crit
-        specialDamage += Math.ceil(
+         specialDamage += Math.ceil(
           [15, 30, 60, 120][pokemon.stars - 1] *
             (1 + pokemon.ap / 100) *
-            (abilityCrit ? pokemon.critPower : 1)
+            (abilityCrit ? min(1)(pokemon.critPower * reductionFactor): 1)
         )
+        
         pokemon.effects.delete(EffectEnum.TELEPORT_NEXT_ATTACK)
       }
 
@@ -182,7 +184,7 @@ export default abstract class PokemonState {
         specialDamage += Math.ceil(
           [30, 60, 120][pokemon.stars - 1] *
             (1 + pokemon.ap / 100) *
-            (abilityCrit ? pokemon.critPower : 1)
+            (abilityCrit ? min(1)(pokemon.critPower * reductionFactor): 1)
         )
         pokemon.effects.delete(EffectEnum.SHADOW_PUNCH_NEXT_ATTACK)
       }
@@ -200,7 +202,7 @@ export default abstract class PokemonState {
           (([20, 40, 60][pokemon.stars - 1] ?? 60) +
             nbComfeeAllies * ([10, 20, 30][pokemon.stars - 1] ?? 60)) *
             (1 + pokemon.ap / 100) *
-            (abilityCrit ? pokemon.critPower : 1)
+            (abilityCrit ? min(1)(pokemon.critPower * reductionFactor) : 1)
         )
         pokemon.effects.delete(EffectEnum.ATTACK_ORDER_NEXT_ATTACK)
       }


### PR DESCRIPTION
Updated abilities that apply effects to their user to be reduced by crit reduction if spell crit is enabled. Currently abilities like Teleport are not reduced by crit reducing effects such as rocky helmet