### PR TITLE
Fix player cycling hotkeys to follow displayed rank order

### DIFF
--- a/app/public/dist/client/changelog/patch-6.11.md
+++ b/app/public/dist/client/changelog/patch-6.11.md
@@ -76,6 +76,8 @@ Added a fourth tier (or fifth tier ?) of ability power per unit star level to al
 
 # Bugfix
 
+- Previous/next player board hotkeys now follow the same order as the right-side player list.
+
 # Misc
 
 - New title: Five Stars

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -117,15 +117,22 @@ export function getGameContainer(): GameContainer {
 }
 
 export function cyclePlayers(amt: number) {
-  const players = schemaValues(gameContainer.room?.state.players)
-  playerClick(
-    players[
-      (players.findIndex((p) => p === gameContainer.player) +
-        amt +
-        players.length) %
-        players.length
-    ].id
+  const players = schemaValues(gameContainer.room?.state.players).sort(
+    (a, b) => {
+      return a.rank - b.rank
+    }
   )
+  const currentPlayerIndex = players.findIndex(
+    (p) => p.id === gameContainer.player?.id
+  )
+
+  if (players.length === 0 || currentPlayerIndex < 0) {
+    return
+  }
+
+  const nextPlayer =
+    players[(currentPlayerIndex + amt + players.length) % players.length]
+  playerClick(nextPlayer.id)
 }
 
 export function playerClick(id: string) {


### PR DESCRIPTION
## Summary

This updates the previous/next player board hotkeys so they cycle through players in the same order shown in the right-side player list.

Previously, the hotkeys used the raw player map order, which could differ from the displayed player order. This made Page Up / Page Down feel inconsistent, unintuitive and confusing during games.

## Changes

- Sort players by `rank` before cycling with previous/next player hotkeys
- Dead players are still included in the cycle
- Add a guard so cycling does nothing if the current spectated player cannot be found for some reason

P.S. Not sure under which category to add the change in the patch notes. I added it under bugfix for now.