### PR TITLE
Load portraits on demand instead of preloading every pokemon index

### DIFF
--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -37,6 +37,7 @@ import type AnimationManager from "../animation-manager"
 import { DEPTH } from "../depths"
 import type GameScene from "../scenes/game-scene"
 import { displayAbility, displayHit } from "./abilities-animations"
+import { loadPortrait } from "./loading-manager"
 import PokemonSprite from "./pokemon"
 import {
   DEFAULT_POKEMON_ANIMATION_CONFIG,
@@ -1275,15 +1276,9 @@ export default class BattleManager {
     }
     const dy = Math.round(50 * (Math.random() - 0.5))
 
-    const image = this.scene.add.existing(
-      new GameObjects.Image(this.scene, 0, 0, `portrait-${index}`)
-        .setScale(0.5, 0.5)
-        .setOrigin(0, 0)
-    )
     const text = this.scene.add.existing(
       new GameObjects.Text(this.scene, 25, 0, amount.toFixed(0), textStyle)
     )
-    image.setDepth(DEPTH.DAMAGE_PORTRAIT)
     text.setDepth(DEPTH.DAMAGE_TEXT)
 
     const container = this.scene.add.existing(
@@ -1291,9 +1286,19 @@ export default class BattleManager {
         this.scene,
         coordinates[0] + 30,
         coordinates[1] + dy,
-        [text, image]
+        [text]
       )
     )
+
+    loadPortrait(this.scene, index).then((loaded) => {
+      if (!loaded || !container.scene) return // popup already faded out
+      container.add(
+        new GameObjects.Image(this.scene, 0, 0, `portrait-${index}`)
+          .setScale(0.5, 0.5)
+          .setOrigin(0, 0)
+          .setDepth(DEPTH.DAMAGE_PORTRAIT)
+      )
+    })
 
     this.scene.add.tween({
       targets: [container],

--- a/app/public/src/game/components/loading-manager.ts
+++ b/app/public/src/game/components/loading-manager.ts
@@ -4,10 +4,8 @@ import type { GameObjects } from "phaser"
 import pkg from "../../../../../package.json"
 import { RegionDetails } from "../../../../config"
 import { getMusicAlt } from "../../../../config/game/music"
-import type Player from "../../../../models/colyseus-models/player"
 import { getPkmWithCustom } from "../../../../models/colyseus-models/pokemon-customs"
 import { DungeonMusic, type DungeonPMDO } from "../../../../types/enum/Dungeon"
-import { PkmIndex } from "../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../../utils/avatar"
 import { schemaValues } from "../../../../utils/schemas"
 import atlas from "../../assets/atlas.json"
@@ -107,7 +105,6 @@ export default class LoadingManager {
           .filter<DungeonPMDO>((map): map is DungeonPMDO => map !== "town")
       )
       preloadMusic(scene, RegionDetails[player.map].music)
-      preloadPortraits(this.scene, player)
     }
 
     // load missingno as default pokemon texture if not found
@@ -186,12 +183,34 @@ export function loadEnvironmentMultiAtlas(scene: Phaser.Scene) {
   )
 }
 
-export function preloadPortraits(scene: Phaser.Scene, player: Player) {
-  Object.values(PkmIndex).forEach((index) => {
-    const pokemonCustom = getPkmWithCustom(index, player.pokemonCustoms)
-    scene.load.image(
-      `portrait-${index}`,
-      getPortraitSrc(index, pokemonCustom.shiny, pokemonCustom.emotion)
-    )
+const portraitLoadingRequests = new Map<string, Promise<boolean>>()
+
+export function loadPortrait(
+  scene: GameScene,
+  index: string
+): Promise<boolean> {
+  const key = `portrait-${index}`
+  if (scene.textures.exists(key)) return Promise.resolve(true)
+  const pending = portraitLoadingRequests.get(key)
+  if (pending) return pending
+
+  const request = new Promise<boolean>((resolve) => {
+    scene.load.once("complete", () => {
+      portraitLoadingRequests.delete(key)
+      resolve(scene.textures.exists(key)) // false if the file failed to load
+    })
+    const roster = scene.room?.state.players
+    const players = roster ? schemaValues(roster) : []
+    const player = players.find((p) => p.id === scene.uid) ?? players[0]
+    const pokemonCustom = getPkmWithCustom(index, player?.pokemonCustoms)
+    scene.load
+      .image(
+        key,
+        getPortraitSrc(index, pokemonCustom.shiny, pokemonCustom.emotion)
+      )
+      .start()
   })
+
+  portraitLoadingRequests.set(key, request)
+  return request
 }

--- a/app/public/src/game/components/wanderers-manager.ts
+++ b/app/public/src/game/components/wanderers-manager.ts
@@ -18,6 +18,7 @@ import { chance } from "../../../../utils/random"
 import { DEPTH } from "../depths"
 import { isReplayRoom } from "../replay-room-id"
 import type GameScene from "../scenes/game-scene"
+import { loadPortrait } from "./loading-manager"
 import PokemonSprite from "./pokemon"
 import PokemonSpecial from "./pokemon-special"
 
@@ -335,11 +336,6 @@ export default class WanderersManager {
       stroke: "#000"
     }
 
-    const image = this.scene.add.existing(
-      new GameObjects.Image(this.scene, 0, 0, `portrait-${index}`)
-        .setScale(0.5, 0.5)
-        .setOrigin(0, 0)
-    )
     const text = this.scene.add.existing(
       new GameObjects.Text(
         this.scene,
@@ -352,7 +348,6 @@ export default class WanderersManager {
         textStyle
       )
     )
-    image.setDepth(DEPTH.TEXT_MINOR)
     text.setDepth(DEPTH.TEXT)
 
     const container = this.scene.add.existing(
@@ -360,9 +355,19 @@ export default class WanderersManager {
         this.scene,
         coordinates[0],
         coordinates[1] - 50,
-        [text, image]
+        [text]
       )
     )
+
+    loadPortrait(this.scene, index).then((loaded) => {
+      if (!loaded || !container.scene) return // popup already faded out
+      container.add(
+        new GameObjects.Image(this.scene, 0, 0, `portrait-${index}`)
+          .setScale(0.5, 0.5)
+          .setOrigin(0, 0)
+          .setDepth(DEPTH.TEXT_MINOR)
+      )
+    })
 
     this.scene.add.tween({
       targets: [container],


### PR DESCRIPTION
`LoadingManager.preload()` queues one `scene.load.image` per `PkmIndex`, ~1178 individual portrait files, on every game load and every refresh, and the cache-first service worker turns each one into a separate Cache Storage write. That is much slower in Firefox than in Chrome, so Firefox players sit on the loading screen for a long time, and because game start waits for the slowest client a single Firefox player holds up the whole lobby. The `portrait-<index>` texture has only two consumers, the damage number in `battle-manager` and the shard gain in `wanderers-manager`, so this loads portraits on first use instead, mirroring what `lazyLoadAnimations` already does for pokemon atlases. Each popup renders its text immediately and adds the portrait once the texture arrives.