### PR TITLE
Fix Rollout AP Scaling

### DIFF
--- a/app/core/abilities/rollout.ts
+++ b/app/core/abilities/rollout.ts
@@ -20,7 +20,8 @@ export class RolloutStrategy extends AbilityStrategy {
       board,
       AttackType.SPECIAL,
       pokemon,
-      crit
+      false,
+      false
     )
   }
 }


### PR DESCRIPTION
Rollout currently will crit on the damage and scales with AP where it should not. The crit and ap scaling should only apply to the defense buff according to the ability description