### PR TITLE
Fix Minior Nomicon interaction

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -418,7 +418,6 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
         attackType === AttackType.SPECIAL
       ) {
         this.status.triggerBurn(3000, this, attacker)
-        this.addSpecialDefense(-1, attacker, 0, false)
       }
 
       const damageResult = this.state.handleDamage({

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -611,6 +611,7 @@ export default abstract class PokemonState {
 
         if (attacker && attacker.items.has(Item.POKEMONOMICON)) {
           pokemon.status.triggerBurn(3000, pokemon, attacker)
+          pokemon.addSpecialDefense(-1, attacker, 0, false)
         }
       }
 


### PR DESCRIPTION
Currently because of the placement of pokenomicon's special defense drop being in handleSpecialDamage, some instances of special damage don't trigger it. One such trigger is Minior, which probably needs to be changed to use the other call but in the meantime this refactor seems preferred to doing a wide review and possibly missing edge cases. 

https://discord.com/channels/737230355039387749/1516308277787623536