### PR TITLE
Fix metronome contaminating the shared special pokemon pool

### DIFF
--- a/app/core/abilities/abilities.ts
+++ b/app/core/abilities/abilities.ts
@@ -659,7 +659,8 @@ export class MetronomeStrategy extends AbilityStrategy {
       rarity = Rarity.COMMON
     }
 
-    const pokemonOptions = PRECOMPUTED_POKEMONS_PER_RARITY[rarity]
+    // copy: the push below would mutate the shared precomputed array
+    const pokemonOptions = [...PRECOMPUTED_POKEMONS_PER_RARITY[rarity]]
     if (rarity === Rarity.SPECIAL) {
       pokemonOptions.push(...PRECOMPUTED_POKEMONS_PER_RARITY[Rarity.HATCH])
     }


### PR DESCRIPTION
This is the long-standing bug where booster packs almost never drop specials.

The SPECIAL rarity roll fires at the right rate and then delivers a HATCH pokemon, because the SPECIAL pokemon pool gets permanently contaminated with the HATCH pool at runtime. The rate depends on how long the process has been running matches, which is why booster code run on a fresh process measures the right odds, the pool gets poisoned over time.

The bug:
`MetronomeStrategy` takes a reference to `PRECOMPUTED_POKEMONS_PER_RARITY[rarity]` and then pushes the HATCH pool into it when it rolls SPECIAL. That array is the module-level precomputed table, so the push mutates it permanently. The SPECIAL pool gains the whole HATCH list on every SPECIAL-branch cast (1 in 8) and never shrinks.

`pickRandomPokemonBooster` filters candidates on Unown, DEFAULT skill and alt-form but not on rarity, so the injected HATCH pokemon get drawn.

Measured on `createBooster`, 1000 packs per row (excluding the guaranteed unique/legendary in slot 10), running metronome casts in between:

| Metronome SPECIAL-branch casts | SPECIAL | HATCH | SPECIAL+HATCH |
|---|---|---|---|
| 0 (fresh process) | 0.0503 | 0.0498 | 0.1001 |
| 10 | 0.0044 | 0.0954 | 0.0999 |
| 100 | 0.0007 | 0.1002 | 0.1009 |

The table says 0.05 / 0.05. The pair stays conserved at 0.10 because nothing is lost. The SPECIAL roll still fires, it just returns a HATCH pokemon.

The fix:
Copy the array before pushing into it. With it applied the pool stays at its original 76 entries and SPECIAL holds at 0.05 across the same 100 casts. It does not change what Metronome can cast: `skillOptions` is already deduplicated with a `Set`, so the extra HATCH copies never affected it.

**Deploying this will not fix the running processes.** The contamination lives in their memory, so it survives a rebuild. They keep serving the poisoned pool until they restart. A `pm2 restart` (or a deploy that restarts them) is needed before the rate recovers.

Introduced in #3192.