### PR TITLE
translation(pt): add missing Portuguese translations

### DIFF
--- a/app/public/dist/client/locales/pt/translation.json
+++ b/app/public/dist/client/locales/pt/translation.json
@@ -567,7 +567,25 @@
 		"CEASELESS_EDGE": "Borda Incessante",
 		"MOUNTAIN_GALE": "Vendaval da Montanha",
 		"TWINEEDLE": "Duplagulhas",
-		"ROCK_WRECKER": "Destruidor de Rochas"
+		"ROCK_WRECKER": "Destruidor de Rochas",
+		"DEFAULT": "Sem Habilidade",
+		"VESPIQUEN_ORDERS": "Ordens de Vespiquen",
+		"DEFEND_ORDER": "Comando de Defesa",
+		"ATTACK_ORDER": "Comando de Ataque",
+		"BUG_BITE": "Mordida de Inseto",
+		"AQUA_STEP": "Passo Aquático",
+		"SNORE": "Ronco",
+		"STUFF_CHEEKS": "Estufar as Bochechas",
+		"SILK_TRAP": "Armadilha de Seda",
+		"SKITTER_SMACK": "Tapa Sorrateiro",
+		"NIGHT_DAZE": "Atordoamento Noturno",
+		"BITTER_MALICE": "Malícia Amarga",
+		"COIL": "Enrosco",
+		"SUBSTITUTE": "Substituto",
+		"SWARM": "Chamado do Enxame",
+		"FLING": "Lançamento",
+		"REVELATION_DANCE": "Dança da Revelação",
+		"THUNDERCLAP_PRESS": "Golpe Trovejante"
 	},
 	"pkm": {
 		"DEFAULT": "MissingNo.",
@@ -1748,7 +1766,24 @@
 		"EISCUE": "Eiscue (Face Gélida)",
 		"EISCUE_NOICE": "Eiscue",
 		"DWEBBLE": "Dwebble",
-		"CRUSTLE": "Crustle"
+		"CRUSTLE": "Crustle",
+		"PIKACHU_LIBRE": "Pikachu Libre",
+		"KECLEON_PURPLE": "Kecleon (Roxo)",
+		"SKWOVET": "Skwovet",
+		"GREEDENT": "Greedent",
+		"QUAXLY": "Quaxly",
+		"QUAXWELL": "Quaxwell",
+		"QUAQUAVAL": "Quaquaval",
+		"KOMALA": "Komala",
+		"TAROUNTULA": "Tarountula",
+		"SPIDOPS": "Spidops",
+		"BUG_NEST": "Ninho de Insetos",
+		"SLITHER_WING": "Slither Wing",
+		"PASSIMIAN": "Passimian",
+		"ORICORIO_BAILE": "Oricorio (Estilo Apaixonado)",
+		"ORICORIO_PA_U": "Oricorio (Estilo Tranquilo)",
+		"ORICORIO_POMPOM": "Oricorio (Estilo Animado)",
+		"ORICORIO_SENSU": "Oricorio (Estilo Refinado)"
 	},
 	"ability_description": {
 		"SOFT_BOILED": "Cura todos os efeitos de status e concede [20,40,80,160,SP] de SHIELD para cada aliado",
@@ -2291,7 +2326,29 @@
 		"CEASELESS_EDGE": "Atinge os 3 inimigos à frente do usuário com [20,40,80,160,SP] de SPECIAL, além de deixar espinhos sob eles. Pode causar acerto crítico por padrão. \nBOARD_EFFECT: os espinhos causam 10 de TRUE por segundo e aplicam ARMOR_BREAK em Pokémons que pisarem neles e que não sejam dos tipos FLYING ou STEEL.",
 		"MOUNTAIN_GALE": "Lança [1,3,5,10] pedaços gigantes de gelo aleatoriamente no alvo e em inimigos ADJACENT, aplicando FLINCH por 3 segundos e depois [40,SP] de SPECIAL por projétil. Se o usuário tiver Bergmite nas costas, ela também será lançada, causando o mesmo dano.",
 		"TWINEEDLE": "Causa [25,50,80,160,SP] de SPECIAL ao alvo duas vezes. O primeiro golpe pode ser crítico por padrão, e o segundo golpe tem [40,LK]% de chance de aplicar POISONNED por 4 segundos.",
-		"ROCK_WRECKER": "Lança uma enorme pedra no alvo, aplicando FLINCH por 2 segundos e depois [80,160,320,640,SP] de SPECIAL. Em seguida, o usuário recebe FATIGUE por 4 segundos."
+		"ROCK_WRECKER": "Lança uma enorme pedra no alvo, aplicando FLINCH por 2 segundos e depois [80,160,320,640,SP] de SPECIAL. Em seguida, o usuário recebe FATIGUE por 4 segundos.",
+		"DEFAULT": "",
+		"MYSTICAL_FIRE": "Inflige [20,40,80,160,SP] de SPECIAL ao alvo e reduz seu AP em [15,20,25,50,SP].",
+		"DISABLE": "Inflige [12,25,50,100,SP] de SPECIAL ao alvo e a todos os Pokémon inimigos ADJACENT e aplica SILENCE por [2,3,4,8] segundos.",
+		"APPLE_ACID": "Inflige [15,30,50,100,SP] de SPECIAL aos 3 Pokémon inimigos na frente. Causa o dobro de dano se a SPE_DEF do alvo for 0.",
+		"VESPIQUEN_ORDERS": "Vespiquen mudará sua habilidade de acordo com a fileira em que começa:\n- Fileira da frente: $t(ability.DEFEND_ORDER)\n- Fileira do meio: $t(ability.HEAL_ORDER)\n- Fileira de trás: $t(ability.ATTACK_ORDER)",
+		"DEFEND_ORDER": "Invoca um Combee próximo e concede [10,20,30,50,SP] de SHIELD ao usuário e a todos os Combee aliados. O usuário recebe [10,20,30,SP] de SHIELD adicional para cada Combee aliado no tabuleiro.",
+		"ATTACK_ORDER": "Invoca um Combee próximo e todos os Combee aliados recebem RAGE por 3 segundos. O próximo ataque do usuário causa [20,40,60,120,SP] de SPECIAL adicional + [10,20,30,60,SP] para cada Combee aliado no tabuleiro.",
+		"BUG_BITE": "Inflige [20,40,80,160,SP] de SPECIAL ao alvo, rouba e come uma de suas frutas, se estiver com uma equipada.",
+		"SHELL_TRAP": "O SHIELD do usuário explode, causando [50,50,50,100,SP] de SPECIAL + o SHIELD atual a todos os Pokémon inimigos ADJACENT. Se o usuário não tiver SHIELD, recebe [25,50,75,150,SP] de SHIELD em vez disso.",
+		"AQUA_STEP": "Desloca-se para uma célula ADJACENT desocupada com passos de dança fluidos antes de causar [25,50,100,200,SP] de SPECIAL ao alvo e aumentar sua SPEED em [10,15,20,25,SP].",
+		"SNORE": "Causa [20,40,60,120,SP] de SPECIAL aos 3 Pokémon inimigos na frente, aplicando FLINCH por 3 segundos.",
+		"STUFF_CHEEKS": "Se o usuário estiver com alguma fruta equipada, come uma delas imediatamente e recebe [100,SP]% do HP que seria curado como SHIELD em vez disso. Caso contrário, procura e equipa uma fruta aleatória, que será mantida para batalhas futuras, se possível.",
+		"SILK_TRAP": "O usuário tece uma armadilha de seda, recebendo PROTECT por 1.5 segundos. Qualquer ataque corpo a corpo recebido durante esse tempo reduzirá a SPEED do atacante em [5,10,15,30,SP] e aplicará PARALYSIS por [1.5,SP,ND=1] segundos.",
+		"SKITTER_SMACK": "Desliza-se por trás do alvo para golpeá-lo, causando [15,30,60,120,SP] de SPECIAL. Isso também reduz o AP do alvo em 20.",
+		"NIGHT_DAZE": "Causa [25,50,100,200,SP] de SPECIAL ao alvo e aplica BLINDED por [3,SP] segundos. Se o usuário estiver disfarçado como um aliado, esta habilidade também afeta os inimigos ADJACENT ao alvo, e o disfarce do usuário é desfeito.",
+		"BITTER_MALICE": "Causa [25,50,100,200,SP] de SPECIAL ao alvo e aplica FATIGUE por [3,SP] segundos. Se o usuário estiver disfarçado como um aliado, esta habilidade também afeta os inimigos ADJACENT ao alvo, e o disfarce do usuário é desfeito.",
+		"COIL": "Prende o alvo com sua cauda poderosa, aplicando LOCKED e PARALYSIS por 3 segundos. O usuário também aumenta seu ATK e DEF em [3,5,10,20,SP]",
+		"SUBSTITUTE": "Cria um Substituto na posição do usuário com [25,25,25,50,SP]% do HP máximo do usuário como HP bônus. O usuário se move para uma célula livre próxima e toda a agressividade é redirecionada para o Substituto.",
+		"SWARM": "Uma cópia de um Pokémon BUG do seu tabuleiro salta para fora do ninho. A raridade aumenta a cada uso.",
+		"FLING": "Ao lançar a BALL, todos os inimigos entre o usuário e o receptor recebem [30,30,30,100,SP]% da SPEED do usuário como SPECIAL. Se não estiver com uma BALL equipada, salta para um canto do tabuleiro e recebe uma nova BALL",
+		"REVELATION_DANCE": "Realiza uma dança que projeta penas em células ADJACENT. Os inimigos atingidos recebem [15,30,50,80,SP] de SPECIAL e os aliados ganham um bônus dependendo do estilo:\n- Estilo Apaixonado: [3,6,10,15,SP] SPEED\n- Estilo Animado: [2,4,6,10,SP] ATK\n- Estilo Tranquilo: [2,4,6,10,SP] SPE_DEF\n- Estilo Refinado: [15,30,50,80,SP] SHIELD",
+		"THUNDERCLAP_PRESS": "O alvo é atingido por um golpe elétrico de corpo e empurrado para trás. Ele e o inimigo atingido no caminho recebem PARALYSIS por 4 segundos e sofrem [20,40,80,160,SP] de SPECIAL."
 	},
 	"effect": {
 		"STAMINA": "Vigor",
@@ -2407,7 +2464,8 @@
 		"ETHEREAL": "Etéreo",
 		"APPETIZER": "Aperitivo",
 		"LUNCH_BREAK": "Hora do Almoço",
-		"BANQUET": "Banquete"
+		"BANQUET": "Banquete",
+		"COACHING": "Treinamento"
 	},
 	"effect_description": {
 		"STAMINA": "Ganhe 15 de SHIELD. Receba um SILK_SCARF",
@@ -2518,7 +2576,12 @@
 		"ETHEREAL": "A equipe aliada recebe +5 de SPEED e +10 de HP por sinergia ativa única.",
 		"APPETIZER": "Ganhe um CHEF_HAT. Cozinhe um Prato de Assinatura após cada rodada e alimente o aliado ADJACENT STRONGEST",
 		"LUNCH_BREAK": "O Chef prepara dois pratos e alimenta os dois aliados ADJACENT STRONGEST após cada rodada.",
-		"BANQUET": "Ganhe um segundo CHEF_HAT."
+		"BANQUET": "Ganhe um segundo CHEF_HAT.",
+		"COACHING": "Bloqueia 12 de dano. Receba um Saco de Treino. Em cada estágio, Pokémon FIGHTING no banco com um saco de treino ou um pilar à esquerda treinarão e ganharão 4 ATK e 10% do HP máximo base permanentemente.",
+		"AROMATIC_MIST": "Escolha uma entre três varinhas dentre BLAST_WAND, HP_SWAP_WAND, SPIRIT_WAND, LONG_WAND",
+		"FAIRY_WIND": "Escolha uma entre três varinhas dentre CONFUSE_WAND, PETRIFY_WAND, SLOW_WAND, SLUMBER_WAND",
+		"STRANGE_STEAM": "Escolha uma entre três varinhas dentre GUIDING_WAND, SURROUND_WAND, POUNCE_WAND, TWO_EDGED_WAND",
+		"MOON_FORCE": "Escolha uma entre três varinhas dentre WARP_WAND, SWITCHER_WAND, WHIRLWIND_WAND, TUNNEL_WAND. Pokémon FAIRY ganham 5 LUCK."
 	},
 	"item": {
 		"FOSSIL_STONE": "Pedra Fóssil",
@@ -2820,7 +2883,64 @@
 		"WANTED_NOTICE": "Aviso de Procurado",
 		"TATSUGIRI_CURLY": "Comandante Tatsugiri (Ondulado)",
 		"TATSUGIRI_DROOPY": "Comandante Tatsugiri (Pendente)",
-		"TATSUGIRI_STRETCHY": "Comandante Tatsugiri (Esticado)"
+		"TATSUGIRI_STRETCHY": "Comandante Tatsugiri (Esticado)",
+		"GOLD_MASK": "Máscara Dourada",
+		"STAR_PIECE": "Pedaço de Estrela",
+		"BERRIES": "Frutas",
+		"FLORA_MEMORY": "Memória Floral",
+		"CONFUSE_WAND": "Varinha da Confusão",
+		"PETRIFY_WAND": "Varinha da Petrificação",
+		"SLOW_WAND": "Varinha da Lentidão",
+		"SLUMBER_WAND": "Varinha do Sono",
+		"BLAST_WAND": "Varinha Explosiva",
+		"HP_SWAP_WAND": "Varinha de Troca de HP",
+		"SPIRIT_WAND": "Varinha do Espírito",
+		"LONG_WAND": "Varinha Longa",
+		"GUIDING_WAND": "Varinha Guia",
+		"SURROUND_WAND": "Varinha do Cerco",
+		"POUNCE_WAND": "Varinha Repentina",
+		"TWO_EDGED_WAND": "Varinha de Dois Fios",
+		"WARP_WAND": "Varinha de Teleporte",
+		"SWITCHER_WAND": "Varinha Permutadora",
+		"WHIRLWIND_WAND": "Varinha do Redemoinho",
+		"TUNNEL_WAND": "Varinha do Túnel",
+		"AQUA_MONICA": "Aquamônica",
+		"FIERY_DRUM": "Tambor Ardente",
+		"GRASS_CORNET": "Corneta da Grama",
+		"ICY_FLUTE": "Flauta Gélida",
+		"ROCK_HORN": "Corno de Rocha",
+		"SKY_MELODICA": "Aeromelódica",
+		"TERRA_CYMBAL": "Terracímbalo",
+		"SOOTHE_BELL": "Sininho Calmante",
+		"BALL": "Bola",
+		"POTION": "Poção",
+		"FORAGE_BAG": "Bolsa de Coleta",
+		"COLLECTION_BOX": "Caixa de Coleção",
+		"PRETTY_BOX": "Caixa Bonita",
+		"DELUXE_BOX": "Caixa de Luxo",
+		"BERRIES_GIFT": "Frutas",
+		"SWEETS_GIFT": "Doces",
+		"DITTO_GIFT": "Presente de Ditto",
+		"GEMS_BUNDLE": "Pacote de Gemas",
+		"HATCH_BUNDLE": "Pacote de Eclosão",
+		"TICKET_BUNDLE": "Pacote de Bilhetes",
+		"TOOLBOX": "Caixa de Ferramentas",
+		"COMMON_GIFT": "Presente Comum",
+		"UNCOMMON_GIFT": "Presente Incomum",
+		"RARE_GIFT": "Presente Raro",
+		"EPIC_GIFT": "Presente Épico",
+		"ULTRA_GIFT": "Presente Ultra",
+		"UNIQUE_GIFT": "Presente Único",
+		"LEGENDARY_GIFT": "Presente Lendário",
+		"REGIONAL_TOUR": "Turnê Regional",
+		"SMALL_EXP_GIFT": "Pequeno Presente de XP",
+		"LARGE_EXP_GIFT": "Grande Presente de XP",
+		"STAR_GIFT": "Presente de Estrela",
+		"BANQUET": "Banquete",
+		"PINK_NECTAR": "Néctar Rosa",
+		"PURPLE_NECTAR": "Néctar Púrpura",
+		"YELLOW_NECTAR": "Néctar Amarelo",
+		"RED_NECTAR": "Néctar Vermelho"
 	},
 	"item_description": {
 		"FOSSIL_STONE": "Um fóssil de um Pokémon que viveu em tempos pré-históricos",
@@ -2893,9 +3013,9 @@
 		"SUPER_ROD": "Após cada rodada PvP, pesque um Pokémon que será adicionado a um espaço livre em seu banco. Pode capturar WATER Pokémons épicos, e também $t(pkm.WISHIWASHI).",
 		"DYNAMAX_BAND": "No início da luta, aumente o HP máximo em 200%.",
 		"SHINY_STONE": "Recebe o tipo LIGHT. Um segundo ponto de luz é projetado no espaço do portador no começo do combate.",
-		"EVIOLITE": "O portador recebe vários bônus de atributos, mas não pode mais evoluir. Só pode ser dado a Pokémons que não estejam totalmente evoluídos.",		
+		"EVIOLITE": "O portador recebe vários bônus de atributos, mas não pode mais evoluir. Só pode ser dado a Pokémons que não estejam totalmente evoluídos.",
 		"GOLD_BOTTLE_CAP": "+1% CRIT_POWER por GOLD que você possui. Receba 1 GOLD por nocaute. Se eliminar o último inimigo, ganhe um prêmio que dobra o valor ganho durante a rodada.",
-		"SACRED_ASH": "Recebe RESURRECTION. Após a ressurreição, até 3 aliados nocauteados também são ressuscitados, mas sem itens.",		
+		"SACRED_ASH": "Recebe RESURRECTION. Após a ressurreição, até 3 aliados nocauteados também são ressuscitados, mas sem itens.",
 		"AMULET_COIN": "+1 de ouro cada vez que o titular derrubar um oponente",
 		"HEAVY_DUTY_BOOTS": "O portador se torna imune a qualquer BOARD_EFFECT, deslocamento forçado e LOCKED.",
 		"AQUA_EGG": "O portador recupera 20% do PP máximo após usar sua habilidade, + 2 PP para cada uso realizado no combate.",
@@ -3122,7 +3242,65 @@
 		"WANTED_NOTICE": "Procura-se: Morto ou Vivo\nRecompensa: 10 GOLD",
 		"TATSUGIRI_CURLY": "Pode comandar um Dondozo.",
 		"TATSUGIRI_DROOPY": "Pode comandar um Dondozo.",
-		"TATSUGIRI_STRETCHY": "Pode comandar um Dondozo."
+		"TATSUGIRI_STRETCHY": "Pode comandar um Dondozo.",
+		"GOLD_MASK": "No início da luta, invoca 3 Pokémon que compartilham um tipo com o portador. A raridade e o nível de estrelas aumentam de acordo com o estágio.",
+		"STAR_PIECE": "Concede ao portador uma STAR adicional, o que aumenta o poder de sua habilidade.",
+		"BERRIES": "Procura uma fruta aleatória para o Chef equipar. Se não houver espaços de item livres, ela vai para seu inventário.",
+		"FLORA_MEMORY": "Pode ser equipada em $t(pkm.SILVALLY) para obter o tipo FLORA.",
+		"LUCKY_RIBBON": "O portador recebe 20 LUCK e tem [15,LK]% de chance de esquivar de ataques.",
+		"CONFUSE_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT e têm [5,LK]% de chance de causar CONFUSION por 2 segundos e reduzir a SPE_DEF do alvo em 3.",
+		"PETRIFY_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT e têm [5,LK]% de chance de causar LOCKED por 2 segundos e reduzir a DEF do alvo em 3.",
+		"SLOW_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT e têm [5,LK]% de chance de causar PARALYSIS por 2 segundos e reduzir a SPEED do alvo em 10.",
+		"SLUMBER_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT e têm [5,LK]% de chance de causar SLEEP por 2 segundos e reduzir o ATK do alvo em 3.",
+		"BLAST_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT, ou 50% se for um acerto crítico.",
+		"HP_SWAP_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT. O SPECIAL das varinhas tem [20,LK]% de chance de ser roubado do HP máximo do alvo e concedido ao atacante.",
+		"SPIRIT_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT + 5% para cada habilidade lançada pelo atacante durante a luta, e têm [20,LK]% de chance de conceder 5 PP adicionais.",
+		"LONG_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT. Aliados FAIRY à distância recebem +1 RANGE e têm [1,LK]% de CRIT_CHANCE adicional, multiplicado pela distância entre atacante e alvo.",
+		"GUIDING_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT. O SPECIAL das varinhas tem [50,LK]% de chance de ser redirecionado ao inimigo com a menor % de HP dentro do RANGE.",
+		"SURROUND_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT + 5% para cada inimigo ADJACENT ao atacante. O SPECIAL das varinhas tem [10,LK]% de chance de também ser infligido a todos os inimigos ADJACENT ao atacante, além do alvo.",
+		"POUNCE_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT. Ao serem atingidos corpo a corpo, os aliados FAIRY têm [10,LK]% de chance de retaliar com 30% do dano recebido contra os inimigos ADJACENT, garantido se for um acerto crítico.",
+		"TWO_EDGED_WAND": "Ataques FAIRY causam 50% do ATK como SPECIAL adicional ON_HIT. O SPECIAL das varinhas também pode ser infligido como dano de recuo ao atacante ([80,LK]% de chance de evitar o dano de recuo).",
+		"WARP_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT e têm [5,LK]% de chance de teleportar o alvo para uma célula distante",
+		"SWITCHER_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT e têm [5,LK]% de chance de trocar a posição do alvo com o inimigo mais distante",
+		"WHIRLWIND_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT e têm [5,LK]% de chance de lançar um redemoinho que arrasta para longe todas as unidades em seu caminho.",
+		"TUNNEL_WAND": "Ataques FAIRY causam 20% do ATK como SPECIAL adicional ON_HIT. O SPECIAL das varinhas tem [5,LK]% de chance de atravessar o alvo e atingir os inimigos em linha atrás dele.",
+		"AQUA_MONICA": "Pokémon na loja têm 5% de chance adicional de ter o tipo WATER.",
+		"FIERY_DRUM": "Pokémon na loja têm 5% de chance adicional de ter o tipo FIRE.",
+		"GRASS_CORNET": "Pokémon na loja têm 5% de chance adicional de ter o tipo GRASS.",
+		"ICY_FLUTE": "Pokémon na loja têm 5% de chance adicional de ter o tipo ICE.",
+		"ROCK_HORN": "Pokémon na loja têm 5% de chance adicional de ter o tipo ROCK.",
+		"SKY_MELODICA": "Pokémon na loja têm 5% de chance adicional de ter o tipo FLYING.",
+		"TERRA_CYMBAL": "Pokémon na loja têm 5% de chance adicional de ter o tipo GROUND.",
+		"SOOTHE_BELL": "Use em um Pokémon para atualizar sua loja com Pokémon que compartilham um tipo com ele",
+		"BALL": "Uma bola feita de uma fruta grande e dura. Ao lançar a habilidade, arremessa a bola para o aliado FIELD mais distante, passando a ele a BALL e 50 SHIELD. Se não houver um aliado FIELD à vista com espaço de item livre, arremessa a bola para o inimigo mais distante, causando [30,SP]% da SPEED do usuário como PHYSICAL",
+		"POTION": "Uma poção que cura 10 de HP do jogador para a equipe",
+		"FORAGE_BAG": "Dá de presente 3 componentes de item aleatórios ao seu parceiro",
+		"COLLECTION_BOX": "Dá de presente 1 SILK_SCARF, 1 item construível aleatório, 1 ferramenta aleatória, 2 frutas e uma maçã ao seu parceiro.",
+		"PRETTY_BOX": "Dá de presente 2 itens completos aleatórios ao seu parceiro.",
+		"DELUXE_BOX": "Dá de presente 1 Item Shiny aleatório ao seu parceiro.",
+		"TOOLBOX": "Dá de presente 3 ferramentas aleatórias ao seu parceiro.",
+		"BERRIES_GIFT": "Dá de presente 7 $t(item.BERRIES) aleatórias ao seu parceiro.",
+		"SWEETS_GIFT": "Dá de presente 7 $t(item.SWEETS) aleatórios ao seu parceiro.",
+		"HATCH_BUNDLE": "Dá de presente 2 Pokémon Chocados aleatórios ao seu parceiro. 5% de chance de receber um Ovo Dourado em vez disso.",
+		"TICKET_BUNDLE": "Dá de presente um pacote contendo um $t(item.EXCHANGE_TICKET), um $t(item.RECYCLE_TICKET) e um $t(item.BRONZE_DOJO_TICKET) ao seu parceiro.",
+		"DITTO_GIFT": "Dá de presente um Ditto ao seu parceiro. Seu parceiro precisa ter pelo menos um espaço livre no banco.",
+		"GEMS_BUNDLE": "Dá de presente 3 gemas de sinergia aleatórias ao seu parceiro.",
+		"COMMON_GIFT": "Dá de presente um Pokémon Comum aleatório de 3 STAR ao seu parceiro. Ele corresponderá à sinergia ativa mais alta do seu parceiro.",
+		"UNCOMMON_GIFT": "Dá de presente um Pokémon Incomum Adicional ou Regional aleatório de 2 STAR ao seu parceiro. Ele corresponderá à sinergia ativa mais alta do seu parceiro.",
+		"RARE_GIFT": "Dá de presente um Pokémon Raro Adicional ou Regional aleatório de 2 STAR ao seu parceiro. Ele corresponderá à sinergia ativa mais alta do seu parceiro.",
+		"EPIC_GIFT": "Dá de presente um Pokémon Épico Adicional ou Regional aleatório de 2 STAR ao seu parceiro. Ele terá a sinergia ativa mais alta do seu parceiro.",
+		"ULTRA_GIFT": "Dá de presente um Pokémon Ultra aleatório de 1 STAR ao seu parceiro. Ele terá uma das 2 sinergias ativas mais altas do seu parceiro.",
+		"UNIQUE_GIFT": "Dá de presente um Pokémon Único aleatório ao seu parceiro. Ele terá a sinergia ativa mais alta do seu parceiro.",
+		"LEGENDARY_GIFT": "Dá de presente um Pokémon Lendário aleatório ao seu parceiro. Ele terá uma das 2 sinergias ativas mais altas do seu parceiro.",
+		"REGIONAL_TOUR": "Dá de presente um $t(item.LAPRAS_PASSPORT) ao seu parceiro e 10 atualizações grátis de loja.",
+		"SMALL_EXP_GIFT": "Seu parceiro recebe 8 XP. O XP excedente no nível máximo é convertido em GOLD.",
+		"LARGE_EXP_GIFT": "Seu parceiro recebe 24 XP. O XP excedente no nível máximo é convertido em GOLD.",
+		"STAR_GIFT": "Evolui um Pokémon aleatório do tabuleiro do seu parceiro. Se nenhum Pokémon do tabuleiro puder evoluir, um deles receberá um grande aumento de status.",
+		"BANQUET": "Dá um prato aleatório a cada Pokémon no tabuleiro e no banco do seu parceiro. Além disso, ele recebe um cogumelo de cada tipo e um conjunto de piquenique. Bon appétit!",
+		"PINK_NECTAR": "Pode ser dado a Oricorio para trocá-lo para o Estilo Tranquilo",
+		"PURPLE_NECTAR": "Pode ser dado a Oricorio para trocá-lo para o Estilo Refinado",
+		"YELLOW_NECTAR": "Pode ser dado a Oricorio para trocá-lo para o Estilo Animado",
+		"RED_NECTAR": "Pode ser dado a Oricorio para trocá-lo para o Estilo Apaixonado"
 	},
 	"passive_description": {
 		"NONE": "Sem passiva",
@@ -3310,7 +3488,18 @@
 		"SPEWPA": "Os Pokémon chocados evoluem automaticamente após 5 estágios. A evolução depende da sua sinergia dominante no tabuleiro entre os tipos: SOUND NORMAL GHOST ICE FOSSIL GRASS PSYCHIC FIELD WATER FIGHTING HUMAN ROCK AQUATIC STEEL ELECTRIC FIRE LIGHT POISON FAIRY ARTIFICIAL",
 		"GALE_WINGS": "Ao voar para longe, solta brasas no chão.\nBOARD_EFFECT: as brasas causam 10 de SPECIAL por segundo e aplicam BURN em Pokémons que não sejam do tipo FLYING ou FIRE que pisarem nelas.",
 		"FINIZEN": "Transforma-se na Forma Heroica Palafin após 5 aliados serem derrotados (sem contar os Pokémon que surgem no mapa), ou se este Pokémon for o último sobrevivente. Recupera todo o HP quando isso acontece.",
-		"COMMANDER": "Tatsugiri não pode carregar itens. No início da luta, um Dondozo ADJACENT com um espaço livre para item engole Tatsugiri. Tatsugiri fornece atributos com base em sua forma:\nForma Enrolado: +8 de ATK\nForma Pendente: +8 de DEF\nForma Esticado: +25 de SPEED"
+		"COMMANDER": "Tatsugiri não pode carregar itens. No início da luta, um Dondozo ADJACENT com um espaço livre para item engole Tatsugiri. Tatsugiri fornece atributos com base em sua forma:\nForma Enrolado: +8 de ATK\nForma Pendente: +8 de DEF\nForma Esticado: +25 de SPEED",
+		"CHIMECHO": "Ressoa com os sons dos aliados ADJACENT, o que concede 3 PP a Chimecho quando eles lançam sua habilidade.",
+		"PIKACHU_LIBRE": "Quando FIGHTING estiver ativo, recebe RAGE por 2 segundos a cada 10 acertos bloqueados.",
+		"DUNSPARCE": "Dunsparce evoluirá após escavar 20 vezes no solo",
+		"COMATOSE": "Está sempre sob SLEEP. Imune a BURN, POISONNED, FREEZE e PARALYSIS. Quando um SOUND tenta despertar este Pokémon, ele se afunda mais profundamente em seu sonho, ganhando 5 AP.",
+		"VESPIQUEN": "O RANGE e a habilidade de Vespiquen variam de acordo com a fileira em que ele começa.\nO efeito de sinergia BUG não invoca uma cópia de Vespiquen, mas sim 2 Combee.",
+		"ILLUSION": "Copia a aparência do aliado à sua esquerda.",
+		"STOUTLAND_SEARCH": "Stoutland late quando está em uma célula com um item escondido enterrado no solo.",
+		"SUBSTITUTE": "Um chamariz criado para se parecer com um Pokémon",
+		"PASSIMIAN": "Passimian já vem com uma BALL equipada",
+		"UXIE": "XP ganho: {{stacks}}",
+		"NECTAR": "Quando um vaso de flores estiver totalmente crescido, receba néctar de acordo com sua cor."
 	},
 	"stat": {
 		"ATK": "Ataque",
@@ -3327,7 +3516,8 @@
 		"MAX_PP": "PP Máximo",
 		"AP": "Poder de Habilidade (AP)",
 		"SHIELD": "Escudo",
-		"LUCK": "Sorte"
+		"LUCK": "Sorte",
+		"XP": "XP"
 	},
 	"status": {
 		"BURN": "Queimadura",
@@ -3451,7 +3641,9 @@
 		"WILD_ADDITIONAL": "Chance atual de encontrar um Pokémon WILD: {{wildChance}}%",
 		"AMORPHOUS": "Pokémons AMORPHOUS são extremamente flexíveis e não possuem forma própria. Sua equipe recebe HP e SPEED ao ativar uma ampla variedade de sinergias.",
 		"GOURMET": "Pokémons GOURMET podem ser equipados com um CHEF_HAT. Os chefs preparam seu Prato de Assinatura entre as batalhas e alimentam os aliados ADJACENT, fornecendo diversos bônus e efeitos.",
-		"NORMAL_SCARVES": "Lenços feitos: {{scarves}}"
+		"NORMAL_SCARVES": "Lenços feitos: {{scarves}}",
+		"FAIRY": "Pokémon FAIRY usam varinhas para causar SPECIAL adicional e diversos efeitos com seus ataques.{{additionalInfo}}",
+		"FAIRY_WANDS": "\nVarinhas equipadas: {{wands}}"
 	},
 	"title": {
 		"NOVICE": "Novato",
@@ -3549,7 +3741,10 @@
 		"POSTMAN": "Carteiro",
 		"SURVEY_CORPS": "Corpo de Pesquisa",
 		"GUILDMASTER": "Mestre da Guilda",
-		"MOLE": "Toupeira"
+		"MOLE": "Toupeira",
+		"PAL": "Parceiro",
+		"LEGIONNAIRE": "Legionário",
+		"FIVE_STARS": "★★★★★"
 	},
 	"title_description": {
 		"NOVICE": "Jogue seu primeiro jogo",
@@ -3645,7 +3840,10 @@
 		"DECURION": "Jogue com 10 unidades na sua equipe, sem contar clones e invocações",
 		"LEGEND": "Jogue com 3 ou mais lendários na sua equipe.",
 		"GIANT": "Obtenha um Pokémon com mais de 1500 de HP permanente.",
-		"LUCKY": "Obtenha um prêmio de 10 GOLD ou mais com uma GOLD_BOTTLE_CAP"
+		"LUCKY": "Obtenha um prêmio de 10 GOLD ou mais com uma GOLD_BOTTLE_CAP",
+		"PAL": "Jogue em Dobles com seu parceiro durante o evento Poképals",
+		"LEGIONNAIRE": "Forme um Falinks com 8 ou mais soldados",
+		"FIVE_STARS": "Jogue com um Pokémon de cinco estrelas em sua equipe"
 	},
 	"weather": {
 		"NEUTRAL": "Tempo calmo",
@@ -3740,7 +3938,7 @@
 		"remove_from_favorites": "Remover dos favoritos"
 	},
 	"bot_builder": "Construtor de Bots",
