### PR TITLE
Fix spectators loading a game with no map or music

### DIFF
--- a/app/public/src/game/components/loading-manager.ts
+++ b/app/public/src/game/components/loading-manager.ts
@@ -19,6 +19,7 @@ export default class LoadingManager {
   scene: Phaser.Scene
   loadingBar: GameObjects.Container | null = null
   statusMessage: string
+  ready: Promise<void>
 
   constructor(scene: Phaser.Scene) {
     this.scene = scene
@@ -32,7 +33,7 @@ export default class LoadingManager {
       this.statusMessage = t("loading_complete")
     })
 
-    this.preload()
+    this.ready = this.preload()
   }
 
   async preload() {
@@ -111,6 +112,13 @@ export default class LoadingManager {
 
     // load missingno as default pokemon texture if not found
     loadCompressedAtlas(scene, "0000")
+
+    if (scene instanceof GameScene) {
+      await new Promise<void>((resolve) => {
+        scene.load.once("complete", () => resolve())
+        scene.load.start()
+      })
+    }
   }
 }
 

--- a/app/public/src/game/components/loading-manager.ts
+++ b/app/public/src/game/components/loading-manager.ts
@@ -19,7 +19,7 @@ export default class LoadingManager {
   scene: Phaser.Scene
   loadingBar: GameObjects.Container | null = null
   statusMessage: string
-  ready: Promise<void>
+  preloadingPromise: Promise<void>
 
   constructor(scene: Phaser.Scene) {
     this.scene = scene
@@ -33,7 +33,7 @@ export default class LoadingManager {
       this.statusMessage = t("loading_complete")
     })
 
-    this.ready = this.preload()
+    this.preloadingPromise = this.preload()
   }
 
   async preload() {
@@ -115,6 +115,7 @@ export default class LoadingManager {
 
     if (scene instanceof GameScene) {
       await new Promise<void>((resolve) => {
+        // start another Phaser loading queue after the fetch requests of preloadMaps have been awaited
         scene.load.once("complete", () => resolve())
         scene.load.start()
       })

--- a/app/public/src/game/scenes/game-scene.ts
+++ b/app/public/src/game/scenes/game-scene.ts
@@ -103,18 +103,20 @@ export default class GameScene extends Scene {
 
   preload() {
     resetSpriteCounts()
-    this.loadingManager = new LoadingManager(this)
+    const loadingManager = (this.loadingManager = new LoadingManager(this))
 
     this.load.on("progress", (value: number) => {
       this.room?.send(Transfer.LOADING_PROGRESS, value * 100)
     })
 
-    this.load.once("complete", () => {
-      logger.debug("Loading complete")
-      if (!this.started) {
-        this.room?.send(Transfer.LOADING_COMPLETE)
-      }
-    })
+    loadingManager.ready
+      .catch((err) => logger.error("loading error", err))
+      .then(() => {
+        logger.debug("Loading complete")
+        if (!this.started) {
+          this.room?.send(Transfer.LOADING_COMPLETE)
+        }
+      })
 
     this.room!.onMessage(Transfer.LOADING_COMPLETE, () => {
       if (!this.started) {

--- a/app/public/src/game/scenes/game-scene.ts
+++ b/app/public/src/game/scenes/game-scene.ts
@@ -103,13 +103,13 @@ export default class GameScene extends Scene {
 
   preload() {
     resetSpriteCounts()
-    const loadingManager = (this.loadingManager = new LoadingManager(this))
+    this.loadingManager = new LoadingManager(this)
 
     this.load.on("progress", (value: number) => {
       this.room?.send(Transfer.LOADING_PROGRESS, value * 100)
     })
 
-    loadingManager.ready
+    this.loadingManager!.preloadingPromise
       .catch((err) => logger.error("loading error", err))
       .then(() => {
         logger.debug("Loading complete")


### PR DESCRIPTION
Spectating a live game sometimes loads with a blank map and no music. Reloading fixes it.

The map tilesets and region music are queued in LoadingManager.preload only after preloadMaps's fetch resolves, so they can be added to the loader after its initial run has already completed. Phaser's loader only joins a file to the active run while it's loading, so those late assets never load. The loader's first complete event still fires, the client reports LOADING_COMPLETE, and for a spectator the server echoes it back immediately, so startGame runs before the map and music are ready.

Fix: Report LOADING_COMPLETE only after LoadingManager has finished its full preload