### PR TITLE
Fix spectators joining a game with no player selected

### DIFF
--- a/app/public/src/game/game-container.ts
+++ b/app/public/src/game/game-container.ts
@@ -655,6 +655,7 @@ class GameContainer {
               this.room.state.gameMode
             )[0] ?? players[0]
           if (spectated) {
+            this.room.send(Transfer.SPECTATE, spectated.id)
             this.setPlayer(spectated)
             const simulation = this.room.state.simulations.get(
               spectated.simulationId

--- a/app/public/src/game/game-container.ts
+++ b/app/public/src/game/game-container.ts
@@ -649,16 +649,16 @@ class GameContainer {
       if (this.room.state.players.size > 0) {
         if (!this.player) {
           const players = schemaValues(this.room.state.players)
-          const spectated =
+          const playerToSpectate =
             sortPlayersByRankAndTeam(
               players.filter((p) => p.alive),
               this.room.state.gameMode
             )[0] ?? players[0]
-          if (spectated) {
-            this.room.send(Transfer.SPECTATE, spectated.id)
-            this.setPlayer(spectated)
+          if (playerToSpectate) {
+            this.room.send(Transfer.SPECTATE, playerToSpectate.id)
+            this.setPlayer(playerToSpectate)
             const simulation = this.room.state.simulations.get(
-              spectated.simulationId
+              playerToSpectate.simulationId
             )
             if (simulation) {
               this.setSimulation(simulation)

--- a/app/public/src/game/game-container.ts
+++ b/app/public/src/game/game-container.ts
@@ -48,6 +48,7 @@ import type { DisplayText } from "../../../types/strings/DisplayText"
 import { logger } from "../../../utils/logger"
 import { clamp, max } from "../../../utils/number"
 import { schemaValues } from "../../../utils/schemas"
+import { sortPlayersByRankAndTeam } from "../models/sort-players"
 import { getCachedPortrait } from "../pages/component/game/game-pokemon-portrait"
 import { playSound, SOUNDS } from "../pages/utils/audio"
 import { transformBoardCoordinates } from "../pages/utils/utils"
@@ -315,7 +316,8 @@ class GameContainer {
     this.game.scene.start("gameScene", {
       room: this.room,
       uid: this.uid,
-      spectate: this.spectate
+      spectate: this.spectate,
+      spectatedPlayerId: this.player?.id
     })
     this.game.scale.on("resize", this.resize, this)
     if (this.game.renderer.type === Phaser.WEBGL) {
@@ -645,6 +647,23 @@ class GameContainer {
     if (this.uid === uid) {
       this.spectate = true
       if (this.room.state.players.size > 0) {
+        if (!this.player) {
+          const players = schemaValues(this.room.state.players)
+          const spectated =
+            sortPlayersByRankAndTeam(
+              players.filter((p) => p.alive),
+              this.room.state.gameMode
+            )[0] ?? players[0]
+          if (spectated) {
+            this.setPlayer(spectated)
+            const simulation = this.room.state.simulations.get(
+              spectated.simulationId
+            )
+            if (simulation) {
+              this.setSimulation(simulation)
+            }
+          }
+        }
         this.initializeGame()
       }
     }

--- a/app/public/src/models/sort-players.ts
+++ b/app/public/src/models/sort-players.ts
@@ -1,10 +1,10 @@
 import type { IPlayer } from "../../../types"
 import { GameMode } from "../../../types/enum/Game"
 
-export function sortPlayersByRankAndTeam(
-  players: IPlayer[],
+export function sortPlayersByRankAndTeam<T extends IPlayer>(
+  players: T[],
   gameMode: string
-): IPlayer[] {
+): T[] {
   return [...players].sort((a, b) => {
     if (gameMode === GameMode.DOUBLE_UP) {
       const aAlive = a.life > 0


### PR DESCRIPTION
Joining a game as a spectator from the lobby shows a board, but no player is actually selected. Clicking any avatar fixes it.

GameContainer only learns it is spectating in initializeSpectactor, which runs from spectators.onAdd, after the players.onAdd loop has already run initializePlayer with this.spectate still false. Its spectator branch (this.spectate && !this.player) is not taken for a lobby spectator and setPlayer is never called, so gameContainer.player stays undefined and playerIdSpectated stays empty (replays set spectator in the constructor and do use that branch). A board still appears, because startGame falls back to playerUids[0], but everything keyed off the spectated player does not.

Fix: select a player in initializeSpectactor the same way playerClick does. The selection has to happen before initializeGame. initializeGame now passes spectatedPlayerId into the scene, and startGame reads it in init.

The player is picked with sortPlayersByRankAndTeam over the players still alive, same order as player list.

sortPlayersByRankAndTeam is unchanged apart from being made generic, so it returns Player to this caller instead of IPlayer; game-players.tsx is unaffected.
