### PR TITLE
Fix Ceaseless Edge being unable to crit by default

### DIFF
--- a/app/core/abilities/ceaseless-edge.ts
+++ b/app/core/abilities/ceaseless-edge.ts
@@ -5,6 +5,7 @@ import type { PokemonEntity } from "../pokemon-entity"
 import { AbilityStrategy } from "./ability-strategy"
 
 export class CeaselessEdgeStrategy extends AbilityStrategy {
+  canCritByDefault = true
   process(
     pokemon: PokemonEntity,
     board: Board,


### PR DESCRIPTION
Ability cannot crit by default, contrary to the description in-game.