### PR TITLE
Don't route portraits through the service worker cache

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -278,6 +278,13 @@ export const server = defineServer({
 
     app.use(cors())
     app.use(express.json())
+    // portraits use the browser's http cache instead of the service worker
+    app.use(
+      "/assets/portraits",
+      express.static(path.join(clientSrc, "assets", "portraits"), {
+        maxAge: isDevelopment ? 0 : "31d"
+      })
+    )
     app.use(express.static(clientSrc))
 
     app.get("/", (req, res) => {

--- a/app/public/dist/client/sw.js
+++ b/app/public/dist/client/sw.js
@@ -42,7 +42,8 @@ self.addEventListener("fetch", async (event) => {
   const url = event.request.url
   if (
     event.request.method === "GET" &&
-    (url.includes("/assets/") || url.includes("/SpriteCollab/"))
+    (url.includes("/assets/") || url.includes("/SpriteCollab/")) &&
+    !url.includes("/assets/portraits/") // portraits are left to the browser's http cache
   )
     cacheFirst(event)
 })


### PR DESCRIPTION
My second attempt at solving the Firefox cache storage problem. (first attempt: #4052)

`sw.js` sends every `/assets/` request through `cacheFirst`, so each of the ~1200 portrait files a game load asks for becomes a Cache Storage operation. Portraits do not need that cache. The set is ~1260 files and ~730 KB, and it is already served with a long `max-age`, so the browser's own http cache covers it.

`preloadPortraits` untouched, all portraits still load before the game starts, so `getCachedPortrait` still returns base64 on the first render.

Measured on master with only `sw.js` differing, two cold runs each, from the spectate click until the loading screen goes:

| | cold load | portrait requests | Cache Storage entries |
|---|---|---|---|
| firefox, master | 70.3s / 75.7s | ~1186 | 1176 |
| firefox, this | 7.3s / 7.5s | ~1188 | 0 |
| chromium, master | 9.0s / 8.1s | ~1189 | 1176 |
| chromium, this | 7.4s / 7.9s | ~1189 | 0 |

Tradeoffs:

This swaps a Cache Storage read for the network-stack fallback, which Chrome does more slowly than it reads Cache Storage. In practice the difference is negligible, a fraction of a second.

Cache Storage is per-origin and quota-managed; the browser http cache is a global LRU that unrelated browsing evicts. A player whose http cache has dropped the portraits has to re-request them. 

"Delete cache" in Options > Game Files stops being a way to force portraits to refetch. These rarely change, so I consider this to be acceptable. Options > Game Files is otherwise unaffected.


The first commit serves `/assets/portraits` with a cache lifetime, because production only gets one from Cloudflare and a self-hosted instance would otherwise trade Cache Storage hits for ~1200 revalidations per load. If you would rather leave caching to the CDN, it's cuttable; the second commit is fine on its own.