### PR TITLE
Fix wrong region music preloaded when spectating

### DIFF
--- a/app/public/src/game/components/loading-manager.ts
+++ b/app/public/src/game/components/loading-manager.ts
@@ -100,7 +100,7 @@ export default class LoadingManager {
 
     if (scene instanceof GameScene) {
       const players = schemaValues(scene.room?.state.players!)
-      const player = players.find((p) => p.id === scene.uid) ?? players[0]
+      const player = scene.getPlayerToSpectate()! // must match what startGame plays, or the music isn't preloaded
       await scene.preloadMaps(
         players
           .map((p) => p.map)

--- a/app/public/src/game/scenes/game-scene.ts
+++ b/app/public/src/game/scenes/game-scene.ts
@@ -127,16 +127,19 @@ export default class GameScene extends Scene {
     })
   }
 
+  getPlayerToSpectate(): Player | undefined {
+    const players = schemaValues(this.room?.state.players!)
+    const uid = this.spectate ? this.spectatedPlayerId : this.uid
+    return players.find((p) => p.id === uid) ?? players[0]
+  }
+
   startGame() {
     if (this.uid && this.room) {
       this.registerKeys()
       this.setupCamera()
       this.input.dragDistanceThreshold = 1
 
-      const playerUids = schemaValues(this.room.state.players).map((p) => p.id)
-      const player = this.room.state.players.get(
-        this.spectate ? (this.spectatedPlayerId ?? playerUids[0]) : this.uid
-      ) as Player
+      const player = this.getPlayerToSpectate() as Player
 
       this.setMap(player.map)
       this.setupMouseEvents()


### PR DESCRIPTION
Spectating a game has a high chance to start with no music and one console error:

can't play music Error: Audio key "music_Time Gear" not found in cache
  at GameScene.startGame (game-scene.ts)

LoadingManager.preload preloads a single region music, for the player it resolves as players.find(p => p.id === scene.uid) ?? players[0]. A spectator's uid is never a key of state.players, so that always falls through to state.players[0]. GameScene.startGame opens the scene on spectatedPlayerId, the standings leader that GameContainer.initializeSpectactor auto-selects, so the track it asks for is only fetched if the leader is also first in state.players.

Maps are fine, preloadMaps loads every player's tilesets

The fix adds a method to get the player to spectate and points both sites at it