-	"meta": "Meta",	
+	"meta": "Meta",
 	"back_to_lobby": "Voltar ao Lobby",
 	"boosters": "Boosters",
 	"rank_labels": {
@@ -3754,7 +3952,7 @@
 	"team": "Equipe",
 	"synergies": "Sinergias",
 	"join_as_guest": "Entrar como Convidado",
-	"welcome": "Bem-vindo",	
+	"welcome": "Bem-vindo",
 	"stage": "Estágio",
 	"spectate": "Assistir",
 	"join": "Juntar-se",
@@ -3893,20 +4091,33 @@
 			"board_return": "Retorne ao seu tabuleiro",
 			"wiki": "Abrir/fechar Wiki",
 			"team_planner": "Abrir/fechar Planejador de Times",
-			"avatar_show_emote": "Acionar emote"
-		}
+			"avatar_show_emote": "Acionar emote",
+			"meta_report": "Abrir/fechar relatório da meta"
+		},
+		"record_replays": "Gravar replays das partidas automaticamente em segundo plano",
+		"theme": "Tema"
 	},
 	"jukebox": {
 		"music_volume": "Volume da Música",
 		"previous_music": "Música anterior",
 		"next_music": "Próxima música",
-		"random_music": "Música aleatória"
+		"random_music": "Música aleatória",
+		"music_credits": "Créditos musicais"
 	},
 	"save": "Salvar",
 	"player_choices": {
 		"choose_add_pick": "Escolha um Pokémon adicional. Ele estará disponível para todos.",
 		"free_slot_hint": "Você deve ter um espaço livre no banco, ou dois para Duplas",
-		"choose_first_partner": "Escolha seu Pokémon inicial. Você receberá uma cópia dele a cada estágio até o estágio 10."
+		"choose_first_partner": "Escolha seu Pokémon inicial. Você receberá uma cópia dele a cada estágio até o estágio 10.",
+		"choose_item": "Escolha um item entre os seguintes",
+		"choose_starter": "Escolha seu Pokémon inicial",
+		"choose_mission_order": "Escolha sua missão",
+		"choose_unique": "Escolha um Único para sua equipe. Você só pode escolher uma vez, faça valer!",
+		"choose_legendary": "Escolha um Lendário para sua equipe. Você só pode escolher uma vez, faça valer!",
+		"choose_wand": "Escolha uma varinha para dar efeitos adicionais aos ataques dos seus Pokémon do tipo Fada",
+		"choose_gift": "Escolha um presente para enviar ao seu parceiro",
+		"more_choices": "Mais {{count}} escolha(s) depois desta!",
+		"cost_amount": "Custo: {{cost}} GOLD"
 	},
 	"hide": "Esconder",
 	"show": "Mostrar",
