### PR TITLE
Update storm wiki entry

### DIFF
--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -3773,7 +3773,7 @@
 		"WINDY": "+10 SPEED (+20 if FLYING)",
 		"RAIN": "+3 PP per second\n-30% BURN and POISONNED damage",
 		"NIGHT": "+10% CRIT_CHANCE\n+30% SLEEP duration",
-		"STORM": "Lightning randomly strikes on the board, dealing 100 SPECIAL (ELECTRIC are immune)\n+30% PARALYSIS duration",
+		"STORM": "Lightning randomly strikes on the board, dealing 100 SPECIAL (ELECTRIC are supercharged instead)\n+30% PARALYSIS duration",
 		"MISTY": "+20% SPECIAL\n+30% CHARM duration",
 		"SNOW": "-10 SPEED if not ICE\n+30% FREEZE duration",
 		"SANDSTORM": "5 SPECIAL per second (GROUND are immune)\n+30% CONFUSION duration",


### PR DESCRIPTION
At present the wiki doesn't say that electric pokemon are supercharged when struck by lightning in storm. This aims to fix that