### PR TITLE
Fix Dark melee units missing their adjusted opening cooldown

### DIFF
--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -206,15 +206,16 @@ export class PokemonEntity extends Schema implements IPokemonEntity {
     this.shieldDamageTaken = 0
     this.healDone = 0
     this.shieldDone = 0
+
+    pokemon.types.forEach((type) => {
+      this.types.add(type)
+    })
+
     if (this.types.has(Synergy.DARK) && this.range === 1) {
       this.cooldown = 300 // ensure dark assassins move first
     } else {
       this.resetCooldown(500)
     }
-
-    pokemon.types.forEach((type) => {
-      this.types.add(type)
-    })
 
     this.passive = Passive.NONE
     this.changePassive(pokemon.passive)

--- a/app/public/dist/client/changelog/patch-6.11.md
+++ b/app/public/dist/client/changelog/patch-6.11.md
@@ -76,6 +76,8 @@ Added a fourth tier (or fifth tier ?) of ability power per unit star level to al
 
 # Bugfix
 
+- Fix DARK melee Pokémon not receiving their intended shorter opening cooldown before jumping.
+
 # Misc
 
 - New title: Five Stars


### PR DESCRIPTION
## Summary

Dark melee units were intended to receive a shorter opening cooldown so they can usually move first at the start of combat, but the check was running before the battle entity had copied its synergies from the source Pokemon.

As a result, the condition was always false during construction, even when the source Pokemon already had the Dark synergy.

This moves the existing pokemon.types copy before the first read of this.types.

## Testing

I tested this locally before and after the fix and recorded both cases (you can check the videos below).

For the test setup, I created a custom bot team with its units arranged in a 3x3 box in the corner (no speed items). The enemy board included fast melee units at the edges, including Poliwrath, Samurott, and Feraligatr. My team used Dark melee units that were slower than those Water units.

Before the fix, the enemy Poliwrath, Samurott, and Feraligatr began moving first, and the Dark units only jumped after those enemy units had already left their starting positions. This made the Dark opening jump behave like it was using the normal initial cooldown.

After the fix, the enemy formation stayed in its original 3x3 box long enough for the Dark units to jump first. This should match the intended behavior here.

https://github.com/user-attachments/assets/1856b0c5-4ef3-4961-b7ac-8c6d1b9ba37a


https://github.com/user-attachments/assets/d2d571a6-6903-4bf7-a9b7-d42a09c3eb70

