### PR TITLE
fix nullify bandanna duplication

### DIFF
--- a/app/core/effects/passives.ts
+++ b/app/core/effects/passives.ts
@@ -559,6 +559,7 @@ const FurCoatEffect = new OnStageStartEffect(({ pokemon, player }) => {
     if (pokemon.stacks >= pokemon.stacksRequired && player) {
       pokemon.stacks = 0
       player.items.push(Item.SILK_SCARF)
+      player.extraScarves += 1
     }
     pokemon.stacks = 0
   } else if (pokemon.stacks < pokemon.stacksRequired) {

--- a/app/core/mini-game.ts
+++ b/app/core/mini-game.ts
@@ -887,6 +887,9 @@ export class MiniGame {
             player.updateSynergies()
           } else {
             player.items.push(item.name)
+            if (item.name === Item.SILK_SCARF) {
+              player.extraScarves += 1
+            }
           }
         }
       }

--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -497,12 +497,12 @@ export default class Player extends Schema implements IPlayer {
   }
 
   getScarvesItemsWithNbScarves(n: number): Item[] {
+    n=n+this.extraScarves
     let i = 0
     const scarves: Item[] = []
     while (n > 0) {
       const scarf = this.scarvesItems[i] ?? Item.SILK_SCARF
-      const nbOfNullifyBandannas = scarves.filter(item => item === Item.NULLIFY_BANDANNA).length;
-      n -= ((scarf === Item.NULLIFY_BANDANNA) && ( (this.extraScarves % 2 === 0) || (nbOfNullifyBandannas > 0) )) ? 2 : 1
+      n -= scarf === Item.NULLIFY_BANDANNA ? 2 : 1
       if (n >= 0) {
         scarves.push(scarf)
         i++
@@ -525,7 +525,7 @@ export default class Player extends Schema implements IPlayer {
     )
     const newNbNormalScarves = getSynergyTier(updatedSynergies, Synergy.NORMAL)
     const newScarves = this.getScarvesItemsWithNbScarves(newNbNormalScarves)
-
+      
     if (newScarves.length > previousScarves.length) {
       // some scarves are gained
       const gainedScarves = newScarves.slice(

--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -198,6 +198,7 @@ export default class Player extends Schema implements IPlayer {
   specialGameRule: SpecialGameRule | null = null // its easier to duplicate this here and in gamestate than passing gamestate everywhere we need it
   shopsSinceLastUnownShop: number = 0
   regions: DungeonPMDO[] = []
+  extraScarves: number = 0
   unownReminiscences: number = 0
   doubleUpEliminationRound: number = 999
 
@@ -500,7 +501,8 @@ export default class Player extends Schema implements IPlayer {
     const scarves: Item[] = []
     while (n > 0) {
       const scarf = this.scarvesItems[i] ?? Item.SILK_SCARF
-      n -= scarf === Item.NULLIFY_BANDANNA ? 2 : 1
+      const nbOfNullifyBandannas = scarves.filter(item => item === Item.NULLIFY_BANDANNA).length;
+      n -= ((scarf === Item.NULLIFY_BANDANNA) && ( (this.extraScarves % 2 === 0) || (nbOfNullifyBandannas > 0) )) ? 2 : 1
       if (n >= 0) {
         scarves.push(scarf)
         i++

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -669,13 +669,7 @@ export class OnDragDropCombineCommand extends Command<
       return
     } else {
       if (itemA === Item.SILK_SCARF || itemB === Item.SILK_SCARF) {
-        const nbScarvesBasedOnNormalSynergy = getSynergyTier(
-          player.synergies,
-          Synergy.NORMAL
-        )
-        if (player.scarvesItems.length < nbScarvesBasedOnNormalSynergy) {
-          player.scarvesItems.push(result)
-        }
+        player.scarvesItems.push(result)
       }
 
       player.items.push(result)


### PR DESCRIPTION
how to recreate the issue: start a game with a scarf given by either wooloo or the shop then reach normal 3 synergy and create a nullify bandanna with both scarves. Then reach normal 5 and you get another nullify bandana instead of a silk scarf.

what this fix does:

- create a player.extraScarves counter that increases every time the player is given a scarf in the shop or with the fur coat ability
- change the player.getScarvesItemsWithNbScarves logic to give the correct weight of 1 instead of 2 when the nullify bandana is made of one normal synergy's scarf and one extra scarf.