@@ -3980,7 +4191,7 @@
 	"add_bot": "Adicionar Bot",
 	"bot_difficulty": {
 		"BEGINNER": "Iniciante (<850)",
-		"EASY":  "Fácil (850-999)",
+		"EASY": "Fácil (850-999)",
 		"MEDIUM": "Médio (1000-1149)",
 		"HARD": "Difícil (1150-1299)",
 		"EXTREME": "Extremo (1300-1449)",
@@ -3999,7 +4210,7 @@
 	"valid": "Válido",
 	"invalid": "Inválido",
 	"all": "Todos",
-	"status_label": "Status",	
+	"status_label": "Status",
 	"help": "Ajuda",
 	"bot_admin": "Admin BOT",
 	"change": "Mudar",
@@ -4034,7 +4245,8 @@
 			"titles_unlocked": "{{count}}/{{total}} títulos conquistados",
 			"avatars_unlocked": "{{count}}/{{total}} avatares conquistados",
 			"pokemons_played": "{{count}}/{{total}} Pokémon jogados",
-			"gadgets_unlocked": "{{count}}/{{total}} Engenhocas disponíveis"
+			"gadgets_unlocked": "{{count}}/{{total}} Engenhocas disponíveis",
+			"unlocks_theme": "Desbloqueia o Tema: {{theme}}"
 		},
 		"avatar": {
 			"change_avatar": "Mudar Avatar",
@@ -4054,6 +4266,14 @@
 			"change_name": "Mude o nome",
 			"username_disclaimer": "Nomes de usuário impróprios levarão ao banimento da sua conta. Isso inclui:\n- ilegais: discurso de ódio, ameaças, referências a material ilegal\n- explícitos: coisas que você não pode dizer na frente da sua mãe ou do seu irmãozinho\n- ofensivos: alguns jogadores podem ficar realmente irritados ao ler o nome\n- personificação: fingir ser um membro da equipe ou outro jogador conhecido\n- assédio: atacar outro usuário específico (ex.: \"Usuário123_é_um_perdedor\")\n- publicidade: promover conteúdo externo não relacionado ao jogo (ex.: \"JoinMySiteDOTcom\")\n- abuso de unicode/caracteres: caracteres invisíveis, excesso de texto Zalgo ou caracteres que podem quebrar a interface.",
 			"invalid_username": "Nome de usuário inválido. O nome de usuário deve ter entre 3 e 24 caracteres, começar com uma letra, conter apenas letras, números ou \".-_\", sem espaços em branco."
+		},
+		"elo_tab": {
+			"title": "Elo",
+			"current_elo": "Elo Atual",
+			"max_elo_reached": "Maior Elo alcançado",
+			"elo_decay_info": "Se você não jogar pelo menos 3 partidas nos últimos 20 dias (partidas Classificatórias caso esteja no rank Ultra Ball ou superior), seu elo começará a decair (-{{eloLoss}} elo/dia).",
+			"elo_decay_active": "Seu elo está atualmente decaindo",
+			"elo_decay_inactive": "Seu elo começará a decair em {{time}}"
 		}
 	},
 	"game-reconnect-modal-title": "Reconecte-se ao jogo",
