### PR TITLE
Allow click-to-carry pokemon and sell with hotkey while held

### DIFF
--- a/app/public/src/game/scenes/game-scene.ts
+++ b/app/public/src/game/scenes/game-scene.ts
@@ -65,6 +65,8 @@ export default class GameScene extends Scene {
   music: Phaser.Sound.WebAudioSound | undefined
   pokemonHovered: PokemonSprite | null = null
   pokemonDragged: PokemonSprite | null = null
+  /** Pokemon stays attached to the cursor after a click (no button hold). */
+  isClickCarrying = false
   shopIndexHovered: number | null = null
   itemDragged: ItemContainer | null = null
   dropSpots: Phaser.GameObjects.Image[] = []
@@ -77,6 +79,10 @@ export default class GameScene extends Scene {
   started: boolean = false
   spectate: boolean = false
   spectatedPlayerId: string | undefined = undefined
+  private dragStartedThisPress = false
+  private skipNextPokemonPickup = false
+  private soldDuringDrag = false
+  private lastClickCarryDropZone: Phaser.GameObjects.Zone | null = null
 
   constructor() {
     super({
@@ -231,6 +237,13 @@ export default class GameScene extends Scene {
     })
 
     this.input.on("pointermove", (pointer) => {
+      if (this.isClickCarrying && this.pokemonDragged) {
+        this.pokemonDragged.x = pointer.worldX
+        this.pokemonDragged.y = pointer.worldY
+        this.updatePokemonDragVisibility()
+        this.updateClickCarryDropHighlight(pointer)
+        return
+      }
       if (!pointer.isDown || this.itemDragged || this.pokemonDragged) return
       const cam = this.cameras.main
       if (cam.zoom === 1 || preference("cameraLocked")) return
@@ -261,23 +274,8 @@ export default class GameScene extends Scene {
         this.buyExperience()
       })
 
-      this.input.keyboard!.on("keydown-" + keybindings.sell, (e) => {
-        if (this.pokemonDragged != null) return
-        if (this.shopIndexHovered !== null) {
-          this.removeFromShop(this.shopIndexHovered)
-          this.shopIndexHovered = null
-        } else if (
-          this.pokemonHovered &&
-          this.pokemonHovered
-            .getBounds()
-            .contains(
-              this.input.activePointer.worldX,
-              this.input.activePointer.worldY
-            )
-        ) {
-          this.sellPokemon(this.pokemonHovered)
-          this.pokemonHovered = null
-        }
+      this.input.keyboard!.on("keydown-" + keybindings.sell, () => {
+        this.sellSelectedPokemon()
       })
 
       this.input.keyboard!.on("keydown-" + keybindings.switch, () => {
@@ -321,6 +319,196 @@ export default class GameScene extends Scene {
   sellPokemon(pokemon: PokemonSprite) {
     if (!pokemon) return
     this.room?.send(Transfer.SELL_POKEMON, pokemon.id)
+  }
+
+  /** Sell the pokemon currently dragged/carried, or the hovered one / shop slot. */
+  sellSelectedPokemon() {
+    if (this.pokemonDragged != null) {
+      if (
+        !canSell(
+          this.pokemonDragged.name as Pkm,
+          this.room?.state.specialGameRule
+        )
+      ) {
+        return
+      }
+
+      const wasClickCarry = this.isClickCarrying
+      this.soldDuringDrag = !wasClickCarry
+      this.sellPokemon(this.pokemonDragged)
+      this.clearPokemonCarryState()
+      if (!wasClickCarry) {
+        this.input.setDragState(this.input.activePointer, 0)
+      }
+      return
+    }
+
+    if (this.shopIndexHovered !== null) {
+      this.removeFromShop(this.shopIndexHovered)
+      this.shopIndexHovered = null
+    } else if (
+      this.pokemonHovered &&
+      this.pokemonHovered
+        .getBounds()
+        .contains(
+          this.input.activePointer.worldX,
+          this.input.activePointer.worldY
+        )
+    ) {
+      this.sellPokemon(this.pokemonHovered)
+      this.pokemonHovered = null
+    }
+  }
+
+  private showPokemonDragUI(pokemon: PokemonSprite) {
+    this.dropSpots.forEach((spot) => {
+      if (
+        this.room?.state.phase === GamePhaseState.PICK ||
+        spot.getData("y") === 0
+      ) {
+        spot.setFrame(0).setVisible(true)
+      }
+    })
+
+    if (
+      this.sellZone &&
+      canSell(pokemon.name as Pkm, this.room?.state.specialGameRule)
+    ) {
+      this.sellZone.showForPokemon(pokemon)
+    }
+  }
+
+  private hidePokemonDragUI() {
+    this.sellZone?.hide()
+    this.useItemZone?.hide()
+    this.dropSpots.forEach((spot) => spot.setVisible(false))
+    if (this.lastClickCarryDropZone?.name === "board-zone") {
+      this.lastClickCarryDropZone.getData("sprite")?.setFrame(0)
+    }
+    this.lastClickCarryDropZone = null
+  }
+
+  private updatePokemonDragVisibility() {
+    if (!this.pokemonDragged) return
+    const pkm = <Pkm>this.pokemonDragged.name
+    const pokemon = new PokemonClasses[pkm](pkm)
+
+    this.dropSpots.forEach((spot) => {
+      const inBench = spot.getData("y") === 0
+      let visible = false
+      if (inBench) {
+        visible = pokemon.canBeBenched
+      } else if (this.room?.state.phase === GamePhaseState.PICK) {
+        visible = true
+      }
+      spot.setVisible(visible)
+    })
+    if (
+      this.sellZone?.visible === false &&
+      canSell(
+        this.pokemonDragged.name as Pkm,
+        this.room?.state.specialGameRule
+      )
+    ) {
+      this.sellZone.setVisible(true)
+    }
+  }
+
+  private clearPokemonCarryState() {
+    this.hidePokemonDragUI()
+    this.isClickCarrying = false
+    this.pokemonDragged = null
+    document.body.classList.remove("grabbing")
+  }
+
+  private startPokemonClickCarry(
+    pokemon: PokemonSprite,
+    pointer: Phaser.Input.Pointer
+  ) {
+    this.isClickCarrying = true
+    this.pokemonDragged = pokemon
+    pokemon.setDepth(DEPTH.DRAGGED_POKEMON)
+    pokemon.x = pointer.worldX
+    pokemon.y = pointer.worldY
+    this.showPokemonDragUI(pokemon)
+    document.body.classList.add("grabbing")
+  }
+
+  private cancelPokemonClickCarry() {
+    if (!this.isClickCarrying || !this.pokemonDragged) return
+    const pokemon = this.pokemonDragged
+    const [x, y] = transformBoardCoordinates(
+      pokemon.positionX,
+      pokemon.positionY
+    )
+    pokemon.setPosition(x, y)
+    pokemon.setDepth(DEPTH.POKEMON)
+    this.clearPokemonCarryState()
+  }
+
+  private findDropZoneAt(
+    pointer: Phaser.Input.Pointer
+  ): Phaser.GameObjects.Zone | null {
+    const carried = this.pokemonDragged
+    if (carried?.input) {
+      carried.input.enabled = false
+    }
+    const hits = this.input.hitTestPointer(pointer)
+    if (carried?.input) {
+      carried.input.enabled = true
+    }
+
+    const zones = hits.filter(
+      (obj): obj is Phaser.GameObjects.Zone =>
+        obj instanceof Phaser.GameObjects.Zone &&
+        (obj.name === "sell-zone" || obj.name === "board-zone")
+    )
+    return (
+      zones.find((zone) => zone.name === "sell-zone") ?? zones[0] ?? null
+    )
+  }
+
+  private updateClickCarryDropHighlight(pointer: Phaser.Input.Pointer) {
+    const zone = this.findDropZoneAt(pointer)
+    if (zone === this.lastClickCarryDropZone) return
+
+    if (this.lastClickCarryDropZone?.name === "sell-zone") {
+      this.sellZone?.onDragLeave()
+    } else if (this.lastClickCarryDropZone?.name === "board-zone") {
+      this.lastClickCarryDropZone.getData("sprite")?.setFrame(0)
+    }
+
+    if (zone?.name === "sell-zone") {
+      this.sellZone?.onDragEnter()
+    } else if (zone?.name === "board-zone") {
+      zone.getData("sprite")?.setFrame(1)
+    }
+
+    this.lastClickCarryDropZone = zone
+  }
+
+  private tryDropClickCarriedPokemon(pointer: Phaser.Input.Pointer) {
+    if (!this.isClickCarrying || !this.pokemonDragged) return
+
+    const pokemon = this.pokemonDragged
+    const dropZone = this.findDropZoneAt(pointer)
+
+    this.skipNextPokemonPickup = true
+    this.isClickCarrying = false
+    document.body.classList.remove("grabbing")
+    this.hidePokemonDragUI()
+
+    if (dropZone) {
+      this.input.emit("drop", pointer, pokemon, dropZone)
+    } else {
+      const [x, y] = transformBoardCoordinates(
+        pokemon.positionX,
+        pokemon.positionY
+      )
+      pokemon.setPosition(x, y)
+      pokemon.setDepth(DEPTH.POKEMON)
+      this.pokemonDragged = null
+    }
   }
 
   useitem(item: Item) {
@@ -420,6 +608,10 @@ export default class GameScene extends Scene {
   }
 
   resetDragState() {
+    if (this.isClickCarrying) {
+      this.cancelPokemonClickCarry()
+      return
+    }
     if (this.pokemonDragged) {
       this.input.emit(
         "dragend",
@@ -479,6 +671,17 @@ export default class GameScene extends Scene {
     }
 
     this.input.on("pointerdown", (pointer) => {
+      this.dragStartedThisPress = false
+
+      if (this.isClickCarrying) {
+        if (pointer.rightButtonDown()) {
+          this.cancelPokemonClickCarry()
+        } else if (pointer.leftButtonDown()) {
+          this.tryDropClickCarriedPokemon(pointer)
+        }
+        return
+      }
+
       if (
         pointer.leftButtonDown() &&
         this.minigameManager &&
@@ -540,29 +743,36 @@ export default class GameScene extends Scene {
     )
 
     this.input.on(
+      Phaser.Input.Events.GAMEOBJECT_POINTER_UP,
+      (pointer, gameObject: Phaser.GameObjects.GameObject) => {
+        if (pointer.rightButtonReleased() || this.spectate) return
+        if (this.skipNextPokemonPickup) {
+          this.skipNextPokemonPickup = false
+          return
+        }
+        if (
+          this.dragStartedThisPress ||
+          this.isClickCarrying ||
+          this.pokemonDragged ||
+          this.itemDragged
+        ) {
+          return
+        }
+        if (gameObject instanceof PokemonSprite && gameObject.draggable) {
+          this.startPokemonClickCarry(gameObject, pointer)
+        }
+      }
+    )
+
+    this.input.on(
       "dragstart",
       (pointer, gameObject: Phaser.GameObjects.GameObject) => {
+        if (this.isClickCarrying) return
+        this.dragStartedThisPress = true
         if (gameObject instanceof PokemonSprite) {
           this.pokemonDragged = gameObject
           this.pokemonDragged.setDepth(DEPTH.DRAGGED_POKEMON)
-          this.dropSpots.forEach((spot) => {
-            if (
-              this.room?.state.phase === GamePhaseState.PICK ||
-              spot.getData("y") === 0
-            ) {
-              spot.setFrame(0).setVisible(true)
-            }
-          })
-
-          if (
-            this.sellZone &&
-            canSell(
-              this.pokemonDragged.name as Pkm,
-              this.room?.state.specialGameRule
-            )
-          ) {
-            this.sellZone.showForPokemon(this.pokemonDragged)
-          }
+          this.showPokemonDragUI(this.pokemonDragged)
         } else if (gameObject instanceof ItemContainer) {
           this.itemDragged = gameObject
           if (this.useItemZone && isIn(Gifts, this.itemDragged.name)) {
@@ -580,32 +790,12 @@ export default class GameScene extends Scene {
         dragX: number,
         dragY: number
       ) => {
+        if (this.isClickCarrying) return
         const g = <Phaser.GameObjects.Container>gameObject
         g.x = dragX
         g.y = dragY
         if (g && this.pokemonDragged != null) {
-          const pkm = <Pkm>this.pokemonDragged!.name
-          const pokemon = new PokemonClasses[pkm](pkm)
-
-          this.dropSpots.forEach((spot) => {
-            const inBench = spot.getData("y") === 0
-            let visible = false
-            if (inBench) {
-              visible = pokemon.canBeBenched
-            } else if (this.room?.state.phase === GamePhaseState.PICK) {
-              visible = true
-            }
-            spot.setVisible(visible)
-          })
-          if (
-            this.sellZone?.visible === false &&
-            canSell(
-              this.pokemonDragged.name as Pkm,
-              this.room?.state.specialGameRule
-            )
-          ) {
-            this.sellZone.setVisible(true)
-          }
+          this.updatePokemonDragVisibility()
         }
       }
     )
@@ -712,6 +902,14 @@ export default class GameScene extends Scene {
     )
 
     this.input.on("dragend", (pointer, gameObject, dropped) => {
+      if (this.soldDuringDrag) {
+        this.soldDuringDrag = false
+        this.hidePokemonDragUI()
+        this.pokemonDragged = null
+        this.itemDragged = null
+        return
+      }
+      if (this.isClickCarrying) return
       this.sellZone?.hide()
       this.useItemZone?.hide()
       this.dropSpots.forEach((spot) => spot.setVisible(false))

--- a/app/public/src/game/scenes/game-scene.ts
+++ b/app/public/src/game/scenes/game-scene.ts
@@ -323,95 +323,99 @@ export default class GameScene extends Scene {
 
   /** Sell the pokemon currently dragged/carried, or the hovered one / shop slot. */
   sellSelectedPokemon() {
-    if (this.pokemonDragged != null) {
-      if (
-        !canSell(
-          this.pokemonDragged.name as Pkm,
-          this.room?.state.specialGameRule
-        )
-      ) {
-        return
-      }
+    if (this.trySellDraggedPokemon()) return
+    if (this.tryRemoveHoveredShopPokemon()) return
+    this.trySellHoveredPokemon()
+  }
 
-      const wasClickCarry = this.isClickCarrying
-      this.soldDuringDrag = !wasClickCarry
-      this.sellPokemon(this.pokemonDragged)
-      this.clearPokemonCarryState()
-      if (!wasClickCarry) {
-        this.input.setDragState(this.input.activePointer, 0)
-      }
-      return
+  private trySellDraggedPokemon(): boolean {
+    const dragged = this.pokemonDragged
+    if (!dragged) return false
+    if (!canSell(dragged.name as Pkm, this.room?.state.specialGameRule)) {
+      return true
     }
 
-    if (this.shopIndexHovered !== null) {
-      this.removeFromShop(this.shopIndexHovered)
-      this.shopIndexHovered = null
-    } else if (
-      this.pokemonHovered &&
-      this.pokemonHovered
-        .getBounds()
-        .contains(
-          this.input.activePointer.worldX,
-          this.input.activePointer.worldY
-        )
-    ) {
-      this.sellPokemon(this.pokemonHovered)
-      this.pokemonHovered = null
-    }
+    const wasClickCarry = this.isClickCarrying
+    this.soldDuringDrag = !wasClickCarry
+    this.sellPokemon(dragged)
+    this.clearPokemonCarryState()
+    if (wasClickCarry) return true
+
+    this.input.setDragState(this.input.activePointer, 0)
+    return true
+  }
+
+  private tryRemoveHoveredShopPokemon(): boolean {
+    if (this.shopIndexHovered === null) return false
+    this.removeFromShop(this.shopIndexHovered)
+    this.shopIndexHovered = null
+    return true
+  }
+
+  private trySellHoveredPokemon(): boolean {
+    const hovered = this.pokemonHovered
+    if (!hovered) return false
+
+    const { worldX, worldY } = this.input.activePointer
+    if (!hovered.getBounds().contains(worldX, worldY)) return false
+
+    this.sellPokemon(hovered)
+    this.pokemonHovered = null
+    return true
+  }
+
+  private canShowDropSpot(spot: Phaser.GameObjects.Image): boolean {
+    return (
+      this.room?.state.phase === GamePhaseState.PICK ||
+      spot.getData("y") === 0
+    )
+  }
+
+  private isDropSpotVisibleForPokemon(
+    spot: Phaser.GameObjects.Image,
+    pokemon: { canBeBenched: boolean }
+  ): boolean {
+    if (spot.getData("y") === 0) return pokemon.canBeBenched
+    return this.room?.state.phase === GamePhaseState.PICK
   }
 
   private showPokemonDragUI(pokemon: PokemonSprite) {
-    this.dropSpots.forEach((spot) => {
-      if (
-        this.room?.state.phase === GamePhaseState.PICK ||
-        spot.getData("y") === 0
-      ) {
-        spot.setFrame(0).setVisible(true)
-      }
-    })
+    this.dropSpots
+      .filter((spot) => this.canShowDropSpot(spot))
+      .forEach((spot) => spot.setFrame(0).setVisible(true))
 
-    if (
-      this.sellZone &&
-      canSell(pokemon.name as Pkm, this.room?.state.specialGameRule)
-    ) {
-      this.sellZone.showForPokemon(pokemon)
-    }
+    if (!this.sellZone) return
+    if (!canSell(pokemon.name as Pkm, this.room?.state.specialGameRule)) return
+    this.sellZone.showForPokemon(pokemon)
   }
 
   private hidePokemonDragUI() {
     this.sellZone?.hide()
     this.useItemZone?.hide()
     this.dropSpots.forEach((spot) => spot.setVisible(false))
-    if (this.lastClickCarryDropZone?.name === "board-zone") {
-      this.lastClickCarryDropZone.getData("sprite")?.setFrame(0)
-    }
+    this.clearClickCarryDropHighlight(this.lastClickCarryDropZone)
     this.lastClickCarryDropZone = null
   }
 
   private updatePokemonDragVisibility() {
     if (!this.pokemonDragged) return
+
     const pkm = <Pkm>this.pokemonDragged.name
     const pokemon = new PokemonClasses[pkm](pkm)
-
     this.dropSpots.forEach((spot) => {
-      const inBench = spot.getData("y") === 0
-      let visible = false
-      if (inBench) {
-        visible = pokemon.canBeBenched
-      } else if (this.room?.state.phase === GamePhaseState.PICK) {
-        visible = true
-      }
-      spot.setVisible(visible)
+      spot.setVisible(this.isDropSpotVisibleForPokemon(spot, pokemon))
     })
+
+    if (this.sellZone?.visible !== false) return
     if (
-      this.sellZone?.visible === false &&
-      canSell(
+      !canSell(
         this.pokemonDragged.name as Pkm,
         this.room?.state.specialGameRule
       )
     ) {
-      this.sellZone.setVisible(true)
+      return
     }
+    this.sellZone.setVisible(true)
   }
 
   private clearPokemonCarryState() {
@@ -434,15 +438,18 @@ export default class GameScene extends Scene {
     document.body.classList.add("grabbing")
   }
 
-  private cancelPokemonClickCarry() {
-    if (!this.isClickCarrying || !this.pokemonDragged) return
-    const pokemon = this.pokemonDragged
+  private returnPokemonToBoardCell(pokemon: PokemonSprite) {
     const [x, y] = transformBoardCoordinates(
       pokemon.positionX,
       pokemon.positionY
     )
     pokemon.setPosition(x, y)
     pokemon.setDepth(DEPTH.POKEMON)
+  }
+
+  private cancelPokemonClickCarry() {
+    if (!this.isClickCarrying || !this.pokemonDragged) return
+    this.returnPokemonToBoardCell(this.pokemonDragged)
     this.clearPokemonCarryState()
   }
 
@@ -450,40 +457,52 @@ export default class GameScene extends Scene {
     pointer: Phaser.Input.Pointer
   ): Phaser.GameObjects.Zone | null {
     const carried = this.pokemonDragged
-    if (carried?.input) {
-      carried.input.enabled = false
-    }
+    const wasEnabled = carried?.input?.enabled ?? true
+    if (carried?.input) carried.input.enabled = false
+
     const hits = this.input.hitTestPointer(pointer)
-    if (carried?.input) {
-      carried.input.enabled = true
-    }
+    if (carried?.input) carried.input.enabled = wasEnabled
 
     const zones = hits.filter(
       (obj): obj is Phaser.GameObjects.Zone =>
         obj instanceof Phaser.GameObjects.Zone &&
         (obj.name === "sell-zone" || obj.name === "board-zone")
     )
-    return (
-      zones.find((zone) => zone.name === "sell-zone") ?? zones[0] ?? null
-    )
+    return zones.find((zone) => zone.name === "sell-zone") ?? zones[0] ?? null
+  }
+
+  private clearClickCarryDropHighlight(
+    zone: Phaser.GameObjects.Zone | null
+  ) {
+    if (!zone) return
+    if (zone.name === "sell-zone") {
+      this.sellZone?.onDragLeave()
+      return
+    }
+    if (zone.name === "board-zone") {
+      zone.getData("sprite")?.setFrame(0)
+    }
+  }
+
+  private applyClickCarryDropHighlight(
+    zone: Phaser.GameObjects.Zone | null
+  ) {
+    if (!zone) return
+    if (zone.name === "sell-zone") {
+      this.sellZone?.onDragEnter()
+      return
+    }
+    if (zone.name === "board-zone") {
+      zone.getData("sprite")?.setFrame(1)
+    }
   }
 
   private updateClickCarryDropHighlight(pointer: Phaser.Input.Pointer) {
     const zone = this.findDropZoneAt(pointer)
     if (zone === this.lastClickCarryDropZone) return
 
-    if (this.lastClickCarryDropZone?.name === "sell-zone") {
-      this.sellZone?.onDragLeave()
-    } else if (this.lastClickCarryDropZone?.name === "board-zone") {
-      this.lastClickCarryDropZone.getData("sprite")?.setFrame(0)
-    }
-
-    if (zone?.name === "sell-zone") {
-      this.sellZone?.onDragEnter()
-    } else if (zone?.name === "board-zone") {
-      zone.getData("sprite")?.setFrame(1)
-    }
-
+    this.clearClickCarryDropHighlight(this.lastClickCarryDropZone)
+    this.applyClickCarryDropHighlight(zone)
     this.lastClickCarryDropZone = zone
   }
 
@@ -500,15 +519,36 @@ export default class GameScene extends Scene {
 
     if (dropZone) {
       this.input.emit("drop", pointer, pokemon, dropZone)
-    } else {
-      const [x, y] = transformBoardCoordinates(
-        pokemon.positionX,
-        pokemon.positionY
-      )
-      pokemon.setPosition(x, y)
-      pokemon.setDepth(DEPTH.POKEMON)
-      this.pokemonDragged = null
+      return
     }
+
+    this.returnPokemonToBoardCell(pokemon)
+    this.pokemonDragged = null
+  }
+
+  private handleClickCarryPointerDown(pointer: Phaser.Input.Pointer): boolean {
+    if (!this.isClickCarrying) return false
+    if (pointer.rightButtonDown()) {
+      this.cancelPokemonClickCarry()
+      return true
+    }
+    if (pointer.leftButtonDown()) {
+      this.tryDropClickCarriedPokemon(pointer)
+    }
+    return true
+  }
+
+  private canStartPokemonClickCarry(
+    gameObject: Phaser.GameObjects.GameObject
+  ): gameObject is PokemonSprite {
+    if (this.skipNextPokemonPickup) {
+      this.skipNextPokemonPickup = false
+      return false
+    }
+    if (this.dragStartedThisPress) return false
+    if (this.isClickCarrying) return false
+    if (this.pokemonDragged || this.itemDragged) return false
+    return gameObject instanceof PokemonSprite && gameObject.draggable
   }
 
   useitem(item: Item) {
@@ -672,15 +712,7 @@ export default class GameScene extends Scene {
 
     this.input.on("pointerdown", (pointer) => {
       this.dragStartedThisPress = false
-
-      if (this.isClickCarrying) {
-        if (pointer.rightButtonDown()) {
-          this.cancelPokemonClickCarry()
-        } else if (pointer.leftButtonDown()) {
-          this.tryDropClickCarriedPokemon(pointer)
-        }
-        return
-      }
+      if (this.handleClickCarryPointerDown(pointer)) return
 
       if (
         pointer.leftButtonDown() &&
@@ -746,21 +778,8 @@ export default class GameScene extends Scene {
       Phaser.Input.Events.GAMEOBJECT_POINTER_UP,
       (pointer, gameObject: Phaser.GameObjects.GameObject) => {
         if (pointer.rightButtonReleased() || this.spectate) return
-        if (this.skipNextPokemonPickup) {
-          this.skipNextPokemonPickup = false
-          return
-        }
-        if (
-          this.dragStartedThisPress ||
-          this.isClickCarrying ||
-          this.pokemonDragged ||
-          this.itemDragged
-        ) {
-          return
-        }
-        if (gameObject instanceof PokemonSprite && gameObject.draggable) {
-          this.startPokemonClickCarry(gameObject, pointer)
-        }
+        if (!this.canStartPokemonClickCarry(gameObject)) return
+        this.startPokemonClickCarry(gameObject, pointer)
       }
     )
 


### PR DESCRIPTION
## Summary
- Clicking a board pokemon now picks it up onto the cursor (no need to hold the mouse button while moving).
- Pressing the sell hotkey (default `E`) sells the currently dragged or click-carried pokemon, not only the hovered one.
- Right-click cancels click-carry and returns the pokemon to its original cell; traditional click-and-drag still works.

## Test plan
- [ ] Click a bench/board pokemon: it should stick to the cursor and show the sell zone
- [ ] Move the cursor and left-click a board cell to place it
- [ ] Click a pokemon, then press `E`: it should sell without dropping on the sell zone
- [ ] Click-and-drag a pokemon (hold button), press `E` mid-drag: it should sell
- [ ] Hover a pokemon and press `E` (existing behavior): it should still sell
- [ ] Right-click while click-carrying: pokemon returns to original spot
- [ ] Confirm traditional drag-drop onto sell zone still sells