### PR TITLE
add all game modes to game history, not only ranked

### DIFF
--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -1020,33 +1020,6 @@ export default class GameRoom extends Room<{ state: GameState }> {
           )
         }
 
-        const dbrecord = this.transformToSimplePlayer(player)
-        const synergiesMap = new Map<Synergy, number>()
-        player.synergies.forEach((v, k) => {
-          v > 0 && synergiesMap.set(k, v)
-        })
-        DetailledStatistic.create({
-          time: Date.now(),
-          name: dbrecord.name,
-          pokemons: dbrecord.pokemons.map((pokemon) => ({
-            ...pokemon,
-            items: Array.from(pokemon.items ?? []).map(
-              (item) => item.toString() as Item
-            )
-          })),
-          rank: dbrecord.rank,
-          nbplayers: humans.length + bots.length,
-          avatar: dbrecord.avatar,
-          playerId: dbrecord.id,
-          elo: elo,
-          synergies: synergiesMap,
-          gameMode: this.state.gameMode,
-          regions: player.regions,
-          unholdableItems: schemaValues(player.items).filter((item) =>
-            isIn(UnholdableItemsToSaveForStats, item)
-          )
-        })
-
         if (
           usr.eventFinishTime == null &&
           getCurrentGameEvent() === GameEvent.VICTORY_ROAD
@@ -1108,6 +1081,34 @@ export default class GameRoom extends Room<{ state: GameState }> {
           logger.error("Error updating event points", error)
         }
       }
+
+      // add game to player game history
+      const dbrecord = this.transformToSimplePlayer(player)
+      const synergiesMap = new Map<Synergy, number>()
+      player.synergies.forEach((v, k) => {
+        v > 0 && synergiesMap.set(k, v)
+      })
+      DetailledStatistic.create({
+        time: Date.now(),
+        name: dbrecord.name,
+        pokemons: dbrecord.pokemons.map((pokemon) => ({
+          ...pokemon,
+          items: Array.from(pokemon.items ?? []).map(
+            (item) => item.toString() as Item
+          )
+        })),
+        rank: dbrecord.rank,
+        nbplayers: humans.length + bots.length,
+        avatar: dbrecord.avatar,
+        playerId: dbrecord.id,
+        elo: usr.elo,
+        synergies: synergiesMap,
+        gameMode: this.state.gameMode,
+        regions: player.regions,
+        unholdableItems: schemaValues(player.items).filter((item) =>
+          isIn(UnholdableItemsToSaveForStats, item)
+        )
+      })
 
       // update all pokemons played count
       player.pokemonsPlayed.forEach((pkm) => {


### PR DESCRIPTION
We rely on game history for elo decay, but only ranked games are stored in history. That means all players have to play ranked to prevent elo decay, contrary to what has been explained to players. This is likely the cause of the elo deflation we observed these last months.

This change has an impact on the size of the data stored on database. If this is a problem, we need another mechanic for elo decay.

https://discord.com/channels/737230355039387749/1539008432135344138