### PR TITLE
Fix synergy tooltip crash in the replay viewer

### DIFF
--- a/app/public/src/stores/GameStore.ts
+++ b/app/public/src/stores/GameStore.ts
@@ -120,6 +120,8 @@ const gameSlice = createSlice({
       clone.synergies = new Synergies(
         new Map(Object.entries(clone.synergies ?? {}) as [Synergy, number][])
       )
+      // the json-clone flattens the board MapSchema to a plain object
+      if (action.payload.board) clone.board = action.payload.board
 
       const index = state.players.findIndex((p) => p.id === clone.id)
       if (index >= 0) {


### PR DESCRIPTION
Hovering a synergy in the replay viewer kills the view with `r.forEach is not a function`: `addPlayer` stores a json clone of the player, and `MapSchema.toJSON()` returns a plain object, so `schemaValues(player.board)` in the synergy tooltip has nothing to call. Keeping the live map is what the store holds anyway after the first `board.onChange`.