### PR TITLE
Fix units summoned by Unown being untargetable for the rest of the fight

### DIFF
--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -836,6 +836,7 @@ export default abstract class PokemonState {
     board: Board,
     attackType: AttackType
   ) {
+    pokemon.hp = 0 // prevent in-flight damage from killing the unit a second time
     pokemon.team = pokemon.baseTeam
     pokemon.onDeath({ board, attacker })
     board.setEntityOnCell(pokemon.positionX, pokemon.positionY, undefined)


### PR DESCRIPTION
A unit summoned by an unown sometimes can't be targeted by anything for the rest of the fight. It still attacks, still takes damage over time, and still shows on the board, but no enemy will ever attack it.

The bug:

`triggerDeath` removes a unit from play. It clears its cell and deletes it from `blueTeam`/`redTeam`, but never marks it dead. It does not touch `hp`, and there is no dead flag on `PokemonEntity`; the engine expresses "alive" as `hp > 0`. That's fine for the normal path, where `handleDamage` has already clamped `hp` to 0 before calling it, but breaks for direct callers like `HiddenPowerStrategy.process`, which calls `triggerDeath` on its own caster before the letter spawns anything. The unown is now out of play but still reads as alive.

Another unit then takes the cell that death just freed, while the dead unown's `positionX`/`positionY` still point at it. In practice, this mostly happens with unown K/U since they summon onto the unown's tile, but in theory it could be any unit, even one that happens to walk onto the tile at the right time.

Damage that was already in flight when the unown cast now arrives, putting the unown below 0 hp. `handleDamage` sees `hp <= 0`, takes its death branch, and calls `triggerDeath` a second time on the same unit. That second call runs `board.setEntityOnCell(pokemon.positionX, pokemon.positionY, undefined)` on coordinates the unown no longer owns, and the summoned unit is wiped off the board.

It stays in `blueTeam`/`redTeam`, so it is still synced to clients, still rendered, and still updated, but target acquisition all goes through the board (`getNearestTargetAtSight`, `getNearestTargetAtRange`, `getTargetsAtRange`, `getFarthestTarget`), and it is on no cell, so no enemy can ever acquire it again.

The fix:

Set `hp` to 0 in `triggerDeath`. `handleDamage`already returns early on `hp <= 0`, so the second death never happens.

Confirmed via a replay and a local reproduction.
