### PR TITLE
Fix duplicate opponent sprites leaking from the portal transition

### DIFF
--- a/app/public/src/game/components/board-manager.ts
+++ b/app/public/src/game/components/board-manager.ts
@@ -1303,7 +1303,7 @@ export default class BoardManager {
 
           // show the opponent pokemons
           opponent.board.forEach((pokemon) => {
-            if (isOnBench(pokemon)) return
+            if (simulation?.started || isOnBench(pokemon)) return
             const [x, y] = transformEntityCoordinates(
               pokemon.positionX,
               pokemon.positionY - 1,
@@ -1439,7 +1439,7 @@ export default class BoardManager {
         )
         if (!opponent) return
         opponent.board.forEach((pokemon) => {
-          if (isOnBench(pokemon)) return
+          if (simulation?.started || isOnBench(pokemon)) return
           const pokemonSprite = new PokemonSprite(
             this.scene,
             portalX,


### PR DESCRIPTION
The portal transition shows a preview of the opponent's board by creating board sprites for each opponent unit, inside a deferred callback (a tween onComplete for the red player, a setTimeout for the blue player). These previews are only cleared by removePokemonsOnBoard(), which runs when the simulation starts. Combat start is delayed ~2.5s (the portal animation), so normally the previews are created first and cleared at start, but if the deferred callback runs after the fight has already started (a slow/janky transition, or a replay seeking into an ongoing fight), the previews are created after the cleanup and never removed, causing a duplicate, static copy of every enemy to sit on its starting tile for the rest of the fight, in addition to the animated combat sprites.

Fix: Skip creating the preview once simulation.started is true in both branches.