@@ -4079,7 +4299,15 @@
 		"synergy_wheel": "Roda de Sinergia",
 		"synergy_wheel_desc": "Busca sinergias aleatoriamente para te inspirar",
 		"tier_list_maker": "Criador de Tier List",
-		"tier_list_maker_desc": "Crie e compartilhe suas próprias Tier Lists"
+		"tier_list_maker_desc": "Crie e compartilhe suas próprias Tier Lists",
+		"certificate": "Certificado",
+		"certificate_desc": "Desbloqueia o modo Classificatório e a participação em Torneios",
+		"palette": "Paleta de Smeargle",
+		"palette_desc": "Personalize o tema e as cores do jogo em Opções → Interface",
+		"sprite_tracker": "Rastreador de Sprites",
+		"sprite_tracker_desc": "Rastreia os Pokémon disponíveis no SpriteCollab e compara com o Pokémon Auto Chess",
+		"recorder": "Gravador",
+		"recorder_desc": "Grave suas partidas e assista a replays"
 	},
 	"level_required": "Nível necessário",
 	"map": {
@@ -4259,7 +4487,8 @@
 		"room_is_private": "Esta sala é privada. Digite a senha.",
 		"blacklisted": "Você foi expulso desta partida.",
 		"min_rank_not_reached": "Seu rank não é alto o suficiente para participar neste jogo rankeado",
-		"max_rank_not_reached": "Sua classificação é muito alta para jogar esta partida ranqueada"
+		"max_rank_not_reached": "Sua classificação é muito alta para jogar esta partida ranqueada",
+		"ranked_mode_locked": "O modo Classificatório está bloqueado. Você precisa alcançar o nível {{requiredLevel}} para desbloqueá-lo."
 	},
 	"npc_dialog": {
 		"welcome": "Bem-vindo!",
@@ -4270,7 +4499,9 @@
 		"magnemite": "Você viu o fugitivo?",
 		"magnezone": "Escuta aqui, deixe a polícia fazer o trabalho dela; assim que eu tiver mais informações, pode ter certeza de que você será o primeiro a saber.",
 		"xatu": "Vou abrir este baú de tesouros para você...",
-		"lapras": "Preparados para partir? Então, todos a bordo!"
+		"lapras": "Preparados para partir? Então, todos a bordo!",
+		"kecleon_preview": "Seu parceiro te enviou um presente, kec kec kec!",
+		"kecleon": "Kecleon"
 	},
 	"scribble": {
 		"EVERYONE_IS_HERE": "Todos estão presentes!",
@@ -4292,7 +4523,8 @@
 		"GO_BIG_OR_GO_HOME": "Ou vai ou racha",
 		"FAMILY_OUTING": "Passeio em Família",
 		"UNOWN_SPELL": "Magia dos Unowns",
-		"CHOSEN_ONES": "Os Escolhidos"
+		"CHOSEN_ONES": "Os Escolhidos",
+		"BENCH_IS_LAVA": "O Banco é Lava"
 	},
 	"scribble_description": {
 		"EVERYONE_IS_HERE": "Todas as opções adicionais estão disponíveis imediatamente",
@@ -4314,7 +4546,8 @@
 		"FAMILY_OUTING": "Pokémons da mesma família contam para os níveis de sinergia.",
 		"UNOWN_SPELL": "Os Unowns estão assistindo às suas lutas e lançando habilidades em ambas as equipes a cada rodada.",
 		"CHOSEN_ONES": "Os Pokémons adicionais que você escolher evoluem imediatamente e ganham atributos bônus.",
-		"BLOOD_MONEY": "Cada nocaute concede 1 GOLD (exceto clones e invocações). Sem renda extra de juros."
+		"BLOOD_MONEY": "Cada nocaute concede 1 GOLD (exceto clones e invocações). Sem renda extra de juros.",
+		"BENCH_IS_LAVA": "Durante as lutas, seu banco se transforma em lava que aplica BURN em todos os Pokémon nele e pode eliminá-los permanentemente após um tempo."
 	},
 	"town_encounter_description": {
 		"KECLEON": "Kecleon vende Pedras de Sinergia por {{cost}} GOLD",
@@ -4337,7 +4570,9 @@
 		"CINCCINO": "Cinccino oferece elegantes SILK_SCARF",
 		"MAGNEZONE": "Magnezone está à procura de um fora da lei e oferece uma recompensa para quem o encontrar.",
 		"KINGAMBIT": "Kingambit deu ao jogador em primeiro lugar o LEADERS_CREST. Derrote-o em batalha para ganhar GOLD extra!",
-		"LAPRAS": "Lapras oferece transporte para ir a uma região diferente."
+		"LAPRAS": "Lapras oferece transporte para ir a uma região diferente.",
+		"LUDICOLO": "Ludicolo celebra o carnaval e oferece instrumentos para participar das festividades.",
+		"CHIMECHO": "Chimecho pode convocar uma assembleia com o SOOTHE_BELL"
 	},
 	"loading_hints": {
 		"tab_out": "Não saia da tela! O carregamento é pausado quando esta janela do navegador está inativa.",
@@ -4364,7 +4599,8 @@
 			"weather_label": "Clima",
 			"town_label": "Cidade",
 			"dungeon_label": "Regiões",
-			"data_label": "Dados"
+			"data_label": "Dados",
+			"glossary_label": "Glossário"
 		},
 		"faq": {
 			"official_game": "Isso é um jogo oficial?",
@@ -4406,7 +4642,11 @@
 			"code": "Qual linguagem/biblioteca é usada para codificar o jogo?",
 			"code_answer": "TypeScript, Phaser, Coliseu. Se você quiser contribuir",
 			"pull_requests": "solicitações pull estão abertas",
-			"faq": "PERGUNTAS FREQUENTES."
+			"faq": "PERGUNTAS FREQUENTES.",
+			"double_up": "Como funciona o modo Dobles?",
+			"double_up_answer": "Você começa escolhendo um parceiro. Quando os dois jogadores de uma equipe clicam em Pronto, eles ficam travados e não podem mais trocar de equipe.\nDurante a partida, sua vida é compartilhada com seu parceiro. Você recebe metade do dano normal da rodada, mas esse dano corresponde à pior derrota entre vocês dois.\nSe você derrotar seu oponente enquanto seu parceiro ainda estiver lutando, seus Pokémon se juntarão à batalha dele como reforços após 3 segundos. Sinergias ativas, itens e status permanentes da sua equipe serão mantidos. Seus Pokémon não contribuirão nem ganharão nenhum novo efeito de sinergia da equipe do seu parceiro. Efeitos que afetam o jogador se aplicam ao jogador original, mesmo quando lutando no tabuleiro do parceiro.\nO espaço na extremidade direita do seu banco pode ser usado para trocar Pokémon e seus itens equipados com seu parceiro. Itens removíveis são retirados antes da troca. Depois que você e seu parceiro colocarem um Pokémon nele e confirmarem a troca, haverá um período de espera antes que ele possa ser usado novamente; essa duração aumenta com base na raridade, nas estrelas e no número de itens trocados.\nPor fim, nos estágios 15–16 e 25–26, você terá a oportunidade de comprar um presente para seu parceiro.",
+			"reconnect": "Fui desconectado de uma partida/sala em andamento, como faço para reconectar?",
+			"reconnect_answer": "Tente recarregar a página (tecla F5). Se isso não funcionar, volte para <a target=\"_blank\" href=\"https://pokemon-auto-chess.com/\">pokemon-auto-chess.com</a>, reautentique-se se necessário e volte para o lobby principal, e tente procurar sua partida na aba \"Em Jogo\" ou no modo de jogo correspondente. Deve haver um botão verde \"Reconectar\" ao lado da sua sala de jogo."
 		},
 		"tutorials": {
 			"thanks_to": "Graças a",
@@ -4450,7 +4690,12 @@
 			"mulch": "Adubo",
 			"mulch_description": "O adubo é coletado sempre que um Pokémon FLORA é derrotado. Use-a para evoluir seus vasos de flores.",
 			"cell_battery_description": "Após atingir o nível máximo de sinergia ELECTRIC, seus Pokémon carregam CELL_BATTERY com seus ataques, que você pode consumir para potencializar um Pokémon ELECTRIC para a próxima batalha.",
-			"fire_shard_description": "Após atingir o nível máximo na sinergia de FIRE, a cada rodada você pode usar FIRE_SHARD para sacrificar seu HP de jogador e fortalecer um Pokémon de FIRE."
+			"fire_shard_description": "Após atingir o nível máximo na sinergia de FIRE, a cada rodada você pode usar FIRE_SHARD para sacrificar seu HP de jogador e fortalecer um Pokémon de FIRE.",
+			"dishes": "Pratos",
+			"wands": "Varinhas",
+			"wands_description": "Varinhas concedem efeitos adicionais aos ataques de Pokémon FAIRY.",
+			"gifts": "Presentes",
+			"gifts_description": "Presentes podem ser dados ao seu parceiro no modo de jogo Dobles"
 		},
 		"statistics": {
 			"stat_description": {
@@ -4526,7 +4771,22 @@
 			"luck_description": "LUCK aumenta suas chances em todos os sorteios, sejam eles para acertos críticos, esquivas, status ao acertar ou qualquer outro efeito mencionado com o símbolo [LK].",
 			"luck_formula": "LUCK influencia as probabilidades com esta fórmula: P = baseP ^ (1 - sorte/100); por exemplo, um Pokémon com 10% de CRIT_CHANCE e 50 de LUCK terá, na verdade, 0,1^(1-50/100) = ~31,62% de CRIT_CHANCE.",
 			"xp": "XP",
-			"experience": "Experiência"
+			"experience": "Experiência",
+			"speed_calculation": "Como a SPEED funciona?",
+			"speed_calculation_description": "A SPEED influencia o intervalo entre cada ação do seu Pokémon: movimento, ataque, lançamento de habilidade. O intervalo é calculado assim: Intervalo = 1000 / (0.4 + 0.007 * Speed). Então, com 0 de SPEED um Pokémon realiza 0.4 ataques por segundo, e com a SPEED máxima de 300, ele realiza 2.5 ataques por segundo. Algumas habilidades ou efeitos têm um intervalo menor ou um intervalo fixo."
+		},
+		"glossary": {
+			"damage_types": "Tipos de dano",
+			"SPECIAL": "Habilidades geralmente causam SPECIAL. Porém, algumas habilidades podem causar dano verdadeiro ou dano físico. Esse tipo de dano é mitigado pela SPE_DEF",
+			"PHYSICAL": "Ataques automáticos causam PHYSICAL, salvo indicação contrária. Esse tipo de dano é mitigado pela DEF",
+			"TRUE": "TRUE não é mitigado por nenhum status de defesa ou efeito de redução de dano. Ele vem de habilidades, itens ou efeitos de sinergia específicos.",
+			"item_categories": "Categorias de itens",
+			"components": "Dois componentes podem ser combinados para criar um item construível",
+			"craftable_items": "Itens construíveis são criados combinando dois componentes.",
+			"consumable_item": "Itens consumíveis são itens de uso único que são removidos quando seu efeito é utilizado.",
+			"unholdable_item": "Itens não equipáveis são itens que não podem ser equipados por um Pokémon. Seu efeito ainda se aplica a toda a sua equipe.",
+			"removable_item": "Itens removíveis são itens que podem ser retirados de um Pokémon ao colocá-lo no banco.",
+			"gift": "Presentes são itens dados ao seu parceiro de equipe quando você os escolhe"
 		}
 	},
 	"errors": {
@@ -4547,7 +4807,8 @@
 		"USER_ALREADY_JOINED": "Você já esta nesta sala",
 		"GAME_ALREADY_STARTED": "Esta partida já começou",
 		"SERVER_SHUTDOWN": "O servidor está sendo desligado para manutenção",
-		"FAILED_TO_RECONNECT": "Falha em reconectar ao jogo. Por favor, atualize a página e tente novamente."
+		"FAILED_TO_RECONNECT": "Falha em reconectar ao jogo. Por favor, atualize a página e tente novamente.",
+		"title": "Erro"
 	},
 	"connection_status": {
 		"CONNECTION_LOST": "Conexão perdida. Tentando reconectar...",
@@ -4569,14 +4830,23 @@
 		"ADJACENT": "adjacente",
 		"ADJACENT_IN_THE_SAME_ROW": "adjacente na mesma linha",
 		"CONE": "cone",
-		"BOARD_EFFECT": "Efeito de Tabuleiro"
+		"BOARD_EFFECT": "Efeito de Tabuleiro",
+		"title": "Termos Técnicos",
+		"FLY_AWAY": "voar para longe",
+		"INIMITABLE": "Inimitável",
+		"ON_HIT": "ao acertar",
+		"ON_ATTACK": "ao atacar"
 	},
 	"technical_terms_definitions": {
 		"STRONGEST": "O mais forte é definido como, por ordem de prioridade: 1. Número de itens segurados, 2. Nível da unidade, 3. Raridade da unidade.",
 		"ADJACENT": "os 8 espaços ao redor da unidade",
 		"ADJACENT_IN_THE_SAME_ROW": "os espaços imediatamente à esquerda e à direita de uma unidade",
 		"CONE": "disparando em um ângulo de 90 graus à frente da unidade, centrado no alvo.",
-		"BOARD_EFFECT": "Um Efeito de Tabuleiro é um efeito em um espaço do tabuleiro que influencia todas as unidades presentes nela, independentemente da equipe, até o final da luta. Efeitos de tabuleiro podem ser removidos por certas habilidades."
+		"BOARD_EFFECT": "Um Efeito de Tabuleiro é um efeito em um espaço do tabuleiro que influencia todas as unidades presentes nela, independentemente da equipe, até o final da luta. Efeitos de tabuleiro podem ser removidos por certas habilidades.",
+		"FLY_AWAY": "Move-se para o local mais seguro enquanto ainda estiver no RANGE de um inimigo",
+		"INIMITABLE": "Uma habilidade é inimitável se não puder ser copiada e usada por outro Pokémon.",
+		"ON_HIT": "Efeitos Ao Acertar são ativados quando uma unidade é atingida por um ataque ou uma habilidade. Eles são ativados mesmo se o alvo tiver SHIELD, mas não se o alvo esquivar ou tiver PROTECT.",
+		"ON_ATTACK": "Efeitos Ao Atacar são ativados quando uma unidade realiza um ataque básico em outra unidade que ainda está viva, no momento em que o ataque deveria acertar, independentemente de o ataque realmente acertar ou não."
 	},
 	"victory_road": {
 		"title": "Victory Road",
@@ -4603,21 +4873,24 @@
 		"move_row_up": "Move a linha para cima",
 		"move_row_down": "Move a linha para baixo",
 		"delete_row": "Remove a linha",
-		"title": "Minha nova Tier List"
+		"title": "Minha nova Tier List",
+		"symbols": "Símbolos"
 	},
 	"game_modes": {
 		"CLASSIC": "Clássico",
 		"RANKED": "Jogo Rankeado",
 		"SCRIBBLE": "Garabato do Smeargle",
 		"CUSTOM_LOBBY": "Jogo personalizado",
-		"TOURNAMENT": "Torneio"
+		"TOURNAMENT": "Torneio",
+		"DOUBLE_UP": "Dobles"
 	},
 	"game_modes_descriptions": {
 		"CLASSIC": "Uma experiencia casual do PAC !\n8 jogadores, SEM alteração no Elo, livre para todos.",
 		"RANKED": "Competitivo ! 8 jogadores, COM alteração no Elo\nRestrito a jogadores com um ranque próximo ao seu",
 		"SCRIBBLE": "Jogue por diversão! 8 jogadores, SEM alteração no Elo\nUma regra especial é adicionada a esse modo de jogo.",
 		"CUSTOM_LOBBY": "Cria uma sala privada para jogar com seus amigos ou com robôs.",
-		"TOURNAMENT": "Essa partida é parte de um torneio. Veja no Discord para eventos futuros."
+		"TOURNAMENT": "Essa partida é parte de um torneio. Veja no Discord para eventos futuros.",
+		"DOUBLE_UP": "Forme equipe com um parceiro e sobreviva a todas as outras duplas!"
 	},
 	"dendrogram": {
 		"title": "Hierarquia dos grupos",
@@ -4670,10 +4943,15 @@
 		"tournament_finalist_title": "Parabéns!",
 		"tournament_finalist_message": "Parabéns! Você chegou à final do torneio.\nSua posição final: {{place}}",
 		"tournament_finished_title": "Eliminação do torneio",
-		"tournament_finished_message": "Você foi eliminado do torneio.\nSua posição final: {{place}}"
+		"tournament_finished_message": "Você foi eliminado do torneio.\nSua posição final: {{place}}",
+		"info_title": "Informação",
+		"new_gadget_title": "Novo Gadget Desbloqueado!",
+		"new_gadget_message": "Você desbloqueou um novo gadget:\n{{gadget}}: {{description}}",
+		"new_theme_title": "Novo Tema Desbloqueado!",
+		"new_theme_message": "Você desbloqueou um novo tema: {{theme}}.\nVá até as opções do jogo para selecioná-lo!"
 	},
 	"meta_report_info": "Gerado em {{report_date}} de {{time_limit}} - Dados de {{count}} partidas",
