### PR TITLE
add musics per town encounter and post game music

### DIFF
--- a/app/config/game/town-encounters.ts
+++ b/app/config/game/town-encounters.ts
@@ -1,5 +1,9 @@
+import { DungeonMusic } from "../../types/enum/Dungeon"
 import { Pkm } from "../../types/enum/Pokemon"
-import type { TownEncounter } from "../../types/enum/TownEncounter"
+import {
+  type TownEncounter,
+  TownEncounters
+} from "../../types/enum/TownEncounter"
 import { randomWeighted } from "../../utils/random"
 
 export const TownEncounterSellPrice: { [encounter in TownEncounter]?: number } =
@@ -100,4 +104,15 @@ export function getTreasureBoxReward(): TreasureBoxReward {
       goldBow: 0.05
     }) ?? "itemComponents"
   )
+}
+
+export const MusicByTownEncounter: {
+  [encounter in TownEncounter]?: DungeonMusic
+} = {
+  [TownEncounters.LUDICOLO]: DungeonMusic.CARNIVAL_LUDICOLO,
+  [TownEncounters.MAGNEZONE]: DungeonMusic.TROUBLE_IN_TOWN,
+  [TownEncounters.MAROWAK]: DungeonMusic.THE_TERRABLE_JUNGLE,
+  [TownEncounters.WIGGLYTUFF]: DungeonMusic.SKY_PEAK_CAVE,
+  [TownEncounters.SPINDA]: DungeonMusic.SPINDA_CAFE,
+  [TownEncounters.WOBBUFFET]: DungeonMusic.SPINDA_CAFE
 }

--- a/app/public/src/game/components/board-manager.ts
+++ b/app/public/src/game/components/board-manager.ts
@@ -11,6 +11,7 @@ import {
   Troopers
 } from "../../../../config"
 import { getMusicAlt } from "../../../../config/game/music"
