### PR TITLE
Fix Milcery Counting Itself

### DIFF
--- a/app/core/effects/passives.ts
+++ b/app/core/effects/passives.ts
@@ -547,7 +547,7 @@ const MilceryFlavorEffect = new OnStageStartEffect(({ player, pokemon }) => {
         milcery.positionY,
         p.positionX,
         p.positionY
-      ) <= 1
+      ) == 1
   )
   adjacentAllies.forEach((ally) => {
     ally.types.forEach((synergy) => {


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1405181436348334130

Fixed a bug in which milcery counted itself when considering a flavor.

Using Chebyshev distance, assuming all allies' locations are on integer values rather than floats you can assume that changing the distance from `<= 1` to `==1` will only count allies and not milcery whose distance is 0. This should qualify all adjacent allies because this calculation happens between rounds where locations will all be integer values. 

In the occasion where there are no adjacent allies, the code already has a fallback of `VANILLA` flavor so I don't think this will result in any unwanted behavior.