-	"best_regions": "Melhores regiões",	
+	"best_regions": "Melhores regiões",
 	"stats": "Estatísticas",
 	"bench": "Banco",
 	"spectating": "Assistindo {{ name }}",
@@ -4687,7 +4965,8 @@
 		"cancel_tournament_participation": "Cancelar sua participação no torneio",
 		"register_tournament_participation": "Registrar neste torneio",
 		"registrations_open_info": "As inscrições serão abertas uma hora antes do início do torneio.",
-		"starts_at": "Começa às"
+		"starts_at": "Começa às",
+		"tournament_mode_locked": "Você precisa alcançar o nível {{requiredLevel}} para participar de torneios."
 	},
 	"enable_elo": "Ativar Rankeada",
 	"disable_elo": "Desativar Rankeada",
@@ -4703,7 +4982,7 @@
 	"games_in_progress_one": "{{count}} partida em andamento",
 	"games_in_progress_other": "{{count}} partidas em andamento",
 	"events": "Eventos",
-	"custom_room_short": "Personalizado",	
+	"custom_room_short": "Personalizado",
 	"no_bots_found": "Nenhum bot encontrado!",
 	"rooms_one": "{{count}} sala",
 	"rooms_other": "{{count}} salas",
@@ -4725,8 +5004,8 @@
 	"pokedex": "Pokédex",
 	"alt_forms": "Formas Aternativas",
 	"show_evolutions": "Mostrar evoluções",
