### PR TITLE
Fix Avalugg Bergmite troopers (shop exclusion + Mountain Gale gate)

### DIFF
--- a/app/core/abilities/mountain-gale.ts
+++ b/app/core/abilities/mountain-gale.ts
@@ -15,6 +15,7 @@ export class MountainGaleStrategy extends AbilityStrategy {
     target: PokemonEntity,
     crit: boolean
   ) {
+    const isFirstCast = pokemon.count.ult === 0
     super.process(pokemon, board, target, crit, true)
     const damage = 40
     const targets: PokemonEntity[] = board
@@ -26,14 +27,13 @@ export class MountainGaleStrategy extends AbilityStrategy {
     }
 
     const nbHits = [1, 3, 5, 10][pokemon.stars - 1] ?? 10
-    const nbBergmites =
-      pokemon.count.ult === 0
-        ? max(MaxTroopersPerPkm[pokemon.name] ?? 0)(
-            [...pokemon.effectsSet.values()].find(
-              (e) => e instanceof BergmiteOnBackEffect
-            )?.stacks ?? 0
-          )
-        : 0
+    const nbBergmites = isFirstCast
+      ? max(MaxTroopersPerPkm[pokemon.name] ?? 0)(
+          [...pokemon.effectsSet.values()].find(
+            (e) => e instanceof BergmiteOnBackEffect
+          )?.stacks ?? 0
+        )
+      : 0
     for (let i = 0; i < nbHits + nbBergmites; i++) {
       const t = pickRandomIn(targets)
       pokemon.commands.push(

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -137,11 +137,10 @@ export class Pokemon extends Schema implements IPokemon {
 
   get final(): boolean {
     /* true if should be excluded from shops when obtained */
+    if (this.passive === Passive.CORSOLA || this.passive === Passive.AVALUGG)
+      return false
     return (
-      !this.hasEvolution ||
-      (this.evolutionRule.type !== EvolutionRuleType.COUNT &&
-        this.passive !== Passive.CORSOLA &&
-        this.passive !== Passive.AVALUGG)
+      !this.hasEvolution || this.evolutionRule.type !== EvolutionRuleType.COUNT
     )
   }
 


### PR DESCRIPTION
Passive.AVALUGG was non-functional due to two independent bugs:

- Pokemon.final returned true for Avalugg because the Corsola/Avalugg passive exemption sat behind the !hasEvolution short-circuit, and both Avalugg forms are terminal. A finished Avalugg was therefore treated as a final line, removing Bergmite from the shop so troopers could never be bought. Move the exemption ahead of the short-circuit (Corsola behaviour unchanged: its only holder evolves via a non-COUNT rule and was already non-final).

- MountainGaleStrategy gated the trooper hits on count.ult === 0, but the base AbilityStrategy.process increments count.ult first, so the check was always false and bench Bergmites added zero hits. Capture the first-cast state before super.process runs.