### PR TITLE
Recover stuck pokemon sprites

### DIFF
--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -71,6 +71,7 @@ const spriteCountPerPokemon = new Map<string, number>()
 
 export function resetSpriteCounts() {
   spriteCountPerPokemon.clear()
+  for (const index in lazyLoadingRequests) delete lazyLoadingRequests[index]
 }
 
 const isGameScene = (scene: Phaser.Scene): scene is GameScene =>
@@ -1682,6 +1683,13 @@ export function loadCompressedAtlas(
     return lazyLoadingRequests[index]
   }
   lazyLoadingRequests[index] = new Promise((resolve) => {
+    const onError = (file: Phaser.Loader.File) => {
+      if (file.key !== `pokemon-atlas-${index}` && file.key !== index) return
+      scene.load.off("loaderror", onError)
+      delete lazyLoadingRequests[index]
+      resolve(index)
+    }
+    scene.load.on("loaderror", onError)
     scene.load.once(
       `filecomplete-json-pokemon-atlas-${index}`,
       (key, type, data) => {
@@ -1750,6 +1758,7 @@ export function loadCompressedAtlas(
         const index = image.replace(".png", "")
 
         scene.textures.once(`addtexture-${index}`, () => {
+          scene.load.off("loaderror", onError)
           delete lazyLoadingRequests[index]
           resolve(index)
         })


### PR DESCRIPTION
loadCompressedAtlas caches its in-flight promise in lazyLoadingRequests and only deletes the entry on a successful texture load. If a load doesn't complete (a network error, or the 5s scene.load.xhr.timeout firing when the asset server is overloaded), the promise stays pending forever and every later sprite of that index gets stuck awaiting it for the rest of the page session. This is the bug where pokemon sprites get stuck as the pokeball placeholder, which players currently work around by reloading the page.

- drop the cache entry on loaderror so a later sprite re-issues the load and recovers on its own
- clear lazyLoadingRequests in resetSpriteCounts(), since a scene restart aborts in-flight loads without firing their completion events.