-	"show_alt_forms": "Mostrar formas alternativas",	
-	"show_only_available_picks": "Mostrar apenas opções adicionais/regionais",	
+	"show_alt_forms": "Mostrar formas alternativas",
+	"show_only_available_picks": "Mostrar apenas opções adicionais/regionais",
 	"regional_pokemon_hint": "Ao viajar para uma nova região, você encontrará novas espécies regionais de Pokémon.",
 	"total": "Total",
 	"gold_needed_to_level_up": "Ouro necessário para subir de nível",
@@ -4785,7 +5064,7 @@
 	"location": "Localização",
 	"ping": "Ping",
 	"overlaps": "Sobreposições",
-	"toggle_locked": "Mostrar bloqueados",	
+	"toggle_locked": "Mostrar bloqueados",
 	"belly_full": "BARRIGA CHEIA",
 	"not_hungry": "SEM FOME",
 	"fully_grown": "TOTALMENTE CRESCIDO",
@@ -4798,7 +5077,13 @@
 	"full_patch_notes": "Informações Completas do Patch",
 	"thanks_for_playing": "Obrigado por jogar nosso jogo!",
 	"admin_panel": {
-		"heap_snapshot": "Gravar Heap Snapshot"
+		"heap_snapshot": "Gravar Heap Snapshot",
+		"title": "Administração",
+		"refresh_leaderboards": "Atualizar tabelas de classificação",
+		"refresh_meta_reports": "Atualizar relatório da meta",
+		"refresh_sprite_gap_data": "Atualizar dados de sprites ausentes",
+		"refresh_twitch_streams": "Atualizar transmissões da Twitch",
+		"refresh_twitch_blacklist": "Atualizar lista negra da Twitch"
 	},
 	"synergy_wheel": {
 		"results": "Resultados",
@@ -4826,5 +5111,257 @@
 		"BATTLE_WIN_STREAK_DESCRIPTION": "Consiga uma sequência de {{amount}} vitórias ou mais",
 		"DELIVERY_DESCRIPTION": "Obtenha {{quantity}} {{item}} no seu inventário ou equipado em um Pokémon ao final da partida",
 		"reward": "Recompensa: {{points}} XP"
+	},
+	"replay": {
+		"leave_replay": "Sair do replay",
+		"loading": "Carregando replay…",
+		"loading_sub": "preparando a partida",
+		"seeking": "Buscando…",
+		"seeking_sub": "reconstruindo a cena",
+		"error_title": "Erro no replay",
+		"boundary_title": "A visualização do replay encontrou um erro",
+		"resume": "Continuar",
+		"reload": "Recarregar",
+		"nav": "Replays",
+		"controls": {
+			"prev_stage": "Estágio anterior (Shift+←)",
+			"prev_phase": "Fase anterior (←)",
+			"next_phase": "Próxima fase (→)",
+			"next_stage": "Próximo estágio (Shift+→)",
+			"restart": "Reiniciar",
+			"play": "Reproduzir (Espaço)",
+			"pause": "Pausar (Espaço)",
+			"step_back": "Voltar um quadro (,)",
+			"step_forward": "Avançar um quadro (.)",
+			"speed": "Velocidade de reprodução (↑/↓)",
+			"ended": "Replay terminado",
+			"badge": "REPLAY",
+			"pos": "Estágio {{stage}} · {{phase}}",
+			"events": "Registro de eventos"
+		},
+		"endgame": {
+			"download": "Baixar replay",
+			"download_failed": "Falha no download"
+		},
+		"library": {
+			"title": "Assistir a um replay",
+			"saved_here": "Salvo neste navegador",
+			"open_file": "Abrir um arquivo",
+			"keep_before": "Manter",
+			"keep_after": "mais recentes",
+			"loading": "Carregando replays salvos…",
+			"empty": "Nenhum replay foi salvo neste navegador ainda.",
+			"empty_on": "Eles aparecerão aqui após você terminar uma partida.",
+			"empty_off": "A gravação está desativada. Ative-a marcando a caixa de seleção no topo.",
+			"empty_unsupported": "Salvar replays não é compatível com este navegador.",
+			"other_build": "outra versão",
+			"delete_q": "Excluir?",
+			"watch": "Assistir",
+			"download_tip": "Baixar",
+			"dropzone_pre": "Arraste um",
+			"dropzone_post": "arquivo aqui, ou",
+			"choose_file": "Escolha um arquivo",
+			"reading": "Lendo replay…",
+			"choose_another": "Escolher outro",
+			"no_summary": "Sem pré-visualização para esta gravação"
+		},
+		"about": {
+			"title": "Sobre replays gravados pelo navegador",
+			"storage": "Seus replays são salvos neste navegador, não na nuvem. Apenas suas partidas mais recentes são mantidas; replays mais antigos são removidos automaticamente quando você inicia uma nova partida. Baixe qualquer um que queira manter.",
+			"storage_detail": "Eles ficam apenas neste dispositivo e não são sincronizados ou salvos em backup. Limpar os dados do seu navegador os exclui, e um replay feito em uma janela privada desaparece assim que ela é fechada.",
+			"recording_title": "Limitações da gravação",
+			"rec_intro": "Os replays são gravados do ponto de vista de um jogador. Isso significa que:",
+			"rec_shop": "Apenas a loja do jogador que está gravando é capturada. As lojas dos outros jogadores ficam ocultas, e quando outro jogador compra uma unidade, isso aparece no registro de eventos como \"obteve\".",
+			"rec_combat": "Lançamentos de habilidade e dano de combate só são gravados para o tabuleiro que o jogador que está gravando estava visualizando no momento. Isso significa que os demais combates não exibirão animações de habilidade, e o registro de eventos não terá registro desses lançamentos. O estado do tabuleiro, como HP/PP, ainda é rastreado para todos os tabuleiros, então os combates continuam legíveis.",
+			"rec_income": "Apenas o detalhamento de renda do jogador que está gravando (base, juros, sequência) é capturado.",
+			"rec_gap": "Se o jogador que está gravando se desconectar no meio da partida, esse trecho ficará ausente da gravação.",
+			"playback_title": "Limitações de reprodução",
+			"play_rebuild": "O replay é reconstruído a partir de dados de jogo salvos, não de um vídeo. Isso significa que:",
+			"play_sound": "A música e outros efeitos sonoros são reproduzidos em tempo real, não a partir da gravação. Eles não são afetados pela velocidade de reprodução.",
+			"play_speed": "O controle de velocidade altera a rapidez com que a partida avança, mas não afeta a velocidade de renderização. As animações sempre são reproduzidas na velocidade normal, então velocidades mais altas podem parecer entrecortadas. Pausar interrompe o avanço da partida, mas as animações das unidades continuam em loop. A velocidade é aplicada da melhor forma possível, então um dispositivo lento ou sobrecarregado pode não acompanhar as configurações mais altas."
+		},
+		"eventlog": {
+			"title": "Registro de eventos",
+			"free_scroll": "Rolagem livre",
+			"cat": {
+				"combat": "Combate",
+				"economy": "Economia",
+				"flow": "Fluxo da Partida",
+				"flavor": "Diálogos",
+				"positioning": "Posicionamento",
+				"moves": "Movimento de Combate",
+				"engine": "Motor"
+			},
+			"sub": {
+				"damage": "Dano",
+				"heals": "Cura",
+				"text": "Texto",
+				"board_effects": "Efeitos de Tabuleiro"
+			},
+			"section": {
+				"casts_pov": "Habilidade / dano / cura",
+				"board_weather": "Efeitos de tabuleiro / clima",
+				"moves_all": "Movimento"
+			},
+			"phase": {
+				"pick": "Escolha"
+			},
+			"row": {
+				"phase": "Estágio {{stage}}: {{phase}}",
+				"elimination": "{{player}} eliminado",
+				"round_win": "Vitória contra {{opponent}}",
+				"round_loss": "Derrota contra {{opponent}}",
+				"round_draw": "Empate contra {{opponent}}",
+				"shiny_opponent": "{{opponent}} Shiny",
+				"region": "Entrou em {{region}}",
+				"hatch": "Chocou {{pkm}}",
+				"evolve": "{{from}} evoluiu para {{to}}",
+				"shop_gold": "{{pkm}} ({{gold}})",
+				"reroll": "Atualização ({{gold}})",
+				"shop_refresh": "Atualização da loja",
+				"xp": "Comprou {{amount}} XP ({{gold}})",
+				"egg_named": "Pôs um ovo de {{pkm}}",
+				"egg_golden": "Pôs um ovo dourado de {{pkm}}",
+				"fish": "Pescou {{pkm}}",
+				"gained": "Obteve {{pkm}}",
+				"got_item": "Obteve {{item}}",
+				"equip": "Equipou {{item}} em {{unit}}",
+				"unequip": "Removeu {{item}} de {{unit}}",
+				"craft": "Combinou {{c0}} e {{c1}} em {{result}}",
+				"craft_on": "Combinou {{c0}} e {{c1}} em {{result}} em {{unit}}",
+				"move": "{{pkm}} moveu-se para ({{x}},{{y}})",
+				"combatmove": "{{unit}} moveu-se de ({{fromX}},{{fromY}}) para ({{x}},{{y}})",
+				"level": "Alcançou o nível {{level}}",
+				"synergy": "Sinergia {{synergy}}: {{count}}",
+				"berry_ripe": "{{berry}} está madura",
+				"berries": "Novas árvores de frutos silvestres: {{list}}",
+				"flower": "Um Vaso de Flores evoluiu: {{flower}}",
+				"wanderer": "Um {{pkm}} errante entra em cena",
+				"pick": "Escolheu {{chosen}}",
+				"pick_over": "Escolheu {{chosen}} em vez de {{alternatives}}",
+				"town": "Encontro na cidade: {{npc}}",
+				"rule": "Regra especial: {{rule}}",
+				"weather": "Clima mudou para {{weather}}",
+				"status": "{{unit}} recebeu {{status}}",
+				"status_poison_one": "{{unit}} foi envenenado ({{count}} acúmulo)",
+				"status_poison_other": "{{unit}} foi envenenado ({{count}} acúmulos)",
+				"stat_gain": "{{unit}} ganhou {{delta}} de {{stat}}",
+				"stat_loss": "{{unit}} perdeu {{delta}} de {{stat}}",
+				"cast": "{{caster}} lançou {{skill}}",
+				"cast_at": "Lançou {{skill}} em ({{x}},{{y}})",
+				"dmg": "{{src}} causou {{amount}} de {{type}} a {{target}}",
+				"heal": "{{src}} curou {{amount}} de HP em {{target}}",
+				"heal_shield": "{{src}} deu {{amount}} de escudo a {{target}}",
+				"board_effect": "{{effect}} em ({{x}},{{y}})",
+				"life_lost_one": "{{count}} de HP perdido",
+				"life_lost_other": "{{count}} de HP perdidos",
+				"income": "+{{total}} de ouro ({{parts}})",
+				"income_plain": "+{{total}} de ouro",
+				"income_base": "{{n}} de base",
+				"income_interest": "{{n}} de juros",
+				"income_streak": "{{n}} de sequência de vitórias/derrotas",
+				"placed": "Terminou em {{rank}}",
+				"game_start": "Início da partida",
+				"game_over": "Fim da partida",
+				"cooked": "Cozinhou {{dishes}}",
+				"dig": "Escavou{{where}}{{found}}",
+				"dig_site": " em ({{x}},{{y}}), profundidade {{depth}}",
+				"dig_treasure": ", encontrou {{item}}",
+				"npc_dialog": "{{npc}}: {{dialog}}",
+				"emote": "Emote"
+			}
+		},
+		"skew": {
+			"version": "Este replay foi gravado na versão do jogo {{recorded}}; você está usando a versão {{running}}. Algumas partes podem não ser reproduzidas corretamente.",
+			"serializer": "Este replay foi gravado com um formato de estado diferente ({{recorded}} vs {{running}}). Algumas partes podem não ser reproduzidas corretamente.",
+			"build": "Este replay foi gravado em uma build diferente de {{version}} ({{recorded}} vs {{running}}). Algumas partes podem não ser reproduzidas corretamente."
+		}
+	},
+	"spectators_watching_one": "{{count}} espectador está assistindo a esta partida",
+	"spectators_watching_other": "{{count}} espectadores estão assistindo a esta partida",
+	"twitch_streams": {
+		"title": "Transmissões",
+		"language": "Idioma: {{language}}",
+		"unavailable": "As transmissões da Twitch estão temporariamente indisponíveis",
+		"viewers": "{{count}} espectadores",
+		"live_duration": "Ao vivo há {{duration}}"
+	},
+	"terms_of_service": "Termos de Serviço",
+	"unlocked": "Desbloqueados",
+	"theme": {
+		"default": "Clássico",
+		"super": "Super",
+		"autumn": "Outono",
+		"lilac": "Lilás",
+		"rainbow": "Picos Arco-íris",
+		"umbra": "Umbra",
+		"unown": "Unown Preto",
+		"zengarden": "Jardim Zen",
+		"redsea": "Mar Vermelho",
+		"deerling": "Deerling",
+		"origin": "Origem"
+	},
+	"history": "Histórico",
+	"sprite_tracker": {
+		"failed_to_fetch_data": "Falha ao buscar dados",
+		"error_label": "Erro",
+		"summary_line": "SpriteCollab: {{totalSpriteCollab}} sprites | Não está no PAC: {{missingInPac}} sprites — Última atualização: {{lastUpdated}} (levou {{refreshDurationMs}} ms)",
+		"criteria_title": "Como as entradas são selecionadas",
+		"criteria_line_1": "Esta lista inclui apenas entradas do SpriteCollab que o Pokémon Auto Chess realmente pode usar.",
+		"criteria_line_2": "Para contar, uma entrada precisa ter pelo menos um retrato e as animações de sprite necessárias, como Idle, Walk, Sleep, Hurt, Attack e Hop.",
+		"criteria_line_3": "Formas Shiny seguem as regras do PAC, e a lista final mostra apenas entradas disponíveis no SpriteCollab que ainda estão faltando no PAC.",
+		"filter_alternate": "Alternativas ({{count}})",
+		"filter_altcolor": "Cor Alternativa ({{count}})",
+		"filter_female": "Fêmea ({{count}})",
+		"filter_cutscene": "Cinemática ({{count}})",
+		"filter_alcremie": "Alcremie ({{count}})",
+		"filter_beta": "Beta ({{count}})",
+		"filter_mega": "Mega ({{count}})",
+		"normal": "Normal",
+		"shiny": "Shiny"
+	},
+	"game_activity": "Atividade de Partidas",
+	"game_count": "Partidas",
+	"total_games_30d": "Partidas (últimos 30 dias)",
+	"gift": "Presente",
+	"wands": "Varinhas",
+	"gifts": "Presentes",
+	"inimitable": "Inimitável",
+	"choose_partner": "Parceiro?",
+	"team_name": "Equipe {{name}}",
+	"not_pokemons": "Não Pokémon",
+	"bark": "AU AU!",
+	"drop_here_to_open": "Solte aqui para abrir seu presente. Certifique-se de ter um espaço livre no banco!",
+	"player_dialog": {
+		"YES": "SIM",
+		"NO": "NÃO",
+		"QM": "?",
+		"OK": "OK",
+		"ME": "EU",
+		"YOU": "VOCÊ",
+		"TRADE": "⇌ TROCAR?",
+		"HELP": "AJUDA!"
+	},
+	"board_tooltips_titles": {
+		"player_tile": "Zona de teleporte",
+		"partner_tile": "Zona de teleporte do parceiro"
+	},
+	"board_tooltips": {
+		"player_tile": "Se você e seu parceiro colocarem um Pokémon em suas zonas de teleporte, vocês podem trocar esses Pokémon e seus itens equipados. Itens removíveis são retirados antes da troca.",
+		"partner_tile": "Aqui você verá qual Pokémon seu parceiro colocou na zona de teleporte dele"
+	},
+	"pokepals": {
+		"title": "Poképals",
+		"leaderboard": "Classificação",
+		"points": "{{points}} pontos",
+		"team_score": "Pontuação da equipe: {{points}}",
+		"instructions": "Jogue com seu parceiro no modo Dobles!",
+		"help1": "Jogar no modo Dobles em equipe com o parceiro designado concede pontos com base na sua posição final",
+		"help2": "O trabalho em equipe levará você à vitória!",
+		"your_pal": "Seu parceiro",
+		"confirmed": "Sua equipe está confirmada e pronta para competir.",
+		"not_confirmed": "Seu parceiro precisa inserir seu nome em troca para confirmar a equipe.",
+		"enter_pal_name": "Digite o nome do seu parceiro",
+		"change_pal": "Trocar parceiro"
 	}
 }


### PR DESCRIPTION
## Summary
- Fills 495 missing Portuguese (pt) translation strings that existed in `en` but not in `pt`.
- Includes recently added content such as fairy wand synergies (`effect_description` / items), Double Up / Poképals UI, replay event log, wiki glossary entries, and related ability/passive text.
- Preserves existing key order and tab formatting so the diff stays focused on additions.

## Test plan
- [ ] Open the in-game translation / locale checker for `pt` and confirm no remaining missing keys vs `en`
- [ ] Spot-check fairy wand effects (AROMATIC_MIST, FAIRY_WIND, STRANGE_STEAM, MOON_FORCE, COACHING) in Portuguese
- [ ] Spot-check a few replay / Double Up / gift UI strings in `pt`