### PR TITLE
Fix Powder possibly restoring speed to the wrong unit

### DIFF
--- a/app/core/abilities/powder.ts
+++ b/app/core/abilities/powder.ts
@@ -41,25 +41,26 @@ export class PowderStrategy extends AbilityStrategy {
           positionX: cell.x,
           positionY: cell.y
         })
-        if (cell.value) {
-          if (cell.value.team !== pokemon.team) {
+        const debuffedUnit = cell.value
+        if (debuffedUnit) {
+          if (debuffedUnit.team !== pokemon.team) {
             // Enemy: take damage and reduce SPEED
-            cell.value.handleSpecialDamage(
+            debuffedUnit.handleSpecialDamage(
               damage,
               board,
               AttackType.SPECIAL,
               pokemon,
               crit
             )
-            const speedNerf = max(cell.value.speed)(
+            const speedNerf = max(debuffedUnit.speed)(
               speedFactor *
                 (1 + pokemon.ap / 100) *
                 (crit ? pokemon.critPower : 1)
             )
-            cell.value.addSpeed(-speedNerf, pokemon, 0, false)
-            cell.value.commands.push(
+            debuffedUnit.addSpeed(-speedNerf, pokemon, 0, false)
+            debuffedUnit.commands.push(
               new DelayedCommand(() => {
-                cell.value?.addSpeed(speedNerf, pokemon, 0, false)
+                debuffedUnit.addSpeed(speedNerf, pokemon, 0, false)
               }, 5000)
             )
           }

--- a/app/public/dist/client/changelog/patch-6.11.md
+++ b/app/public/dist/client/changelog/patch-6.11.md
@@ -76,6 +76,8 @@ Added a fourth tier (or fifth tier ?) of ability power per unit star level to al
 
 # Bugfix
 
+- Fix Powder's SPEED debuff not always being restored to the correct Pokémon after movement.
+
 # Misc
 
 - New title: Five Stars


### PR DESCRIPTION
## Summary
 Powder reduced SPEED on `cell.value`, but the delayed restore also referenced `cell.value`. If the affected Pokémon moved before the restore timer expired, the restore could miss the original target or apply to a different Pokémon that moved into that cell.

## Fix
Capture the debuffed `PokemonEntity` at cast time and schedule the restore on that entity directly.