### PR TITLE
Fix Urshifu cast crit by default

### DIFF
--- a/app/core/abilities/surging-strikes.ts
+++ b/app/core/abilities/surging-strikes.ts
@@ -5,6 +5,7 @@ import { DelayedCommand } from "../simulation-command"
 import { AbilityStrategy } from "./ability-strategy"
 
 export class SurgingStrikesStrategy extends AbilityStrategy {
+  canCritByDefault = true
   process(
     pokemon: PokemonEntity,
     board: Board,

--- a/app/core/abilities/wicked-blow.ts
+++ b/app/core/abilities/wicked-blow.ts
@@ -4,6 +4,7 @@ import type { PokemonEntity } from "../pokemon-entity"
 import { AbilityStrategy } from "./ability-strategy"
 
 export class WickedBlowStrategy extends AbilityStrategy {
+  canCritByDefault = true
   process(
     pokemon: PokemonEntity,
     board: Board,


### PR DESCRIPTION
Surging Strikes always crits, but without crit by default it will interact with reaper's cloth incorrectly. Same with wicked blow