### PR TITLE
Fix grammar/typo in english quest reward message

### DIFF
--- a/app/public/dist/client/locales/en/translation.json
+++ b/app/public/dist/client/locales/en/translation.json
@@ -4773,7 +4773,7 @@
 		"tell_price": "{{price}} GOLD each !",
 		"thank_you": "THANK YOU !",
 		"good_job": "Good job !",
-		"here_are_your_reward": "Here are your reward:\n{{reward}}",
+		"here_are_your_reward": "Here are your rewards:\n{{reward}}",
 		"magnemite": "Have you seen the fugitive ?",
 		"magnezone": "Listen, let the police do their job; as soon as I have more information, rest assured you will be the first to know.",
 		"xatu": "Let me open this treasure box for you...",


### PR DESCRIPTION
Fixed a typo `here are your reward` is incorrect grammar. Sorry Chatot :(