### PR TITLE
Reduce Spell Crit by Augurite

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -406,7 +406,11 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
         specialDamage *= 1.2
       }
       if (crit && attacker && this.items.has(Item.ROCKY_HELMET) === false) {
-        specialDamage *= attacker.critPower
+        const nbBlackAugurite = this.player
+          ? count(target.player.items, Item.BLACK_AUGURITE)
+          : 0
+        let reductionFactor = 1 - 0.1 * nbBlackAugurite
+        specialDamage *= (attacker.critPower * reductionFactor)
       }
       if (
         attacker &&


### PR DESCRIPTION
Reduce all special damage on crit by black augurite, per the conversation: https://discord.com/channels/737230355039387749/1511246856896647288/1511343117947768922

It is worth noting that this doesn't reduce Teleport damage twice, because this code only triggers if crit is true and `handleSpecialDamage` is called with `crit = false` after leaving the attack method in `pokemon-state.ts`

This bug is reported here: https://discord.com/channels/737230355039387749/1511453438460821704