### PR TITLE
elo adjustments

### DIFF
--- a/app/core/elo.ts
+++ b/app/core/elo.ts
@@ -1,5 +1,5 @@
 import type { ISimplePlayer } from "../types"
-import { GameMode } from "../types/enum/Game"
+import type { GameMode } from "../types/enum/Game"
 import { average, min } from "../utils/number"
 import { EloEngine } from "./elo-engine"
 
@@ -33,15 +33,8 @@ export function computeElo(
 
   let newElo = min(0)(Math.floor(average(...eloGains)))
   //logger.debug("mean gain", meanGain)
-  if (
-    rank <= Math.floor(players.length / 2) &&
-    newElo < previousElo &&
-    !isBot
-  ) {
-    newElo = previousElo // ensure to not lose ELO if you're on the upper part of the ranking
-  }
-  if (rank === 1 && gameMode === GameMode.RANKED) {
-    newElo = min(previousElo + 1)(newElo) // ensure you get minimum +1 if finishing first
+  if (rank <= Math.floor(players.length / 2) && !isBot) {
+    newElo = min(previousElo + 1)(newElo) // ensure you get minimum +1 if you're on the upper part of the ranking
   }
 
   if (

--- a/app/public/dist/client/changelog/patch-6.11.md
+++ b/app/public/dist/client/changelog/patch-6.11.md
@@ -107,6 +107,13 @@ Added a fourth tier (or fifth tier ?) of ability power per unit star level to al
 - Fix DARK melee Pokémon not receiving their intended shorter opening cooldown before jumping.
 - Fix BURN damage not being applied when the source of the status is not a Pokémon, like embers board effect (thanks Thomas)
 
+# Elo adjustments
+
+> We are experiencing slow Elo deflation with the anti-smurfing measures and the decrease in the number of new players, so we're making small adjustments to counterbalance that. +0 never felt good anyway. We are also removing the overlaps which were initially intended to streamline lobby filling but ended up causing friction, as players in the overlap had an advantage over the others.
+
+- Minimum elo gain when you're on the upper part of the ranking (top 4 on a regular 8 player lobby with no disconnect) raised from +0 to +1 elo (same as first place)
+- Ranked games elo ranges adjusted to remove elo overlaps: 0-1099 → 0-1050 ; 1050-1200 → 1050-1150 ; 1150-1299 → 1150-1250
+
 # Misc
 
 - Rune Protect status is renamed to Safeguard

--- a/app/rooms/commands/lobby-commands.ts
+++ b/app/rooms/commands/lobby-commands.ts
@@ -590,23 +590,23 @@ export class JoinOrOpenRoomCommand extends Command<
         let maxRank = EloRank.BEAST_BALL
         switch (userRank) {
           case EloRank.LEVEL_BALL:
-          case EloRank.NET_BALL:
-            // 0- 1099
+            // 0- 1050
             minRank = EloRank.LEVEL_BALL
-            maxRank = EloRank.NET_BALL
+            maxRank = EloRank.LEVEL_BALL
             break
+          case EloRank.NET_BALL:
           case EloRank.SAFARI_BALL:
-          case EloRank.LOVE_BALL:
-            // 1050-1200
+            // 1050-1150
             minRank = EloRank.NET_BALL
-            maxRank = EloRank.LOVE_BALL
+            maxRank = EloRank.SAFARI_BALL
             break
+          case EloRank.LOVE_BALL:
           case EloRank.PREMIER_BALL:
-          case EloRank.QUICK_BALL:
-            // 1150-1299
+            // 1150-1250
             minRank = EloRank.LOVE_BALL
-            maxRank = EloRank.QUICK_BALL
+            maxRank = EloRank.PREMIER_BALL
             break
+          case EloRank.QUICK_BALL:
           case EloRank.POKE_BALL:
           case EloRank.SUPER_BALL:
           case EloRank.ULTRA_BALL:


### PR DESCRIPTION
We are experiencing slow Elo deflation with the anti-smurfing measures and the decrease in the number of new players, so we're making small adjustments to counterbalance that. +0 never felt good anyway. We are also removing the overlaps which were initially intended to streamline lobby filling but ended up causing friction, as players in the overlap had an advantage over the others.