### PR TITLE
Fix Unown reminiscence leaking across locked shops

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1736,6 +1736,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom> {
             } else {
               this.state.shop.refillShop(player, this.state)
               player.shopLocked = false
+              player.unownReminiscences = 0
             }
           }
         }


### PR DESCRIPTION
unownReminiscences is only cleared in Shop.assignShop (the unlocked auto-refresh). When the shop is locked, the round takes the Shop.refillShop path instead, which never clears it, so a pending reminiscence survives the locked round and accumulates with later casts.

Two or more banked reminiscences added to a sub-7 Psychic board reach the effective-7 Transcendence threshold, opening the full Unown shop for a player who never reached Psychic 7. Repeating the lock-and-cast loop banks arbitrarily many.

Consume the pending reminiscence on the locked-shop branch too, so a locked round forfeits it, consistent with locking already forgoing that round's Unown shop.