### PR TITLE
fix headlong rush

### DIFF
--- a/app/core/abilities/headlong-rush.test.ts
+++ b/app/core/abilities/headlong-rush.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { HeadlongRushStrategy } from "./headlong-rush"
+
+test("Headlong Rush applies the full effect to the main target, path enemies, and the user", () => {
+  const strategy = new HeadlongRushStrategy()
+
+  const damageCalls: Array<{ targetId: string; damage: number }> = []
+  const moveCalls: Array<{ targetId: string; x: number; y: number }> = []
+  const defenseChanges: Array<number> = []
+  const specialDefenseChanges: Array<number> = []
+
+  const createEntity = (id: string, positionX: number, positionY: number) => {
+    const entity: any = {
+      id,
+      team: 1,
+      stars: 3,
+      positionX,
+      positionY,
+      pp: 100,
+      maxPP: 100,
+      ap: 0,
+      critPower: 1,
+      critChance: 0,
+      skill: "HEADLONG_RUSH",
+      count: { ult: 0 },
+      simulation: {
+        blueAbilitiesCast: [],
+        redAbilitiesCast: []
+      },
+      defense: 10,
+      specialDefense: 10,
+      broadcastAbility() {},
+      addDefense(amount: number) {
+        defenseChanges.push(amount)
+        this.defense += amount
+      },
+      addSpecialDefense(amount: number) {
+        specialDefenseChanges.push(amount)
+        this.specialDefense += amount
+      },
+      moveTo(x: number, y: number) {
+        moveCalls.push({ targetId: id, x, y })
+        this.positionX = x
+        this.positionY = y
+      },
+      cooldown: 0,
+      handleSpecialDamage(damage: number) {
+        damageCalls.push({ targetId: id, damage })
+      }
+    }
+
+    return entity
+  }
+
+  const pokemon = createEntity("pokemon", 0, 0)
+  pokemon.team = 0
+  const selectedTarget = createEntity("selectedTarget", 2, 2)
+  selectedTarget.team = 1
+  const farthestTarget = createEntity("farthestTarget", 3, 3)
+  farthestTarget.team = 1
+  const pathEnemy = createEntity("pathEnemy", 1, 1)
+  pathEnemy.team = 1
+
+  const board = {
+    getFarthestTargetCoordinateAvailablePlace() {
+      return { x: 3, y: 3, target: farthestTarget }
+    },
+    getCellsBetween() {
+      return [{ x: 1, y: 1, value: pathEnemy }]
+    },
+    isOnBoard() {
+      return true
+    },
+    getEntityOnCell() {
+      return undefined
+    }
+  }
+
+  strategy.process(pokemon, board as any, selectedTarget as any, false)
+
+  assert.equal(
+    damageCalls.filter((call) => call.targetId === "farthestTarget").length,
+    1,
+    "The farthest target returned by the board helper should take the main damage"
+  )
+  assert.equal(
+    damageCalls.filter((call) => call.targetId === "farthestTarget")[0]?.damage,
+    80,
+    "The main target should receive the final damage for stars 3"
+  )
+  assert.equal(
+    damageCalls.filter((call) => call.targetId === "selectedTarget").length,
+    0,
+    "The selected target argument should not receive the main damage"
+  )
+  assert.equal(
+    damageCalls.filter((call) => call.targetId === "pathEnemy").length,
+    1,
+    "Enemies on the path should still take damage"
+  )
+  assert.equal(
+    damageCalls.filter((call) => call.targetId === "pathEnemy")[0]?.damage,
+    30,
+    "Enemies on the path should receive the path damage for stars 3"
+  )
+
+  assert.deepEqual(
+    defenseChanges,
+    [-1],
+    "The user should lose 1 DEF per enemy hit"
+  )
+  assert.deepEqual(
+    specialDefenseChanges,
+    [-1],
+    "The user should lose 1 SPE_DEF per enemy hit"
+  )
+  assert.equal(pokemon.defense, 9, "The user defense should be reduced")
+  assert.equal(
+    pokemon.specialDefense,
+    9,
+    "The user special defense should be reduced"
+  )
+
+  assert.ok(
+    moveCalls.some((call) => call.targetId === "pathEnemy"),
+    "Enemies on the path should be pushed to a new position"
+  )
+  assert.ok(
+    moveCalls.some(
+      (call) => call.targetId === "pokemon" && call.x === 3 && call.y === 3
+    ),
+    "The user should rush to the farthest target coordinate"
+  )
+  assert.equal(
+    pathEnemy.cooldown,
+    500,
+    "Path enemies should be put on cooldown after being pushed"
+  )
+})