+import { MusicByTownEncounter } from "../../../../config/game/town-encounters"
 import {
   FLOWER_POTS_POSITIONS_BLUE,
   FlowerPotMons
@@ -856,8 +857,11 @@ export default class BoardManager {
   minigameMode() {
     this.mode = BoardMode.TOWN
     this.scene.setMap("town")
-    if (this.state.townEncounter === TownEncounters.LUDICOLO) {
-      playMusic(this.scene, DungeonMusic.CARNIVAL_LUDICOLO)
+    if (
+      this.state.townEncounter &&
+      this.state.townEncounter in MusicByTownEncounter
+    ) {
+      playMusic(this.scene, MusicByTownEncounter[this.state.townEncounter]!)
       this.scene.music?.once("looped", () => {
         playMusic(
           this.scene,

--- a/app/public/src/game/components/loading-manager.ts
+++ b/app/public/src/game/components/loading-manager.ts
@@ -2,7 +2,7 @@ import { t } from "i18next"
 import type Phaser from "phaser"
 import type { GameObjects } from "phaser"
 import pkg from "../../../../../package.json"
-import { RegionDetails } from "../../../../config"
+import { MusicByTownEncounter, RegionDetails } from "../../../../config"
 import { getMusicAlt } from "../../../../config/game/music"
 import type Player from "../../../../models/colyseus-models/player"
 import { getPkmWithCustom } from "../../../../models/colyseus-models/pokemon-customs"
@@ -35,6 +35,7 @@ export default class LoadingManager {
     })
 
     this.preloadingPromise = this.preload()
+    this.preloadingPromise.then(() => setTimeout(() => this.postload(), 5000))
   }
 
   async preload() {
@@ -46,7 +47,6 @@ export default class LoadingManager {
     preloadMusic(scene, getMusicAlt(DungeonMusic.TREASURE_TOWN_STAGE_0))
     preloadMusic(scene, getMusicAlt(DungeonMusic.TREASURE_TOWN_STAGE_10))
     preloadMusic(scene, getMusicAlt(DungeonMusic.TREASURE_TOWN_STAGE_20))
-    preloadMusic(scene, DungeonMusic.CARNIVAL_LUDICOLO)
 
     scene.load.image("rain", "/assets/environment/rain.png")
     scene.load.image("sand", "/assets/environment/sand.png")
@@ -134,6 +134,14 @@ export default class LoadingManager {
         scene.load.start()
       })
     }
+  }
+
+  async postload() {
+    // those files can be loaded in the background after game start
+    const scene = this.scene
+    Object.values(MusicByTownEncounter).forEach((encounterMusic) => {
+      preloadMusic(scene, encounterMusic)
+    })
   }
 }
 

--- a/app/public/src/pages/after-game.tsx
+++ b/app/public/src/pages/after-game.tsx
@@ -5,6 +5,7 @@ import { Navigate } from "react-router"
 import { GADGETS } from "../../../config/game/gadgets"
 import type AfterGameState from "../../../rooms/states/after-game-state"
 import { CloseCodes } from "../../../types/enum/CloseCodes"
+import { DungeonMusic } from "../../../types/enum/Dungeon"
 import { useAppDispatch, useAppSelector } from "../hooks"
 import { authenticateUser, client, joinAfter, rooms } from "../network"
 import { preference } from "../preferences"
@@ -29,6 +30,9 @@ export default function AfterGame() {
   const initialized = useRef<boolean>(false)
   const [toLobby, setToLobby] = useState<boolean>(false)
   const [toAuth, setToAuth] = useState<boolean>(false)
+  const endMusic = useRef<HTMLAudioElement>(
+    new Audio(`assets/musics/ogg/${DungeonMusic.AT_THE_END_OF_THE_DAY}.ogg`)
+  )
 
   useEffect(() => {
     const reconnect = async () => {
@@ -84,9 +88,13 @@ export default function AfterGame() {
       $state.players.onAdd((player) => {
         dispatch(addPlayer(player))
         if (player.id === currentPlayerId) {
-          playSound(
+          const jingle = playSound(
             SOUNDS[("FINISH" + player.rank) as keyof typeof SOUNDS],
             preference("musicVolume") / 100
+          )
+          endMusic.current.volume = preference("musicVolume") / 300
+          jingle?.addEventListener("ended", () =>
+            setTimeout(() => endMusic.current.play(), 1000)
           )
         }
       })
@@ -103,6 +111,10 @@ export default function AfterGame() {
 
     if (!initialized.current) {
       reconnect()
+    }
+
+    return () => {
+      endMusic.current?.pause()
     }
   })
 

--- a/app/public/src/pages/after-game.tsx
+++ b/app/public/src/pages/after-game.tsx
@@ -30,9 +30,7 @@ export default function AfterGame() {
   const initialized = useRef<boolean>(false)
   const [toLobby, setToLobby] = useState<boolean>(false)
   const [toAuth, setToAuth] = useState<boolean>(false)
-  const endMusic = useRef<HTMLAudioElement>(
-    new Audio(`assets/musics/ogg/${DungeonMusic.AT_THE_END_OF_THE_DAY}.ogg`)
-  )
+  const endMusic = useRef<HTMLAudioElement | null>(null)
 
   useEffect(() => {
     const reconnect = async () => {
@@ -92,9 +90,15 @@ export default function AfterGame() {
             SOUNDS[("FINISH" + player.rank) as keyof typeof SOUNDS],
             preference("musicVolume") / 100
           )
+
+          const music =
+            player.rank <= 4
+              ? DungeonMusic.AT_THE_END_OF_THE_DAY
+              : DungeonMusic.IN_THE_HANDS_OF_FATE
+          endMusic.current = new Audio(`assets/musics/ogg/${music}.ogg`)
           endMusic.current.volume = preference("musicVolume") / 300
           jingle?.addEventListener("ended", () =>
-            setTimeout(() => endMusic.current.play(), 1000)
+            setTimeout(() => endMusic.current?.play(), 1000)
           )
         }
       })

--- a/app/public/src/pages/utils/audio.ts
+++ b/app/public/src/pages/utils/audio.ts
@@ -64,13 +64,15 @@ function setupSounds() {
 preloadSounds()
 setupSounds()
 
-export function playSound(key: Soundkey, volume = 1) {
+export function playSound(key: Soundkey, volume = 1): HTMLAudioElement | null {
   const sound = AUDIO_ELEMENTS[key]
   if (sound) {
     sound.currentTime = 0
     sound.volume = (volume * preference("sfxVolume")) / 100
     sound.play()
+    return sound
   }
+  return null
 }
 
 interface SceneWithMusic extends Phaser.Scene {

--- a/app/types/enum/Dungeon.ts
+++ b/app/types/enum/Dungeon.ts
@@ -4,7 +4,7 @@ export enum DungeonMusic {
   A_NEW_WORLD = "A New World",
   APPLE_WOODS = "Apple Woods",
   AT_THE_SNOWY_MOUNTAIN = "At the Snowy Mountain",
-  AT_THE_END_OF_THE_DAY = "At the End of the Day", // UNUSED
+  AT_THE_END_OF_THE_DAY = "At the End of the Day",
   BARREN_VALLEY = "Barren Valley",
   BATTLE_WITH_RAYQUAZA = "Battle with Rayquaza",
   BEACH_CAVE = "Beach Cave",
@@ -102,7 +102,7 @@ export enum DungeonMusic {
   SHAYMIN_VILLAGE = "Shaymin Village",
   SILENT_CHASM = "Silent Chasm",
   SINISTER_WOODS = "Sinister Woods",
-  SKY_PEAK_CAVE = "Sky Peak Cave", // UNUSED
+  SKY_PEAK_CAVE = "Sky Peak Cave",
   SKY_PEAK_COAST = "Sky Peak Coast",
   SKY_PEAK_FINAL_PASS = "Sky Peak Final Pass",
   SKY_PEAK_FOREST = "Sky Peak Forest",
@@ -112,7 +112,7 @@ export enum DungeonMusic {
   SKY_TOWER_SUMMIT = "Sky Tower Summit",
   SOUTHERN_JUNGLE = "Southern Jungle",
   SPACIAL_CLIFFS = "Spacial Cliffs",
-  SPINDA_CAFE = "Spinda's Cafe", // UNUSED
+  SPINDA_CAFE = "Spinda's Cafe",
   SPRING_CAVE = "Spring Cave",
   SPRING_CAVE_DEPTHS = "Spring Cave Depths",
   STAFF_ROLL = "Staff Roll",

--- a/app/types/enum/Dungeon.ts
+++ b/app/types/enum/Dungeon.ts
@@ -57,7 +57,7 @@ export enum DungeonMusic {
   ICICLE_FOREST = "Icicle Forest",
   ILLUSION_STONE_CHAMBER = "Illusion Stone Chamber",
   IN_THE_FUTURE = "In the Future",
-  IN_THE_HANDS_OF_FATE = "In the Hands of Fate", // UNUSED
+  IN_THE_HANDS_OF_FATE = "In the Hands of Fate",
   IN_THE_NIGHTMARE = "In the Nightmare",
   JOB_CLEAR = "Job Clear!",
   KECLEONS_SHOP = "Kecleon's Shop",


### PR DESCRIPTION
A proposal to make use of the remaining unused musics in the jukebox, and possibly more bangers by John Rei in the future

Add special musics triggered by a specific town encounter, just like we did with Carnival Ludicolo and Ludicolo encounter on Carnival patch:

- Magnezone: Trouble In Town
- Marowak: The Terrable Jungle
- Wigglytuff: Sky Peak Cave
- Spinda and Wobuffet: Spinda Café

In the post match screen, after the victory jungle, play at 1/4 volume "At the end of the Day" if top 4, or "In The Hands of Fate" if below