--- a/app/core/abilities/headlong-rush.ts
+++ b/app/core/abilities/headlong-rush.ts
@@ -16,7 +16,8 @@ export class HeadlongRushStrategy extends AbilityStrategy {
     const damageOnThePath = [10, 20, 30, 60][pokemon.stars - 1] ?? 60
     const farthestCoordinate =
       board.getFarthestTargetCoordinateAvailablePlace(pokemon)
-    const targetsHit: Set<PokemonEntity> = new Set()
+    const mainTarget = farthestCoordinate?.target ?? target
+    const targetsHit: Set<PokemonEntity> = new Set([mainTarget])
 
     if (farthestCoordinate) {
       pokemon.broadcastAbility({
@@ -31,16 +32,9 @@ export class HeadlongRushStrategy extends AbilityStrategy {
       )
       cells.forEach((cell) => {
         if (cell.value && cell.value.team != pokemon.team) {
-          targetsHit.add(cell.value)
-          cell.value.handleSpecialDamage(
-            cell.value.id === farthestCoordinate.target.id
-              ? finalTargetDamage
-              : damageOnThePath,
-            board,
-            AttackType.SPECIAL,
-            pokemon,
-            crit
-          )
+          if (!targetsHit.has(cell.value)) {
+            targetsHit.add(cell.value)
+          }
 
           // Lose 1 def and spe def per enemy hit
           pokemon.addDefense(-1, pokemon, 0, false)
@@ -73,15 +67,14 @@ export class HeadlongRushStrategy extends AbilityStrategy {
       pokemon.moveTo(farthestCoordinate.x, farthestCoordinate.y, board, false)
     }
 
-    if (targetsHit.size === 0) {
-      // ensure to at least hit the target
-      target.handleSpecialDamage(
-        finalTargetDamage,
+    targetsHit.forEach((targetEntity) => {
+      targetEntity.handleSpecialDamage(
+        targetEntity.id === mainTarget.id ? finalTargetDamage : damageOnThePath,
         board,
         AttackType.SPECIAL,
         pokemon,
         crit
       )
-    }
+    })
   }
 }

--- a/app/public/dist/client/changelog/patch-6.11.md
+++ b/app/public/dist/client/changelog/patch-6.11.md
@@ -119,6 +119,7 @@ Added a fourth tier (or fifth tier ?) of ability power per unit star level to al
 - Fix BURN damage not being applied when the source of the status is not a Pokémon, like embers board effect (thanks Thomas)
 - Fix some scenarios where HEAVY_DUTY_BOOTS were not preventing the board effect if the board effect spawns directly on their tile
 - Fix Garbodor not being able to trash Mulch and TMs
+- Fix Great Tusk's Headlong Rush so the main target always receives the intended damage even when other enemies are hit on the rush path.
 - On resurrection, Pokémon having done a mid-fight transformation that changes their stats will now keep those stat changes after resurrection. This includes: Palafin Hero, Mimikyu Busted, Hoopa Unbound, Darmanitan Zen, Galarian Darmanitan Zen, Aegislash Blade Form.
 
 # Elo adjustments


### PR DESCRIPTION
the fallback damage to the main target only ran when no enemy had been hit along the rush path. If the ability hit another enemy on the path, the primary target could be skipped even though it should still take the main hit. 

And the fallback damage was on target instead of farthestcoordinate.target